### PR TITLE
chore: Add IamPolicyAutopilot policy ID to access denied flows

### DIFF
--- a/iam-policy-autopilot-access-denied/src/aws/iam_client.rs
+++ b/iam-policy-autopilot-access-denied/src/aws/iam_client.rs
@@ -181,10 +181,14 @@ pub async fn find_canonical_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ActionType, Statement};
+    use crate::{
+        aws::policy_naming::POLICY_PREFIX,
+        types::{ActionType, Statement},
+    };
 
     fn sample_policy() -> PolicyDocument {
         PolicyDocument {
+            id: Some(POLICY_PREFIX.to_string()),
             version: "2012-10-17".to_string(),
             statement: vec![Statement {
                 sid: "Test".into(),

--- a/iam-policy-autopilot-access-denied/src/aws/mod.rs
+++ b/iam-policy-autopilot-access-denied/src/aws/mod.rs
@@ -1,7 +1,7 @@
 //! AWS SDK integration: IAM client wrapper, principal parsing, policy naming.
 
 pub(crate) mod iam_client;
-pub(crate) mod policy_naming;
+pub mod policy_naming;
 pub mod principal;
 pub(crate) mod sts;
 

--- a/iam-policy-autopilot-access-denied/src/aws/policy_naming.rs
+++ b/iam-policy-autopilot-access-denied/src/aws/policy_naming.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 // AWS IAM policy name character limit (128 characters)
 // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
 const MAX_POLICY_NAME_LENGTH: usize = 128;
-const POLICY_PREFIX: &str = "IamPolicyAutopilot";
+pub const POLICY_PREFIX: &str = "IamPolicyAutopilot";
 
 fn sanitize_component(component: &str) -> String {
     static SANITIZE_REGEX: OnceLock<Regex> = OnceLock::new();
@@ -59,8 +59,8 @@ pub fn build_statement_sid(action: &str, date: &str, existing_sids: &[String]) -
     let date_no_hyphens = date.replace("-", "");
 
     let base_sid = format!(
-        "IamPolicyAutopilot{}{}{}",
-        service_cap, action_cap, date_no_hyphens
+        "{}{}{}{}",
+        POLICY_PREFIX, service_cap, action_cap, date_no_hyphens
     );
 
     let mut sid = base_sid.clone();

--- a/iam-policy-autopilot-access-denied/src/commands/apply.rs
+++ b/iam-policy-autopilot-access-denied/src/commands/apply.rs
@@ -1,7 +1,7 @@
 //! Apply logic for IAM Policy Autopilot service
 
 use crate::aws::iam_client::{find_canonical_policy, put_inline_policy};
-use crate::aws::policy_naming::{build_canonical_policy_name, build_statement_sid};
+use crate::aws::policy_naming::{build_canonical_policy_name, build_statement_sid, POLICY_PREFIX};
 use crate::aws::principal::resolve_principal;
 use crate::aws::sts::caller_account_id;
 use crate::synthesis::build_single_statement;
@@ -82,6 +82,10 @@ impl super::service::IamPolicyAutopilotService {
             sort_statements(&mut merged_statements);
 
             let policy_doc = crate::types::PolicyDocument {
+                id: existing
+                    .document
+                    .id
+                    .or_else(|| Some(POLICY_PREFIX.to_string())),
                 version: "2012-10-17".to_string(),
                 statement: merged_statements,
             };
@@ -92,6 +96,7 @@ impl super::service::IamPolicyAutopilotService {
             let stmt = build_single_statement(action.clone(), plan.diagnosis.resource.clone(), sid);
 
             let policy_doc = crate::types::PolicyDocument {
+                id: Some(POLICY_PREFIX.to_string()),
                 version: "2012-10-17".to_string(),
                 statement: vec![stmt],
             };

--- a/iam-policy-autopilot-access-denied/src/lib.rs
+++ b/iam-policy-autopilot-access-denied/src/lib.rs
@@ -4,7 +4,7 @@
 //! - Principal ARN resolution and basic IAM operations (inline policies)
 //!
 
-mod aws;
+pub mod aws;
 pub mod commands;
 mod error;
 mod parsing;

--- a/iam-policy-autopilot-access-denied/src/synthesis/policy_builder.rs
+++ b/iam-policy-autopilot-access-denied/src/synthesis/policy_builder.rs
@@ -27,6 +27,7 @@ pub fn build_inline_allow(actions: Vec<String>, resource: String) -> PolicyDocum
     };
 
     PolicyDocument {
+        id: Some("IamPolicyAutopilot".to_string()),
         version: "2012-10-17".to_string(),
         statement: vec![statement],
     }
@@ -90,6 +91,7 @@ mod tests {
             }
             _ => panic!("expected multiple"),
         }
+        assert_eq!(policy.id, Some("IamPolicyAutopilot".to_string()));
     }
 
     #[test]

--- a/iam-policy-autopilot-access-denied/src/types.rs
+++ b/iam-policy-autopilot-access-denied/src/types.rs
@@ -69,6 +69,8 @@ impl ActionType {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub struct PolicyDocument {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub version: String,
     pub statement: Vec<Statement>,
 }
@@ -156,6 +158,8 @@ impl Statement {
 
 #[cfg(test)]
 mod tests {
+    use crate::aws::policy_naming::POLICY_PREFIX;
+
     use super::*;
 
     #[test]
@@ -251,6 +255,7 @@ mod tests {
             ),
             actions: vec!["s3:GetObject".to_string()],
             policy: PolicyDocument {
+                id: Some(POLICY_PREFIX.to_string()),
                 version: "2012-10-17".to_string(),
                 statement: vec![],
             },

--- a/iam-policy-autopilot-mcp-server/src/tools/fix_access_denied.rs
+++ b/iam-policy-autopilot-mcp-server/src/tools/fix_access_denied.rs
@@ -144,6 +144,7 @@ pub async fn fix_access_denied(
 mod tests {
     use super::*;
     use anyhow::anyhow;
+    use iam_policy_autopilot_access_denied::aws::policy_naming::POLICY_PREFIX;
 
     // Note: These tests focus on the service layer mocking.
     // Full integration tests with RequestContext would require more complex setup.
@@ -303,6 +304,7 @@ mod tests {
             ),
             actions: vec!["s3:GetObject".to_string()],
             policy: PolicyDocument {
+                id: Some(POLICY_PREFIX.to_string()),
                 version: "2012-10-17".to_string(),
                 statement: vec![],
             },

--- a/iam-policy-autopilot-mcp-server/src/tools/generate_policy_for_access_denied.rs
+++ b/iam-policy-autopilot-mcp-server/src/tools/generate_policy_for_access_denied.rs
@@ -39,6 +39,7 @@ pub async fn generate_policy_for_access_denied(
 mod tests {
     use super::*;
     use anyhow::anyhow;
+    use iam_policy_autopilot_access_denied::aws::policy_naming::POLICY_PREFIX;
     use iam_policy_autopilot_access_denied::{
         DenialType, ParsedDenial, PlanResult, PolicyDocument,
     };
@@ -50,6 +51,7 @@ mod tests {
         };
 
         let sample_policy = PolicyDocument {
+            id: Some(POLICY_PREFIX.to_string()),
             version: "2012-10-17".to_string(),
             statement: vec![],
         };
@@ -98,6 +100,7 @@ mod tests {
         };
 
         let sample_policy = PolicyDocument {
+            id: Some(POLICY_PREFIX.to_string()),
             version: "2012-10-17".to_string(),
             statement: vec![],
         };


### PR DESCRIPTION
*Description of changes:*
The access denied flows only place the IamPolicyAutopilot tag in the statement ID, not the policy ID. This change adds it to the policy ID. 

This is `Option<String>` because there is no assurance the incoming policy when merging has the field present, so it must be able to be optionally included for proper parsing. I've manually tested it with a few policies and screwed up others to make sure it handles the merging gracefully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
