### PR TITLE
feat: add dependabot submodule version sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: gitsubmodule
+    schedule:
+        interval: "weekly"
+    directory: /


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/iam-policy-autopilot/issues/63
*Description of changes:*
add dependabot to create PRs to sync submodule versions on weekly basis

*Testing*
see https://github.com/hwei0/iam-policy-autopilot/pulls for example PRs created

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
