### PR TITLE
Clean up boto3 resource loading a bit

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/embedded_data.rs
+++ b/iam-policy-autopilot-policy-generation/src/embedded_data.rs
@@ -9,25 +9,181 @@ use crate::errors::{ExtractorError, Result};
 use crate::extraction::sdk_model::SdkServiceDefinition;
 use crate::providers::JsonProvider;
 use rust_embed::RustEmbed;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::OnceLock;
 
-/// Embedded AWS service definitions with compression
-///
-/// This struct provides access to pre-processed AWS service definitions
-/// that have been simplified to remove documentation and examples,
-/// reducing binary size while maintaining essential functionality.
-#[derive(RustEmbed)]
-#[folder = "target/botocore-data-simplified"]
-#[include = "*.json"]
-pub struct Botocore;
+/// JSON structure for boto3 utilities mapping
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct UtilityMappingJson {
+    /// Map of service names to their utility methods configuration
+    pub(crate) services: std::collections::HashMap<String, ServiceUtilityMethodsJson>,
+}
 
-/// Embedded AWS boto3 resource definitions
-///
-/// This struct provides access to boto3 resource definitions
-/// that are embedded directly into the binary at compile time.
-#[derive(RustEmbed)]
-#[folder = "target/boto3-data-simplified"]
-#[include = "*.json"]
-pub struct Boto3Resources;
+/// Service-level utility methods configuration
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ServiceUtilityMethodsJson {
+    /// Client-level utility methods (e.g., s3.upload_file)
+    pub(crate) client_methods: std::collections::HashMap<String, UtilityMethodJson>,
+    /// Resource-level utility methods organized by resource type
+    pub(crate) resource_methods: std::collections::HashMap<String, ResourceTypeUtilityMethodsJson>,
+}
+
+/// Resource type utility methods map
+pub(crate) type ResourceTypeUtilityMethodsJson =
+    std::collections::HashMap<String, UtilityMethodJson>;
+
+/// Individual utility method specification
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct UtilityMethodJson {
+    /// List of AWS API operations this utility method invokes
+    pub(crate) operations: Vec<ServiceOperation>,
+    /// Parameters accepted by this utility method
+    pub(crate) accepted_params: Vec<String>,
+    /// Mappings from constructor arguments to operation parameters
+    #[serde(default)]
+    pub(crate) identifier_mappings: Vec<IdentifierMapping>,
+}
+
+/// Service operation with required parameters
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ServiceOperation {
+    /// AWS API operation name (e.g., "PutObject", "GetItem")
+    pub(crate) operation: String,
+    /// Required parameters for this operation
+    pub(crate) required_params: Vec<String>,
+}
+
+/// Identifier mapping for utility methods
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct IdentifierMapping {
+    /// Target parameter name in the operation
+    pub(crate) target_param: String,
+    /// Index of the constructor argument to map from
+    pub(crate) constructor_arg_index: usize,
+}
+
+/// Raw JSON structure for parsing boto3 resources files
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Boto3ResourcesJson {
+    /// Service-level configuration
+    pub(crate) service: Option<ServiceSpec>,
+    /// Resource definitions
+    pub(crate) resources: Option<HashMap<String, ResourceSpec>>,
+}
+
+/// Service specification from boto3 resources
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ServiceSpec {
+    /// Service constructors (e.g., s3.Bucket())
+    pub(crate) has: Option<HashMap<String, HasSpec>>,
+    /// Service-level collections
+    #[serde(rename = "hasMany")]
+    pub(crate) has_many: Option<HashMap<String, HasManySpecJson>>,
+}
+
+/// Constructor specification
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct HasSpec {
+    /// Resource reference
+    pub(crate) resource: ResourceRef,
+}
+
+/// Resource reference in constructor
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ResourceRef {
+    /// Resource type name
+    #[serde(rename = "type")]
+    pub(crate) resource_type: String,
+    /// Identifiers for this resource
+    #[serde(default)]
+    pub(crate) identifiers: Option<serde_json::Value>,
+}
+
+/// Resource specification
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ResourceSpec {
+    /// Resource identifiers
+    pub(crate) identifiers: Option<Vec<ResourceIdentifier>>,
+    /// Resource actions
+    pub(crate) actions: Option<HashMap<String, ActionSpec>>,
+    /// Load operation
+    pub(crate) load: Option<LoadSpec>,
+    /// Waiters
+    pub(crate) waiters: Option<HashMap<String, WaiterSpec>>,
+    /// HasMany collections
+    #[serde(rename = "hasMany")]
+    pub(crate) has_many: Option<HashMap<String, HasManySpecJson>>,
+}
+
+/// Resource identifier
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ResourceIdentifier {
+    /// Identifier name
+    pub(crate) name: String,
+}
+
+/// Action specification
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ActionSpec {
+    /// Request details
+    pub(crate) request: RequestSpec,
+}
+
+/// Load operation specification
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct LoadSpec {
+    /// Request details
+    pub(crate) request: RequestSpec,
+}
+
+/// Waiter specification
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WaiterSpec {
+    /// Waiter name
+    #[serde(rename = "waiterName")]
+    pub(crate) waiter_name: String,
+    /// Parameters
+    #[serde(default)]
+    pub(crate) params: Option<Vec<ParamMapping>>,
+}
+
+/// Request specification
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct RequestSpec {
+    /// Operation name
+    pub(crate) operation: String,
+    /// Parameters
+    pub(crate) params: Option<Vec<ParamMapping>>,
+}
+
+/// Parameter mapping
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParamMapping {
+    /// Target parameter
+    pub target: String,
+    /// Source (e.g., "identifier")
+    pub source: String,
+    /// Optional name
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// HasMany collection specification
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct HasManySpecJson {
+    /// Request details
+    pub(crate) request: RequestSpec,
+}
+
+/// Cached, parsed utilities mapping
+static UTILITIES_MAPPING: OnceLock<Option<UtilityMappingJson>> = OnceLock::new();
+
+/// Cached boto3 service versions map
+static BOTO3_SERVICE_VERSIONS: OnceLock<HashMap<String, Vec<String>>> = OnceLock::new();
+
+/// Cached botocore service versions map
+static BOTOCORE_SERVICE_VERSIONS: OnceLock<HashMap<String, Vec<String>>> = OnceLock::new();
 
 /// Embedded boto3 utilities mapping
 ///
@@ -36,29 +192,48 @@ pub struct Boto3Resources;
 #[derive(RustEmbed)]
 #[folder = "resources/config/sdks"]
 #[include = "boto3_utilities_mapping.json"]
-pub struct Boto3Utilities;
+pub(crate) struct Boto3Utilities;
 
 impl Boto3Utilities {
-    /// Get the boto3 utilities mapping configuration
-    pub fn get_utilities_mapping() -> Option<Vec<u8>> {
-        Self::get("boto3_utilities_mapping.json").map(|file| file.data.to_vec())
+    /// Get the boto3 utilities mapping configuration (cached and deserialized)
+    pub(crate) fn get_utilities_mapping() -> Option<&'static UtilityMappingJson> {
+        UTILITIES_MAPPING
+            .get_or_init(|| {
+                let file = Self::get("boto3_utilities_mapping.json")?;
+                serde_json::from_slice(&file.data).ok()
+            })
+            .as_ref()
     }
 }
 
+/// Embedded AWS boto3 resource definitions
+///
+/// This struct provides access to boto3 resource definitions
+/// that are embedded directly into the binary at compile time.
+#[derive(RustEmbed)]
+#[folder = "target/boto3-data-simplified"]
+#[include = "*.json"]
+pub(crate) struct Boto3Resources;
+
 impl Boto3Resources {
-    /// Get a boto3 resources definition file by service name and API version
-    pub fn get_resources_definition(service: &str, api_version: &str) -> Option<Vec<u8>> {
+    /// Get a boto3 resources definition file by service name and API version (deserialized)
+    pub(crate) fn get_resources_definition(
+        service: &str,
+        api_version: &str,
+    ) -> Option<Boto3ResourcesJson> {
         let start_time = std::time::Instant::now();
 
         let json_path = format!("{}/{}/resources-1.json", service, api_version);
         if let Some(file) = Self::get(&json_path) {
             let file_size = file.data.len();
-            let result = Some(file.data.to_vec());
+
+            // Deserialize directly from bytes
+            let result = serde_json::from_slice(&file.data).ok();
 
             let total_time = start_time.elapsed();
             if total_time.as_millis() > 10 {
                 log::debug!(
-                    "Loaded boto3 {}/{}: {}KB in {:?}",
+                    "Loaded and parsed boto3 {}/{}: {}KB in {:?}",
                     service,
                     api_version,
                     file_size / 1024,
@@ -72,51 +247,63 @@ impl Boto3Resources {
         }
     }
 
-    /// Build a complete service-to-versions map for boto3 resources
-    pub(crate) fn build_service_versions_map() -> std::collections::HashMap<String, Vec<String>> {
-        log::debug!("Building boto3 service versions map...");
+    /// Build a complete service-to-versions map for boto3 resources (cached)
+    pub(crate) fn build_service_versions_map() -> &'static HashMap<String, Vec<String>> {
+        BOTO3_SERVICE_VERSIONS.get_or_init(|| {
+            log::debug!("Building boto3 service versions map...");
 
-        let start_time = std::time::Instant::now();
-        let mut service_versions: std::collections::HashMap<
-            String,
-            std::collections::HashSet<String>,
-        > = std::collections::HashMap::new();
-        let mut file_count = 0;
+            let start_time = std::time::Instant::now();
+            let mut service_versions: std::collections::HashMap<
+                String,
+                std::collections::HashSet<String>,
+            > = std::collections::HashMap::new();
+            let mut file_count = 0;
 
-        for file_path in Boto3Resources::iter() {
-            file_count += 1;
-            let path_parts: Vec<&str> = file_path.split('/').collect();
-            if path_parts.len() >= 2 {
-                let service = path_parts[0].to_string();
-                let version = path_parts[1].to_string();
-                service_versions.entry(service).or_default().insert(version);
+            for file_path in Boto3Resources::iter() {
+                file_count += 1;
+                let path_parts: Vec<&str> = file_path.split('/').collect();
+                if path_parts.len() >= 2 {
+                    let service = path_parts[0].to_string();
+                    let version = path_parts[1].to_string();
+                    service_versions.entry(service).or_default().insert(version);
+                }
             }
-        }
 
-        // Convert HashSet to sorted Vec for each service
-        let mut result: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
-        for (service, versions_set) in service_versions {
-            let mut versions: Vec<String> = versions_set.into_iter().collect();
-            versions.sort();
-            result.insert(service, versions);
-        }
+            // Convert HashSet to sorted Vec for each service
+            let mut result: std::collections::HashMap<String, Vec<String>> =
+                std::collections::HashMap::new();
+            for (service, versions_set) in service_versions {
+                let mut versions: Vec<String> = versions_set.into_iter().collect();
+                versions.sort();
+                result.insert(service, versions);
+            }
 
-        let duration = start_time.elapsed();
-        log::debug!(
-            "Built boto3 service versions map in {:?} (processed {} files, found {} services)",
-            duration,
-            file_count,
-            result.len()
-        );
+            let duration = start_time.elapsed();
+            log::debug!(
+                "Built boto3 service versions map in {:?} (processed {} files, found {} services)",
+                duration,
+                file_count,
+                result.len()
+            );
 
-        result
+            result
+        })
     }
 }
 
+/// Embedded AWS service definitions with compression
+///
+/// This struct provides access to pre-processed AWS service definitions
+/// that have been simplified to remove documentation and examples,
+/// reducing binary size while maintaining essential functionality.
+#[derive(RustEmbed)]
+#[folder = "target/botocore-data-simplified"]
+#[include = "*.json"]
+pub(crate) struct Botocore;
+
 impl Botocore {
     /// Get a service definition file by service name and API version
-    pub fn get_service_definition(service: &str, api_version: &str) -> Option<Vec<u8>> {
+    pub(crate) fn get_service_definition(service: &str, api_version: &str) -> Option<Vec<u8>> {
         let start_time = std::time::Instant::now();
 
         let json_path = format!("{}/{}/service-2.json", service, api_version);
@@ -142,7 +329,7 @@ impl Botocore {
     }
 
     /// Get a waiters definition file by service name and API version
-    pub fn get_waiters(
+    pub(crate) fn get_waiters(
         service: &str,
         api_version: &str,
     ) -> Option<std::borrow::Cow<'static, [u8]>> {
@@ -151,7 +338,7 @@ impl Botocore {
     }
 
     /// Get a paginators definition file by service name and API version
-    pub fn get_paginators(
+    pub(crate) fn get_paginators(
         service: &str,
         api_version: &str,
     ) -> Option<std::borrow::Cow<'static, [u8]>> {
@@ -159,45 +346,47 @@ impl Botocore {
         Self::get(&path).map(|file| file.data)
     }
 
-    /// Build a complete service-to-versions map in a single iteration
-    pub(crate) fn build_service_versions_map() -> std::collections::HashMap<String, Vec<String>> {
-        log::debug!("Building service versions map...");
+    /// Build a complete service-to-versions map in a single iteration (cached)
+    pub(crate) fn build_service_versions_map() -> &'static HashMap<String, Vec<String>> {
+        BOTOCORE_SERVICE_VERSIONS.get_or_init(|| {
+            log::debug!("Building service versions map...");
 
-        let start_time = std::time::Instant::now();
-        let mut service_versions: std::collections::HashMap<
-            String,
-            std::collections::HashSet<String>,
-        > = std::collections::HashMap::new();
-        let mut file_count = 0;
+            let start_time = std::time::Instant::now();
+            let mut service_versions: std::collections::HashMap<
+                String,
+                std::collections::HashSet<String>,
+            > = std::collections::HashMap::new();
+            let mut file_count = 0;
 
-        for file_path in Botocore::iter() {
-            file_count += 1;
-            let path_parts: Vec<&str> = file_path.split('/').collect();
-            if path_parts.len() >= 2 {
-                let service = path_parts[0].to_string();
-                let version = path_parts[1].to_string();
-                service_versions.entry(service).or_default().insert(version);
+            for file_path in Botocore::iter() {
+                file_count += 1;
+                let path_parts: Vec<&str> = file_path.split('/').collect();
+                if path_parts.len() >= 2 {
+                    let service = path_parts[0].to_string();
+                    let version = path_parts[1].to_string();
+                    service_versions.entry(service).or_default().insert(version);
+                }
             }
-        }
 
-        // Convert HashSet to sorted Vec for each service
-        let mut result: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
-        for (service, versions_set) in service_versions {
-            let mut versions: Vec<String> = versions_set.into_iter().collect();
-            versions.sort();
-            result.insert(service, versions);
-        }
+            // Convert HashSet to sorted Vec for each service
+            let mut result: std::collections::HashMap<String, Vec<String>> =
+                std::collections::HashMap::new();
+            for (service, versions_set) in service_versions {
+                let mut versions: Vec<String> = versions_set.into_iter().collect();
+                versions.sort();
+                result.insert(service, versions);
+            }
 
-        let duration = start_time.elapsed();
-        log::debug!(
-            "Built service versions map in {:?} (processed {} files, found {} services)",
-            duration,
-            file_count,
-            result.len()
-        );
+            let duration = start_time.elapsed();
+            log::debug!(
+                "Built service versions map in {:?} (processed {} files, found {} services)",
+                duration,
+                file_count,
+                result.len()
+            );
 
-        result
+            result
+        })
     }
 }
 
@@ -208,25 +397,28 @@ impl Botocore {
 pub(crate) struct EmbeddedBoto3Data;
 
 impl EmbeddedBoto3Data {
-    /// Get raw boto3 resources data by service name and API version
+    /// Get boto3 resources data by service name and API version (deserialized)
     ///
     /// # Arguments
     /// * `service` - Service name (e.g., "s3", "ec2", "dynamodb")
     /// * `api_version` - API version (e.g., "2006-03-01", "2016-11-15")
     ///
     /// # Returns
-    /// Raw resources JSON data or None if not found
-    pub fn get_resources_raw(service: &str, api_version: &str) -> Option<Vec<u8>> {
+    /// Deserialized resources JSON data or None if not found
+    pub(crate) fn get_resources_definition(
+        service: &str,
+        api_version: &str,
+    ) -> Option<Boto3ResourcesJson> {
         Boto3Resources::get_resources_definition(service, api_version)
     }
 
-    /// Build a complete service-to-versions map for boto3 resources
-    pub(crate) fn build_service_versions_map() -> std::collections::HashMap<String, Vec<String>> {
+    /// Build a complete service-to-versions map for boto3 resources (cached)
+    pub(crate) fn build_service_versions_map() -> &'static HashMap<String, Vec<String>> {
         Boto3Resources::build_service_versions_map()
     }
 
     /// Get the boto3 utilities mapping configuration from embedded data
-    pub(crate) fn get_utilities_mapping() -> Option<Vec<u8>> {
+    pub(crate) fn get_utilities_mapping() -> Option<&'static UtilityMappingJson> {
         Boto3Utilities::get_utilities_mapping()
     }
 }
@@ -278,7 +470,7 @@ impl EmbeddedServiceData {
     ///
     /// # Returns
     /// Raw waiters JSON data or None if not found
-    pub fn get_waiters_raw(service: &str, api_version: &str) -> Option<Vec<u8>> {
+    pub(crate) fn get_waiters_raw(service: &str, api_version: &str) -> Option<Vec<u8>> {
         Botocore::get_waiters(service, api_version).map(|data| data.to_vec())
     }
 
@@ -291,12 +483,12 @@ impl EmbeddedServiceData {
     /// # Returns
     /// Raw paginators JSON data or None if not found
     #[allow(dead_code)]
-    pub fn get_paginators_raw(service: &str, api_version: &str) -> Option<Vec<u8>> {
+    pub(crate) fn get_paginators_raw(service: &str, api_version: &str) -> Option<Vec<u8>> {
         Botocore::get_paginators(service, api_version).map(|data| data.to_vec())
     }
 
-    /// Build a complete service-to-versions map in a single iteration
-    pub(crate) fn build_service_versions_map() -> std::collections::HashMap<String, Vec<String>> {
+    /// Build a complete service-to-versions map in a single iteration (cached)
+    pub(crate) fn build_service_versions_map() -> &'static HashMap<String, Vec<String>> {
         Botocore::build_service_versions_map()
     }
 }
@@ -331,7 +523,7 @@ mod tests {
         assert!(service_versions.is_empty() || !service_versions.is_empty());
 
         // If there are services, each should have at least one version
-        for (service, versions) in &service_versions {
+        for (service, versions) in service_versions {
             assert!(!service.is_empty(), "Service name should not be empty");
             assert!(
                 !versions.is_empty(),
@@ -415,7 +607,7 @@ mod tests {
     fn test_service_versions_map_structure() {
         let service_versions = Botocore::build_service_versions_map();
 
-        for (service, versions) in &service_versions {
+        for (service, versions) in service_versions {
             // Service names should not contain path separators
             assert!(
                 !service.contains('/'),
@@ -478,7 +670,7 @@ mod tests {
     fn test_service_versions_map_no_duplicates() {
         let service_versions = Botocore::build_service_versions_map();
 
-        for (service, versions) in &service_versions {
+        for (service, versions) in service_versions {
             // Check that there are no duplicate versions
             let mut unique_versions = versions.clone();
             unique_versions.sort();

--- a/iam-policy-autopilot-policy-generation/src/extraction/sdk_model.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/sdk_model.rs
@@ -166,14 +166,13 @@ impl ServiceDiscovery {
         let start_time = std::time::Instant::now();
         log::debug!("Starting optimized service discovery...");
 
-        // Use the optimized single-iteration approach
         let service_versions_map = EmbeddedServiceData::build_service_versions_map();
 
         let mut services = Vec::new();
         for (service_name, api_versions) in service_versions_map {
             // Since build.rs only processes the latest version, there should be exactly one version
             if let Some(api_version) = api_versions.first() {
-                services.push(SdkModel::new(service_name, api_version.clone()));
+                services.push(SdkModel::new(service_name.clone(), api_version.clone()));
             }
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I noticed some inefficiencies and that the code is convoluted, so I started cleaning it up a bit. Submitting this PR, but we can wait with merging this.

* Made `pub` -> `pub(crate)`
* Removed loading the file as bytes, converting to `Vec`, then to `&str` in favor of `serde_json::from_slice` in some cases
* Removed `Deserialize` from `Boto3ResourcesModel`
* Added caching in some places

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
