### PR TITLE
Use SDK info to find operation from method name

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
@@ -243,6 +243,7 @@ pub mod output {
         /// List of all extracted methods
         pub methods: Vec<SdkMethodCall>,
         /// Metadata about the extraction process
+        /// INVARIANT: all source_files must have the same language
         pub metadata: ExtractionMetadata,
     }
 

--- a/iam-policy-autopilot-policy-generation/src/lib.rs
+++ b/iam-policy-autopilot-policy-generation/src/lib.rs
@@ -60,6 +60,23 @@ pub enum Language {
 }
 
 impl Language {
+    fn sdk_type(&self) -> SdkType {
+        match self {
+            Self::Python => SdkType::Boto3,
+            _ => SdkType::Other,
+        }
+    }
+}
+
+/// SdkType used, for Boto3 we look up the method name in the SDF
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum SdkType {
+    Boto3,
+    Other,
+}
+
+impl Language {
     /// Attempts to parse a language from a string representation.
     ///
     /// # Arguments

--- a/iam-policy-autopilot-policy-generation/tests/go_extraction_integration_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/go_extraction_integration_test.rs
@@ -5,7 +5,7 @@
 //! enrichment and policy generation through the public API.
 
 use iam_policy_autopilot_policy_generation::{
-    EnrichmentEngine, ExtractionEngine, Language, PolicyGenerationEngine, SourceFile,
+    EnrichmentEngine, ExtractionEngine, Language, PolicyGenerationEngine, SdkType, SourceFile,
 };
 use std::path::PathBuf;
 
@@ -91,7 +91,7 @@ async fn test_go_extraction_to_policy_generation_integration() {
             let mut enrichment_engine = EnrichmentEngine::new(false).unwrap();
 
             match enrichment_engine
-                .enrich_methods(&extracted_methods.methods)
+                .enrich_methods(&extracted_methods.methods, SdkType::Other)
                 .await
             {
                 Ok(enriched_calls) => {

--- a/iam-policy-autopilot-policy-generation/tests/go_sdk_features_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/go_sdk_features_test.rs
@@ -8,7 +8,7 @@
 //! Based on go-analysis.json which documents operations requiring IAM permissions.
 
 use iam_policy_autopilot_policy_generation::{
-    EnrichmentEngine, ExtractionEngine, Language, PolicyGenerationEngine, SourceFile,
+    EnrichmentEngine, ExtractionEngine, Language, PolicyGenerationEngine, SdkType, SourceFile,
 };
 use std::path::PathBuf;
 
@@ -74,7 +74,7 @@ func main() {
 
     let mut enrichment_engine = EnrichmentEngine::new(false).unwrap();
     let enriched = enrichment_engine
-        .enrich_methods(&extracted.methods)
+        .enrich_methods(&extracted.methods, SdkType::Other)
         .await
         .expect("Enrichment should succeed");
 
@@ -154,7 +154,7 @@ func main() {
 
     let mut enrichment_engine = EnrichmentEngine::new(false).unwrap();
     let enriched = enrichment_engine
-        .enrich_methods(&extracted.methods)
+        .enrich_methods(&extracted.methods, SdkType::Other)
         .await
         .expect("Enrichment should succeed");
 

--- a/iam-policy-autopilot-policy-generation/tests/public_api_integration_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/public_api_integration_test.rs
@@ -6,7 +6,7 @@
 
 use iam_policy_autopilot_policy_generation::{
     EnrichmentEngine, ExtractionEngine, FileSystemProvider, JsonProvider, Language,
-    PolicyGenerationEngine, SourceFile,
+    PolicyGenerationEngine, SdkType, SourceFile,
 };
 use std::io::Write;
 use std::path::PathBuf;
@@ -91,7 +91,7 @@ def download_object():
     let mut enrichment_engine = EnrichmentEngine::new(false).unwrap();
 
     let enriched_methods = enrichment_engine
-        .enrich_methods(&extracted_methods.methods)
+        .enrich_methods(&extracted_methods.methods, SdkType::Boto3)
         .await
         .expect("Enrichment should succeed");
 
@@ -283,7 +283,7 @@ def multi_service_operations():
     let mut enrichment_engine = EnrichmentEngine::new(false).unwrap();
 
     let enriched = enrichment_engine
-        .enrich_methods(&extracted.methods)
+        .enrich_methods(&extracted.methods, SdkType::Boto3)
         .await
         .expect("Should enrich methods");
 
@@ -435,7 +435,7 @@ def start_policy_generation():
     // Enrich the methods
     let mut enrichment_engine = EnrichmentEngine::new(false).unwrap();
     let enriched = enrichment_engine
-        .enrich_methods(&extracted.methods)
+        .enrich_methods(&extracted.methods, SdkType::Boto3)
         .await
         .expect("Enrichment should succeed");
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/iam-policy-autopilot/issues/66

*Description of changes:*

We now look up method names in the service reference when we detect the SDK type is boto3 (i.e., when the input files are Python). This fixes an issue where we wrongly converted method names to operation names via `convert_case`'s `to_case(Case::PascalCase)` before, which fails for operations like `ModifyDBCluster`, where the snake_case method name is `modify_db_cluster` and the conversion results in `ModifyDbCluster`.
For other SDKs we use the extracted method names as-is as the operation name. The conversion to PascalCase, also changed `ModifyDBCluster` to `ModifyDbCluster`, leading to the same error for Go, Typescript and Javascript.

I introduced `SdkType::Boto3` to follow the data the service reference provides, such as
```
{
      "Name" : "rds",
      "Method" : "modify_db_cluster",
      "Package" : "Boto3"
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
