### PR TITLE
Support context in service reference AuthorizedActions

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
@@ -57,6 +57,12 @@ pub(crate) struct Condition {
     pub values: Vec<String>,
 }
 
+/// Trait for context types that can be converted to conditions
+pub(crate) trait Context {
+    fn key(&self) -> &str;
+    fn values(&self) -> &[String];
+}
+
 /// Represents an IAM action enriched with resource and condition information
 ///
 /// This structure combines OperationAction action data with Service Reference resource information to provide


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
* Now uses the the context from `AuthorizedActions`, for instance to add the `iam:PassedToService` condition for `iam:PassRole`.
* Allows both String and Array<String> in the FAS map context (to match the service reference type).

TODO: We currently silently `continue` when other types are in the FAS map. Instead, we should fail, but prevent runtime failures by parsing all configuration files (such as the FAS map) as part of our build, and fail the build if deserialization fails.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
