### PR TITLE
Clean up and stricter tests

### DIFF
--- a/iam-policy-autopilot-access-denied/src/aws/iam_client.rs
+++ b/iam-policy-autopilot-access-denied/src/aws/iam_client.rs
@@ -1,7 +1,7 @@
 //! AWS IAM client wrapper for policy operations
 //!
-//! TODO: Consider consolidating `put_role_policy` and `put_user_policy` into a generic
-//! implementation when adding support for additional principal types.
+// TODO: Consider consolidating `put_role_policy` and `put_user_policy` into a generic
+// implementation when adding support for additional principal types.
 
 use crate::aws::principal::PrincipalKind;
 use crate::aws::{AwsError, AwsResult};

--- a/iam-policy-autopilot-access-denied/src/commands/service.rs
+++ b/iam-policy-autopilot-access-denied/src/commands/service.rs
@@ -23,33 +23,8 @@ impl IamPolicyAutopilotService {
     /// # Errors
     ///
     /// Returns an error if AWS SDK configuration fails to load.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use iam_policy_autopilot_access_denied::IamPolicyAutopilotService;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let service = IamPolicyAutopilotService::new().await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn new() -> IamPolicyAutopilotResult<Self> {
         // Load AWS configuration using the standard credential provider chain.
-        // This automatically resolves the region from multiple sources in order:
-        // 1. AWS_REGION environment variable
-        // 2. AWS_DEFAULT_REGION environment variable
-        // 3. ~/.aws/config file (region = <region> under [default] profile)
-        // 4. AWS_PROFILE with profile-specific region in ~/.aws/config
-        // 5. EC2 instance metadata (for EC2 instances)
-        //
-        // Note: aws_config::load_from_env() is functionally equivalent to this explicit
-        // approach, but the explicit defaults(BehaviorVersion::latest()) pattern is
-        // preferred by AWS SDK documentation as it:
-        // - Makes the SDK behavior version explicit for forward compatibility
-        // - Allows additional configuration customization before .load()
-        // - Clearly documents the configuration approach
         let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .load()
             .await;
@@ -62,32 +37,4 @@ impl IamPolicyAutopilotService {
 
     // plan() method implementation is in plan.rs
     // apply() method implementation is in apply.rs
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_service_creation() {
-        // This test verifies that the service can be instantiated
-        // Note: This requires valid AWS credentials in the environment
-        // In a real test suite, we might want to mock the AWS clients
-        let result = IamPolicyAutopilotService::new().await;
-
-        // We can't guarantee AWS credentials are available in all test environments,
-        // so we just verify the result is of the correct type
-        match result {
-            Ok(_service) => {
-                // Service created successfully
-                assert!(true);
-            }
-            Err(e) => {
-                // Service creation failed, likely due to missing credentials
-                // This is acceptable in a test environment
-                println!("Service creation failed (expected in test env): {}", e);
-                assert!(true);
-            }
-        }
-    }
 }

--- a/iam-policy-autopilot-access-denied/src/error.rs
+++ b/iam-policy-autopilot-access-denied/src/error.rs
@@ -1,4 +1,4 @@
-//! Error types for IAM Policy Autopilot (pure Rust)
+//! Error types for IAM Policy Autopilot
 
 use crate::aws::AwsError;
 use crate::types::ApplyError;

--- a/iam-policy-autopilot-access-denied/src/lib.rs
+++ b/iam-policy-autopilot-access-denied/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate provides the core business logic for AWS IAM Policy Autopilot:
+//! This crate provides the core business logic for IAM Policy Autopilot:
 //! - AccessDenied text parsing
 //! - Policy synthesis
 //! - Principal ARN resolution and basic IAM operations (inline policies)

--- a/iam-policy-autopilot-policy-generation/src/embedded_data.rs
+++ b/iam-policy-autopilot-policy-generation/src/embedded_data.rs
@@ -510,19 +510,4 @@ mod tests {
         let result = EmbeddedServiceData::get_service_definition("", "").await;
         assert!(result.is_err());
     }
-
-    #[test]
-    fn test_service_versions_map_performance() {
-        // Test that building the map doesn't take an unreasonable amount of time
-        let start = std::time::Instant::now();
-        let _service_versions = Botocore::build_service_versions_map();
-        let duration = start.elapsed();
-
-        // Should complete in reasonable time (less than 1 second for this operation)
-        assert!(
-            duration.as_secs() < 1,
-            "build_service_versions_map took too long: {:?}",
-            duration
-        );
-    }
 }

--- a/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
@@ -179,23 +179,6 @@ pub(crate) mod mock_remote_service_reference {
                 "Actions": [
                     {
                         "Name": "AbortMultipartUpload",
-                        "ActionConditionKeys": [
-                            "s3:AccessGrantsInstanceArn",
-                            "s3:ResourceAccount",
-                            "s3:TlsVersion",
-                            "s3:authType",
-                            "s3:signatureAge",
-                            "s3:signatureversion",
-                            "s3:x-amz-content-sha256"
-                        ],
-                        "Annotations": {
-                            "Properties": {
-                            "IsList": false,
-                            "IsPermissionManagement": false,
-                            "IsTaggingOnly": false,
-                            "IsWrite": true
-                            }
-                        },
                         "Resources": [
                             {
                             "Name": "accesspointobject"
@@ -204,10 +187,6 @@ pub(crate) mod mock_remote_service_reference {
                             "Name": "object"
                             }
                         ],
-                        "SupportedBy": {
-                            "IAM Access Analyzer Policy Generation": false,
-                            "IAM Action Last Accessed": false
-                        }
                     },
                     {
                         "Name": "GetObject",

--- a/iam-policy-autopilot-policy-generation/src/enrichment/operation_fas_map.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/operation_fas_map.rs
@@ -149,7 +149,6 @@ pub(crate) fn load_operation_fas_map(service_name: &str) -> Option<Arc<Operation
             let json_str = std::str::from_utf8(&embedded_file.data)
                 .expect("Invalid UTF-8 in embedded operation FAS map");
 
-            // Parse JSON synchronously
             let operation_fas_map: OperationFasMap =
                 serde_json::from_str(json_str).unwrap_or_else(|_| {
                     panic!(

--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -37,11 +37,8 @@ impl ResourceMatcher {
         }
     }
 
-    /// Enrich a parsed method call with OperationAction maps and Service Reference data
-    ///
-    /// This is the main entry point for the enrichment process. For each possible
-    /// service in the ParsedMethodCall, it creates one EnrichedMethodCall with
-    /// complete IAM metadata.
+    /// Enrich a parsed method call with OperationAction maps, FAS maps, and Service
+    /// Reference data
     pub(crate) async fn enrich_method_call<'b>(
         &self,
         parsed_call: &'b SdkMethodCall,

--- a/iam-policy-autopilot-policy-generation/src/extraction/engine.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/engine.rs
@@ -144,8 +144,7 @@ impl Engine {
     /// Detect and validate language consistency across multiple source files.
     ///
     /// This method detects the programming language from file extensions and ensures
-    /// all files have the same detected language. This is useful for CLI tools that
-    /// need to validate language consistency before processing.
+    /// all files have the same detected language.
     pub fn detect_and_validate_language(&self, source_files: &[&Path]) -> Result<Language> {
         if source_files.is_empty() {
             return Err(ExtractorError::validation(
@@ -222,7 +221,6 @@ mod tests {
         }
     }
 
-    // Integration tests moved from core/tests/sdk_validation_test.rs
     /// Test that the extractor can be created with real providers and process a simple file.
     #[tokio::test]
     async fn test_extractor_with_real_providers() {
@@ -259,8 +257,6 @@ def helper_function():
         );
 
         // Test that we can call the extraction method without errors
-        // Note: This may not find actual SDK methods since we're using real parsing,
-        // but it should not crash and should return a valid result structure
         let result = extractor
             .extract_sdk_method_calls(Language::Python, vec![source_file])
             .await;

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/extractor.rs
@@ -55,7 +55,7 @@ impl Extractor for JavaScriptExtractor {
             &scan_results,
         ));
 
-        // Return JavaScript variant with the same AST (no double construction)
+        // Return JavaScript variant with the same AST
         ExtractorResult::JavaScript(ast, method_calls)
     }
 
@@ -351,9 +351,7 @@ const __error__ = await bodyStream.transformToString();
         // Note: This currently may not work since scanner.method_calls is empty in scan_all()
 
         if method_calls.is_empty() {
-            println!("⚠️ No method calls found - method call scanning may need to be integrated in scanner.scan_all()");
-            // For now, we'll pass the test but note the issue
-            return;
+            panic!("method_calls must not be empty")
         }
 
         // Should find GetObject operation from client.getObject() call

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/scanner.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/scanner.rs
@@ -10,7 +10,7 @@ use ast_grep_core::MatchStrictness;
 
 use std::collections::HashMap;
 
-/// Parse import item with line number - standalone utility function
+/// Parse import item with line number
 pub(crate) fn parse_import_item_with_line(import_item: &str, line: usize) -> Option<ImportInfo> {
     let import_item = import_item.trim();
     if import_item.is_empty() {
@@ -29,7 +29,7 @@ pub(crate) fn parse_import_item_with_line(import_item: &str, line: usize) -> Opt
     }
 }
 
-/// Parse object literal - standalone utility function
+/// Parse object literal
 pub(crate) fn parse_object_literal(obj_text: &str) -> HashMap<String, String> {
     let mut result = HashMap::new();
 
@@ -94,7 +94,7 @@ pub(crate) fn parse_object_literal(obj_text: &str) -> HashMap<String, String> {
     result
 }
 
-/// Parse key-value pair - standalone utility function
+/// Parse key-value pair
 fn parse_key_value_pair(pair: &str, result: &mut HashMap<String, String>) {
     if let Some(colon_pos) = pair.find(':') {
         let key = pair[..colon_pos]
@@ -117,7 +117,7 @@ fn parse_key_value_pair(pair: &str, result: &mut HashMap<String, String>) {
     }
 }
 
-/// Parse and add imports from import text with line number - standalone utility function
+/// Parse and add imports from import text with line number
 fn parse_and_add_imports_with_line(
     imports_text: &str,
     sublibrary_info: &mut SublibraryInfo,
@@ -980,15 +980,6 @@ const command = new CreateBucketCommand({ Bucket: "test" });
             command_pos.is_some(),
             "Should find command instantiation in JavaScript"
         );
-
-        // JavaScript should return None for TypeScript-specific CommandInput usage
-        let type_pos = scanner.find_command_input_usage_position("QueryCommandInput");
-        assert!(
-            type_pos.is_none(),
-            "Should return None for CommandInput in JavaScript"
-        );
-
-        println!("✅ JavaScript fallback behavior working correctly");
     }
 
     #[test]

--- a/iam-policy-autopilot-policy-generation/src/extraction/sdk_model.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/sdk_model.rs
@@ -206,7 +206,7 @@ impl ServiceDiscovery {
             services.len(),
             language
         );
-        Self::load_services_parallel(
+        Self::load_services(
             services,
             &mut service_models,
             &mut method_lookup,
@@ -253,8 +253,8 @@ impl ServiceDiscovery {
         })
     }
 
-    /// Load services in parallel using embedded data (native targets only)
-    async fn load_services_parallel(
+    /// Load services in parallel using embedded data
+    async fn load_services(
         services: Vec<SdkModel>,
         service_models: &mut HashMap<String, SdkServiceDefinition>,
         method_lookup: &mut HashMap<String, Vec<ServiceMethodRef>>,

--- a/iam-policy-autopilot-policy-generation/src/lib.rs
+++ b/iam-policy-autopilot-policy-generation/src/lib.rs
@@ -23,8 +23,6 @@ pub(crate) mod service_configuration;
 // Embedded AWS service data
 pub mod embedded_data;
 
-// extraction::SdkMethodCall & policy_generation::MethodActionMapping
-// should be moved to somewhere common for public export
 // Re-export the extraction module for public use
 pub mod extraction;
 // Re-export the policy_generation module for public use

--- a/iam-policy-autopilot-policy-generation/src/providers/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/providers/mod.rs
@@ -6,15 +6,10 @@ pub(crate) mod filesystem;
 // Native JSON provider implementation
 pub(crate) mod json;
 
-// Conditional compilation for provider types
+// These type aliases are remnants of supporting compilation to wasm.
+// We can use these eventually for conditional compilation again.
 /// Type alias for the filesystem provider implementation.
-///
-/// On native platforms, this resolves to [`NativeFileSystemProvider`](filesystem::NativeFileSystemProvider).
-/// This allows for conditional compilation while maintaining a consistent API.
-pub type FileSystemProvider = filesystem::NativeFileSystemProvider;
+pub type FileSystemProvider = filesystem::FileSystemProvider;
 
 /// Type alias for the JSON provider implementation.
-///
-/// On native platforms, this resolves to [`NativeJsonProvider`](json::NativeJsonProvider).
-/// This allows for conditional compilation while maintaining a consistent API.
-pub type JsonProvider = json::NativeJsonProvider;
+pub type JsonProvider = json::JsonProvider;

--- a/iam-policy-autopilot-policy-generation/src/service_configuration.rs
+++ b/iam-policy-autopilot-policy-generation/src/service_configuration.rs
@@ -100,7 +100,6 @@ pub(crate) fn load_service_configuration() -> Result<Arc<ServiceConfiguration>> 
         let json_str = std::str::from_utf8(&embedded_file.data)
             .expect("Invalid UTF-8 in embedded service configuration");
 
-        // Parse JSON synchronously
         let service_config: ServiceConfiguration = serde_json::from_str(json_str)
             .expect("Failed to parse embedded service configuration JSON");
 

--- a/iam-policy-autopilot-policy-generation/tests/public_api_integration_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/public_api_integration_test.rs
@@ -228,24 +228,11 @@ async fn test_filesystem_provider_public_api() {
     let temp_file = create_test_python_file("test content");
     let temp_path = temp_file.path();
 
-    // Test file_exists
-    let exists = FileSystemProvider::file_exists(temp_path)
-        .await
-        .expect("Should check file existence");
-    assert!(exists, "Temp file should exist");
-
     // Test read_file
     let content = FileSystemProvider::read_file(temp_path)
         .await
         .expect("Should read file");
     assert_eq!(content, "test content");
-
-    // Test with non-existent file
-    let non_existent = PathBuf::from("/non/existent/file.txt");
-    let exists = FileSystemProvider::file_exists(&non_existent)
-        .await
-        .expect("Should check non-existent file");
-    assert!(!exists, "Non-existent file should not exist");
 }
 
 #[tokio::test]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Cleaned up useless tests, and searched through comments to clean up LLM-generated comments.
* Stripped `NativeJsonProvider` and `NativeFileSystemProvider` of the `Native` prefix. 
* Added some CLI integration tests.
* Hid the `extract-sdk-calls` command from the CLI, and some options like `--individual-policies` and `--debug`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
