### PR TITLE
fix: rename generate-policy to generate-policies

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -106,8 +106,8 @@ jobs:
             python:3.11-slim bash -c "
               set -e
               pip install /wheels/*.whl
-              echo '=== Testing generate-policy ==='
-              iam-policy-autopilot generate-policy /test-resources/test_sample.py --region us-east-1 --account 123456789012 --pretty
+              echo '=== Testing generate-policies ==='
+              iam-policy-autopilot generate-policies /test-resources/test_sample.py --region us-east-1 --account 123456789012 --pretty
               echo '=== Testing fix-access-denied ==='
               echo 'N' | iam-policy-autopilot fix-access-denied 'User: arn:aws:iam::123456789012:user/testuser is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::my-bucket/my-key because no identity-based policy allows the s3:GetObject action'
               echo '=== Testing mcp-server stdio ==='
@@ -128,8 +128,8 @@ jobs:
           # Test natively
           set -e
           pip install wheels/*.whl
-          echo '=== Testing generate-policy ==='
-          iam-policy-autopilot generate-policy iam-policy-autopilot-cli/tests/resources/test_sample.py --region us-east-1 --account 123456789012 --pretty
+          echo '=== Testing generate-policies ==='
+          iam-policy-autopilot generate-policies iam-policy-autopilot-cli/tests/resources/test_sample.py --region us-east-1 --account 123456789012 --pretty
           echo '=== Testing fix-access-denied ==='
           echo 'N' | iam-policy-autopilot fix-access-denied 'User: arn:aws:iam::123456789012:user/testuser is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::my-bucket/my-key because no identity-based policy allows the s3:GetObject action'
           echo '=== Testing mcp-server stdio ==='

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/) for commi
 For breaking changes, append `!` after the type or add `BREAKING CHANGE:` in the footer:
 
 ```bash
-feat!: change CLI argument format for generate-policy command
+feat!: change CLI argument format for generate-policies command
 
 BREAKING CHANGE: --region flag is now required instead of optional
 ```

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Usage: iam-policy-autopilot <COMMAND>
 
 Commands:
   fix-access-denied  Fix AccessDenied errors by analyzing and optionally applying IAM policy changes
-  generate-policy    Generates complete IAM policy documents from source files
+  generate-policies    Generates complete IAM policy documents from source files
   mcp-server         Start MCP server
   help               Print this message or the help of the given subcommand(s)
 
@@ -213,16 +213,16 @@ Options:
 
 ### Commands
 
-**generate-policy** - Generates complete IAM policy documents from source files
+**generate-policies** - Generates complete IAM policy documents from source files
 
 ```bash
-iam-policy-autopilot generate-policy <source_files> [OPTIONS]
+iam-policy-autopilot generate-policies <source_files> [OPTIONS]
 ```
 
 Example:
 
 ```bash
-iam-policy-autopilot generate-policy \
+iam-policy-autopilot generate-policies \
   ./src/app.py \
   --region us-east-1 \
   --account 123456789012 \

--- a/iam-policy-autopilot-cli/src/main.rs
+++ b/iam-policy-autopilot-cli/src/main.rs
@@ -71,7 +71,7 @@ impl SharedConfig {
     }
 }
 
-/// Configuration specific to generate-policy subcommand
+/// Configuration specific to generate-policies subcommand
 #[derive(Debug, Clone)]
 struct GeneratePolicyCliConfig {
     /// Shared configuration
@@ -114,12 +114,12 @@ be required for the SDK call.";
     long_about = "Unified tool that combines IAM policy generation from source code analysis \
 with automatic AccessDenied error fixing. Supports three main operations:\n\n\
 • fix-access-denied: Fix AccessDenied errors by analyzing and applying IAM policy changes\n\
-• generate-policy: Complete pipeline with enrichment for policy generation\n\
+• generate-policies: Complete pipeline with enrichment for policy generation\n\
 • mcp-server: Start MCP server for IDE integration. Uses STDIO transport by default.\n\n\
 Examples:\n  \
 iam-policy-autopilot fix-access-denied 'User: arn:aws:iam::123456789012:user/testuser is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::my-bucket/my-key because no identity-based policy allows the s3:GetObject action'\n  \
-iam-policy-autopilot generate-policy tests/resources/test_example.py --region us-east-1 --account 123456789012 --pretty\n  \
-iam-policy-autopilot generate-policy tests/resources/test_example.py --region cn-north-1 --account 123456789012\n  \
+iam-policy-autopilot generate-policies tests/resources/test_example.py --region us-east-1 --account 123456789012 --pretty\n  \
+iam-policy-autopilot generate-policies tests/resources/test_example.py --region cn-north-1 --account 123456789012\n  \
 iam-policy-autopilot mcp-server\n  \
 iam-policy-autopilot mcp-server --transport http --port 8001"
 )]
@@ -210,7 +210,7 @@ go, rust, java, cpp, c, csharp. When not specified, all source files must have t
             long_help = "When enabled, outputs the complete ExtractedMethods \
 structure including metadata about extraction time, source files, and warnings. By default, \
 extract-sdk-calls outputs a simplified list of operations with their possible services. \
-This flag has no effect on the generate-policy subcommand."
+This flag has no effect on the generate-policies subcommand."
         )]
         full_output: bool,
 
@@ -228,7 +228,7 @@ This flag has no effect on the generate-policy subcommand."
 Generates complete IAM policy documents from source files. By default, all \
 policies are merged into a single optimized policy document. \
 Optionally takes AWS context (region and account) for accurate ARN generation.")]
-    GeneratePolicy {
+    GeneratePolicies {
         /// Source files to analyze for SDK method extraction
         #[arg(required = true, num_args = 1..)]
         source_files: Vec<PathBuf>,
@@ -403,9 +403,9 @@ async fn handle_extract_sdk_calls(config: &SharedConfig) -> Result<()> {
     Ok(())
 }
 
-/// Handle the generate-policy subcommand
+/// Handle the generate-policies subcommand
 async fn handle_generate_policy(config: &GeneratePolicyCliConfig) -> Result<()> {
-    info!("Running generate-policy command");
+    info!("Running generate-policies command");
 
     // Validate configuration
     config
@@ -552,7 +552,7 @@ async fn main() {
             }
         }
 
-        Commands::GeneratePolicy {
+        Commands::GeneratePolicies {
             source_files,
             debug,
             pretty,
@@ -594,7 +594,7 @@ async fn main() {
                 Ok(()) => ExitCode::Success,
                 Err(e) => {
                     print_cli_command_error(e);
-                    ExitCode::Duplicate // Exit code 1 for generate-policy errors
+                    ExitCode::Duplicate // Exit code 1 for generate-policies errors
                 }
             }
         }

--- a/iam-policy-autopilot-cli/tests/integration_tests.rs
+++ b/iam-policy-autopilot-cli/tests/integration_tests.rs
@@ -53,10 +53,10 @@ fn extract_sdk_calls_command() -> Command {
     cmd
 }
 
-/// Helper function to get the CLI binary command with generate-policy subcommand
+/// Helper function to get the CLI binary command with generate-policies subcommand
 fn generate_policy_command() -> Command {
     let mut cmd = cli_command();
-    cmd.arg("generate-policy");
+    cmd.arg("generate-policies");
     cmd
 }
 
@@ -70,7 +70,7 @@ fn test_cli_help() {
             "Unified tool that combines IAM policy generation",
         ))
         .stdout(predicate::str::contains("fix-access-denied"))
-        .stdout(predicate::str::contains("generate-policy"));
+        .stdout(predicate::str::contains("generate-policies"));
 }
 
 #[test]
@@ -427,7 +427,7 @@ fn test_comprehensive_real_files_generate_policy_for_extension(extension: &str) 
         return;
     }
 
-    // Test generate-policy with multiple real files
+    // Test generate-policies with multiple real files
     let mut cmd = generate_policy_command();
     cmd.arg("--region")
         .arg("us-east-1")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`generate-policy` -> `generate-policies`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
