### PR TITLE
Fix spacing alignment in CLI usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Usage: iam-policy-autopilot <COMMAND>
 
 Commands:
   fix-access-denied  Fix AccessDenied errors by analyzing and optionally applying IAM policy changes
-  generate-policies    Generates complete IAM policy documents from source files
+  generate-policies  Generates complete IAM policy documents from source files
   mcp-server         Start MCP server
   help               Print this message or the help of the given subcommand(s)
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*
Removed extra spaces in the generate-policies command description to align with other commands


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
