### PR TITLE
Add resource cutoff

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -27,6 +27,9 @@ pub(crate) struct ResourceMatcher {
     fas_maps: OperationFasMaps,
 }
 
+// TODO: Make this configurable: https://github.com/awslabs/iam-policy-autopilot/issues/19
+const RESOURCE_CUTOFF: usize = 5;
+
 impl ResourceMatcher {
     /// Create a new ResourceMatcher instance
     #[must_use]
@@ -222,6 +225,12 @@ impl ResourceMatcher {
                                         &action.name,
                                         &service_reference,
                                     )?;
+                                let enriched_resources =
+                                    if RESOURCE_CUTOFF <= enriched_resources.len() {
+                                        vec![Resource::new("*".to_string(), None)]
+                                    } else {
+                                        enriched_resources
+                                    };
 
                                 // Combine conditions from FAS operation context and AuthorizedAction context
                                 let mut conditions = Self::make_condition(&operation.context);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Do not add resources when there are more than `RESOURCE_CUTOFF` (currently set to `5`). This prevents creating overly verbose policies at the expense of less precision. Particularly `ec2:CreateTags` was affected (see https://servicereference.us-east-1.amazonaws.com/v1/ec2/ec2.json)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
