### PR TITLE
ci: add RELEASE.md and workflow to publish binaries to release page

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -160,19 +160,95 @@ jobs:
           echo '=== All tests passed ==='
         fi
 
-  pypi_publish:
-    name: Publish distribution 📦 to PyPI
-    needs: test_wheels # Only publish if tests pass
+  upload_binaries:
+    name: Upload Binaries to Release
+    needs: test_wheels
     runs-on: ubuntu-latest
-    environment: Release
     permissions:
-      id-token: write  # Required for trusted publishing
+      contents: write
 
     steps:
     - name: Download all wheels
       uses: actions/download-artifact@v4
       with:
-        # Download all artifacts into a common directory
+        pattern: wheels-*
+        path: wheels/
+
+    - name: Extract and package binaries
+      shell: bash
+      run: |
+        mkdir -p binaries
+        
+        for wheel in wheels/**/*.whl; do
+          echo "Processing wheel: $wheel"
+          
+          # Determine target and extensions from wheel filename
+          if [[ "$wheel" == *"win_amd64"* ]]; then
+            simple_target="x86_64-pc-windows-msvc"
+            binary_ext=".exe"
+          elif [[ "$wheel" == *"win_arm64"* ]]; then
+            simple_target="aarch64-pc-windows-msvc"
+            binary_ext=".exe"
+          elif [[ "$wheel" == *"manylinux"*"x86_64"* ]]; then
+            simple_target="x86_64-unknown-linux-gnu"
+            binary_ext=""
+          elif [[ "$wheel" == *"manylinux"*"aarch64"* ]]; then
+            simple_target="aarch64-unknown-linux-gnu"
+            binary_ext=""
+          elif [[ "$wheel" == *"macosx"*"x86_64"* ]]; then
+            simple_target="x86_64-apple-darwin"
+            binary_ext=""
+          elif [[ "$wheel" == *"macosx"*"arm64"* ]]; then
+            simple_target="aarch64-apple-darwin"
+            binary_ext=""
+          else
+            echo "WARNING: Unknown platform for $wheel"
+            continue
+          fi
+          
+          # Extract binary from wheel
+          python -m zipfile -e "$wheel" extracted/
+          BINARY_NAME="iam-policy-autopilot${binary_ext}"
+          find extracted -name "${BINARY_NAME}" -exec cp {} binaries/ \;
+          
+          # Package binary
+          cd binaries
+          ARCHIVE_NAME="iam-policy-autopilot-${{ github.event.release.tag_name }}-${simple_target}"
+          
+          if [[ "$binary_ext" == ".exe" ]]; then
+            zip "${ARCHIVE_NAME}.zip" "${BINARY_NAME}"
+            rm "${BINARY_NAME}"
+          else
+            tar czf "${ARCHIVE_NAME}.tar.gz" "${BINARY_NAME}"
+            rm "${BINARY_NAME}"
+          fi
+          cd ..
+          
+          echo "Created: binaries/${ARCHIVE_NAME}"
+        done
+        
+        echo "Final binaries:"
+        ls -lh binaries/
+
+    - name: Upload to release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ github.event.release.tag_name }}
+        files: binaries/*
+
+  pypi_publish:
+    name: Publish distribution 📦 to PyPI
+    needs: test_wheels
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: wheels-*
         path: dist/
 
     - name: Flatten wheel directory structure
@@ -180,8 +256,7 @@ jobs:
         mkdir -p dist-flat
         find dist -name '*.whl' -exec cp {} dist-flat/ \;
 
-    - name: Publish to TestPyPI
+    - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: dist-flat/
-        repository-url: https://test.pypi.org/legacy/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,8 @@ This document outlines the steps to create a new release.
 
 - Write access to the repository
 - Git configured with your credentials
-- [git-cliff](https://github.com/orhun/git-cliff) installed for changelog generation (optional but recommended)
+- Review our [contributing guideline](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md)
+- [git-cliff](https://github.com/orhun/git-cliff) installed for changelog generation
 
 ## Quick Reference
 
@@ -39,7 +40,7 @@ If you need to include only specific commits instead of all changes from `main`:
 
 ```bash
 # Create release branch from a specific base (e.g., last release tag)
-git checkout -b release/X.Y.Z v0.1.0
+git checkout -b release/X.Y.Z 0.1.0
 
 # Cherry-pick specific commits
 git cherry-pick <commit-hash-1>
@@ -58,7 +59,7 @@ git cherry-pick --abort
 **Finding commits to cherry-pick:**
 ```bash
 # View commits since last release
-git log v0.1.0..main --oneline
+git log 0.1.0..main --oneline
 
 # View commits by author
 git log --author="username" --oneline
@@ -67,20 +68,18 @@ git log --author="username" --oneline
 git log --grep="^fix:" --oneline
 ```
 
-### 2. Update Version in Cargo.toml
+### 2. Update Version
 
-Update the version in the workspace `Cargo.toml`:
+Update the [version](https://doc.rust-lang.org/cargo/reference/semver.html) in both `Cargo.toml` and `pyproject.toml`:
 
 ```bash
-# Edit Cargo.toml and update the version field under [workspace.package]
+# Edit Cargo.toml - update version field under [workspace.package]
 # Change: version = "0.1.0"
 # To:     version = "X.Y.Z"
-```
 
-Then update the lock file:
-
-```bash
-cargo update -w
+# Edit pyproject.toml - update version field under [project]
+# Change: version = "0.1.0"
+# To:     version = "X.Y.Z"
 ```
 
 Verify the version is correct:
@@ -92,7 +91,7 @@ cargo build
 
 ### 3. Generate/Update Changelog
 
-#### Option A: Using git-cliff (Recommended)
+#### Using git-cliff
 
 If you have [git-cliff](https://github.com/orhun/git-cliff) installed:
 
@@ -101,10 +100,11 @@ If you have [git-cliff](https://github.com/orhun/git-cliff) installed:
 git cliff --tag X.Y.Z --unreleased -o CHANGELOG.md
 
 # For subsequent releases (prepend to existing CHANGELOG.md)
-git cliff --tag X.Y.Z --prepend CHANGELOG.md
+# Replace PREV_TAG with the previous release tag (e.g., 0.1.0)
+git cliff PREV_TAG..HEAD --tag X.Y.Z --prepend CHANGELOG.md
 
 # Preview without writing to file
-git cliff --tag X.Y.Z --unreleased
+git cliff PREV_TAG..HEAD --tag X.Y.Z
 ```
 
 **Important:** 
@@ -112,37 +112,13 @@ git cliff --tag X.Y.Z --unreleased
 - Use `--prepend` for subsequent releases (adds new release at top, keeps old releases)
 - git-cliff requires conventional commit messages (feat:, fix:, etc.) to generate meaningful changelogs
 
-#### Option B: Manual Update
-
-Create or update `CHANGELOG.md` with the following structure:
-
-```markdown
-# Changelog
-
-## [X.Y.Z] - YYYY-MM-DD
-
-### Added
-- New features
-
-### Changed
-- Changes in existing functionality
-
-### Fixed
-- Bug fixes
-
-### Removed
-- Removed features
-```
-
-Review and edit the changelog to ensure accuracy and completeness.
-
 ### 4. Commit and Push Changes
 
 Commit the version and changelog updates:
 
 ```bash
 # Stage changes
-git add Cargo.toml Cargo.lock CHANGELOG.md
+git add Cargo.toml pyproject.toml CHANGELOG.md
 
 # Commit with descriptive message
 git commit -m "chore: bump version to X.Y.Z"
@@ -166,7 +142,7 @@ gh pr create --base main --head release/X.Y.Z \
 - Updated CHANGELOG.md
 
 ## Checklist
-- [ ] Version updated in Cargo.toml
+- [ ] Version updated in Cargo.toml and pyproject.toml
 - [ ] Changelog updated
 - [ ] All tests passing
 - [ ] Ready for release"
@@ -182,6 +158,7 @@ After PR approval and merge:
    ```bash
    # Checkout main and pull latest
    git checkout main
+   git status # confirm your local changes
    git pull origin main
 
    # Create annotated tag
@@ -207,7 +184,7 @@ After PR approval and merge:
    - Set release title: `Release X.Y.Z`
    - Copy relevant section from CHANGELOG.md to release notes
    - Check "Set as the latest release"
-   - Click "Publish release"
+   - Click "Publish release" ***One-way Door decision, make sure to review all the details***
 
 3. **Automated Build and Publish:**
    
@@ -223,7 +200,6 @@ After PR approval and merge:
 
 1. Verify the release on PyPI: `https://pypi.org/project/iam-policy-autopilot/`
 2. Test installation: `pip install iam-policy-autopilot==X.Y.Z`
-3. Announce the release (if applicable)
 
 ## Troubleshooting
 
@@ -232,7 +208,7 @@ After PR approval and merge:
 If the automated build fails:
 - Check the GitHub Actions logs
 - Ensure all tests pass locally: `cargo test --workspace`
-- Verify version consistency across all Cargo.toml files
+- Verify version consistency in Cargo.toml and pyproject.toml
 
 ### PyPI Publishing Issues
 
@@ -244,8 +220,7 @@ If PyPI publishing fails:
 ### Version Mismatch
 
 If version verification fails:
-- Ensure `Cargo.toml` version matches the git tag exactly
-- Run `cargo update -w` to update lock file
+- Ensure both `Cargo.toml` and `pyproject.toml` versions match the git tag exactly
 - Rebuild and verify: `cargo build && ./target/debug/iam-policy-autopilot --version`
 
 ### Empty Changelog from git-cliff

--- a/iam-policy-autopilot-access-denied/Cargo.toml
+++ b/iam-policy-autopilot-access-denied/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iam-policy-autopilot-access-denied"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Core library for AWS IAM Policy Autopilot: parsing AccessDenied errors, synthesizing IAM policies, principal resolution, and guarded IAM operations."
 

--- a/iam-policy-autopilot-cli/Cargo.toml
+++ b/iam-policy-autopilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iam-policy-autopilot-cli"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Standalone CLI for AWS IAM Policy Autopilot: analyzes AccessDenied errors and applies IAM policy fixes."
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Introduce release.md in preparation for the upcoming release.
* Update build_and_publish.yml to publish binary into github release page
* Update crates to use workspace version 

*Testing:*
Builds:
1. https://github.com/weibenz1/iam-policy-autopilot/actions/runs/19683667061
Release assets:
https://github.com/weibenz1/iam-policy-autopilot/releases/tag/0.1.7


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
