### PR TITLE
fix: Print server url on http transport

### DIFF
--- a/iam-policy-autopilot-mcp-server/src/mcp.rs
+++ b/iam-policy-autopilot-mcp-server/src/mcp.rs
@@ -175,6 +175,9 @@ pub async fn begin_http_transport(
     );
 
     info!("Listening on {}/mcp", bind_address);
+
+    // Fine to print with http
+    println!("Listening on {}/mcp", bind_address);
     let router = axum::Router::new().nest_service("/mcp", service);
     let tcp_listener = tokio::net::TcpListener::bind(bind_address).await?;
 


### PR DESCRIPTION
*Description of changes:* When starting an http mcp server, the process should output the mcp url to connect to
```

~/c/iam-policy-autopilot prerelease ?2 ❯ ./target/debug/iam-policy-autopilot mcp-server --transport http --port 8005
Debug logs written to: /var/folders/vn/pzgrh1q57wqgl592z30p7s480000gq/T/iam-policy-autopilot-mcp-2025-11-20-152924-YyiFFg.log
Listening on 127.0.0.1:8005/mcp
```