### PR TITLE
fix: non-commercial partition and region support in access-denied

### DIFF
--- a/iam-policy-autopilot-access-denied/src/lib.rs
+++ b/iam-policy-autopilot-access-denied/src/lib.rs
@@ -38,4 +38,34 @@ mod tests {
             "arn:aws:iam::123456789012:user/testuser"
         );
     }
+
+    #[test]
+    fn test_parsing_sample_message_eusc() {
+        let msg = "botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the GetMetricStatistics operation: User: arn:aws-eusc:iam::123456789012:user/testuser is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::my-bucket/my-key";
+        let parsed = parse(msg).expect("should parse");
+        assert_eq!(parsed.action, "s3:GetObject");
+        assert_eq!(parsed.resource, "arn:aws:s3:::my-bucket/my-key");
+        assert_eq!(
+            parsed.principal_arn,
+            "arn:aws-eusc:iam::123456789012:user/testuser"
+        );
+    }
+
+    #[test]
+    fn test_parsing_sample_message_cn() {
+        let msg = "Error: an error occurred invoking 'context deploy'
+            with variables: {contexts:[] deployAll:false}
+            caused by: 1 context deployment failures
+            suggestion: To resolve failure 1, determine the cause of: operation error ECR: ListImages, https response error StatusCode: 400, RequestID: xxx, api error AccessDeniedException: User: arn:aws-cn:iam::680431765560:user/auser is not authorized to perform: ecr:ListImages on resource: arn:aws-cn:ecr:cn-northwest-1:680431765560:repository/aws/cromwell-mirror because no resource-based policy allows the ecr:ListImages action";
+        let parsed = parse(msg).expect("should parse");
+        assert_eq!(parsed.action, "ecr:ListImages");
+        assert_eq!(
+            parsed.resource,
+            "arn:aws-cn:ecr:cn-northwest-1:680431765560:repository/aws/cromwell-mirror"
+        );
+        assert_eq!(
+            parsed.principal_arn,
+            "arn:aws-cn:iam::680431765560:user/auser"
+        );
+    }
 }

--- a/iam-policy-autopilot-access-denied/src/parsing/utils.rs
+++ b/iam-policy-autopilot-access-denied/src/parsing/utils.rs
@@ -1,10 +1,16 @@
 //! Utility functions for string-based AccessDenied message parsing.
 
 use regex::Regex;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 /// Compiled regex for ARN validation - only place we use regex in parsing
-static ARN_PATTERN: OnceLock<Regex> = OnceLock::new();
+static ARN_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"arn:aws(?:-[a-z]+)*:[a-zA-Z0-9\-]+:[a-zA-Z0-9\-]*:\d{12}:[^\s\x22]+").unwrap()
+});
+
+pub fn is_account_id(value: &str) -> bool {
+    value.len() == 12 && value.chars().all(|c| c.is_ascii_digit())
+}
 
 /// Validates AWS ARN format using basic pattern matching.
 pub fn is_arn(value: &str) -> bool {
@@ -12,7 +18,7 @@ pub fn is_arn(value: &str) -> bool {
         return false;
     }
     let value = value.trim();
-    if !value.starts_with("arn:aws:") {
+    if !value.starts_with("arn:aws:") && !value.starts_with("arn:aws-") {
         return false;
     }
 
@@ -21,11 +27,15 @@ pub fn is_arn(value: &str) -> bool {
         return false;
     }
 
+    let partition = parts[1];
     let service = parts[2];
     let region = parts[3];
     let account = parts[4];
     let resource = parts[5];
 
+    if partition != "aws" && !partition.chars().all(|c| c.is_alphanumeric() || c == '-') {
+        return false;
+    }
     if service.is_empty() || !service.chars().all(|c| c.is_alphanumeric() || c == '-') {
         return false;
     }
@@ -34,16 +44,13 @@ pub fn is_arn(value: &str) -> bool {
     }
 
     match service {
-        "s3" => region.is_empty() && account.is_empty(),
-        "iam" => {
-            region.is_empty()
-                && (account.is_empty()
-                    || (account.len() == 12 && account.chars().all(|c| c.is_ascii_digit())))
+        "s3" => {
+            (region.is_empty() && account.is_empty())
+                || (region.is_empty() && !account.is_empty() && is_account_id(account))
+                || (!region.is_empty() && !account.is_empty() && is_account_id(account))
         }
-        _ => {
-            account.is_empty()
-                || (account.len() == 12 && account.chars().all(|c| c.is_ascii_digit()))
-        }
+        "iam" => region.is_empty() && (account == "aws" || is_account_id(account)),
+        _ => account.is_empty() || is_account_id(account),
     }
 }
 
@@ -52,10 +59,7 @@ pub fn extract_principal(message: &str) -> Option<String> {
     if message.is_empty() {
         return None;
     }
-    let pattern = ARN_PATTERN.get_or_init(|| {
-        Regex::new(r"arn:aws:[a-zA-Z0-9\-]+:[a-zA-Z0-9\-]*:\d{12}:[^\s\x22]+").unwrap()
-    });
-    pattern.find(message).map(|m| m.as_str().to_string())
+    ARN_PATTERN.find(message).map(|m| m.as_str().to_string())
 }
 
 /// Splits on ' is not authorized to perform: ' pattern to extract the action.
@@ -141,7 +145,7 @@ pub fn extract_resource(message: &str) -> Option<String> {
                     if resource_parts.len() >= 2 {
                         let resource_name =
                             resource_parts[1].trim_end_matches(&['.', ',', ';'] as &[_]);
-                        let formatted = format!("arn:aws:iam::*:{}/{}", first_part, resource_name);
+                        let formatted = format!("arn:*:iam::*:{}/{}", first_part, resource_name);
                         return Some(formatted);
                     }
                 }
@@ -152,10 +156,7 @@ pub fn extract_resource(message: &str) -> Option<String> {
 
     // Fallback: second ARN in the message
     let principal = extract_principal(message);
-    let pattern = ARN_PATTERN.get_or_init(|| {
-        Regex::new(r"arn:aws:[a-zA-Z0-9\-]+:[a-zA-Z0-9\-]*:\d{12}:[^\s\x22]+").unwrap()
-    });
-    let arns: Vec<&str> = pattern.find_iter(message).map(|m| m.as_str()).collect();
+    let arns: Vec<&str> = ARN_PATTERN.find_iter(message).map(|m| m.as_str()).collect();
     if arns.len() >= 2 {
         return Some(arns[1].to_string());
     }
@@ -284,19 +285,30 @@ pub fn normalize_s3_resource(action: &str, resource: &str) -> String {
     }
 
     // Check if it's an S3 ARN
-    if !resource.starts_with("arn:aws:s3:::") {
+    if !resource.starts_with("arn:") {
         return resource.to_string();
     }
+    let mut trimmed = &resource["arn:".len()..];
+    let partition = if let Some(colon) = trimmed.find(':') {
+        &trimmed[..colon]
+    } else {
+        return resource.to_string();
+    };
+    if partition != "aws" && !partition.starts_with("aws-") {
+        return resource.to_string();
+    }
+    trimmed = &trimmed[partition.len()..];
+    if !trimmed.starts_with(":s3:::") {
+        return resource.to_string();
+    }
+    trimmed = &trimmed[":s3:::".len()..];
 
     // Extract bucket name and check if this is an object ARN (contains '/')
-    let prefix = "arn:aws:s3:::";
-    let after_prefix = &resource[prefix.len()..];
-
     // Find the first '/' which indicates this is an object ARN
-    if let Some(slash_pos) = after_prefix.find('/') {
-        let bucket_name = &after_prefix[..slash_pos];
+    if let Some(slash_pos) = trimmed.find('/') {
+        let bucket_name = &trimmed[..slash_pos];
         // Return bucket wildcard pattern
-        format!("arn:aws:s3:::{}/*", bucket_name)
+        format!("arn:{partition}:s3:::{bucket_name}/*")
     } else {
         // No '/' found - this is already a bucket ARN or wildcard
         resource.to_string()
@@ -309,12 +321,29 @@ mod tests {
 
     #[test]
     fn test_is_arn_valid_arns() {
+        // Allow IAM ARNs with account IDs or 'aws'
         assert!(is_arn("arn:aws:iam::123456789012:role/MyRole"));
+        assert!(is_arn("arn:aws:iam::aws:contextProvider/IdentityCenter"));
+
+        // Allow S3 ARNs without region and account, with account but no region, or with both
         assert!(is_arn("arn:aws:s3:::my-bucket"));
         assert!(is_arn("arn:aws:s3:::my-bucket/my-key"));
         assert!(is_arn(
+            "arn:aws:s3::123456789012:accesspoint/test/object/unit-01"
+        ));
+        assert!(is_arn("arn:aws:s3:us-east-1:123456789012:job/example-job"));
+
+        // Allow non-commercial AWS partitions and regions
+        assert!(is_arn(
             "arn:aws:ec2:us-west-2:123456789012:instance/i-1234567890abcdef0"
         ));
+        assert!(is_arn(
+            "arn:aws-cn:ec2:cn-north-1:123456789012:instance/i-1234567890abcdef0"
+        ));
+        assert!(is_arn(
+            "arn:aws-us-gov:sns:us-gov-east-1:123456789012:example-sns-topic-name"
+        ));
+        assert!(is_arn("arn:aws-eusc:sqs:eusc-de-east-1:123456789012:queue"));
     }
 
     #[test]
@@ -322,7 +351,82 @@ mod tests {
         assert!(!is_arn(""));
         assert!(!is_arn("not-an-arn"));
         assert!(!is_arn("arn:aws:iam"));
+        assert!(!is_arn("arn:aws:iam::notvalid:role/MyRole"));
         assert!(!is_arn("arn:aws::123456789012:role/MyRole"));
+        assert!(!is_arn("arn:aws:s3:us-east-1:aws:job/example-job"));
+    }
+
+    // Tests for extract_principal()
+
+    #[test]
+    fn test_extract_principal_present() {
+        assert_eq!(
+            extract_principal("An error occurred (AccessDenied) when calling the GetWidget operation: User: arn:aws:iam::123456789012:user/mateojackson is not authorized to perform: widgets:GetWidget on resource: my-example-widget"),
+            Some("arn:aws:iam::123456789012:user/mateojackson".to_string())
+        );
+        assert_eq!(
+            extract_principal("An error occurred (AccessDenied) when calling the ListRepositories operation: User: arn:aws-cn:iam::123456789012:role/HR is not authorized to perform: codecommit:ListRepositories because no identity-based policy allows the codecommit:ListRepositories action"),
+            Some("arn:aws-cn:iam::123456789012:role/HR".to_string())
+        );
+        assert_eq!(
+            extract_principal("An error occurred (AccessDenied) when calling the Publish operation: User: arn:aws-us-gov:sts::111122223333:assumed-role/role-name/role-session-name is not authorized to perform: SNS:Publish on resource: arn:aws:sns:us-east-1:444455556666:role-name-2 with an explicit deny in a VPC endpoint policy transitively through a service control policy"),
+            Some("arn:aws-us-gov:sts::111122223333:assumed-role/role-name/role-session-name".to_string())
+        );
+        assert_eq!(
+            extract_principal("An error occurred (AccessDenied) when calling the PutObject operation: User: arn:aws-eusc:iam::111122223333:oidc-provider/tokens.actions.githubusercontent.com is not authorized to perform: SNS:Publish on resource: arn:aws:sns:us-east-1:444455556666:role-name-2 with an explicit deny in a VPC endpoint policy transitively through a service control policy"),
+            Some("arn:aws-eusc:iam::111122223333:oidc-provider/tokens.actions.githubusercontent.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_principal_absent() {
+        assert_eq!(extract_principal("An error occurred (AccessDeniedException) when calling the GetObject operation: User is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::my-bucket/my-key"), None);
+        assert_eq!(extract_principal("An error occurred (AccessDeniedException) when calling the InvokeAgent operation: User is not authorized to perform: bedrock-agentcore-runtime:InvokeAgent"), None);
+        assert_eq!(extract_principal("An error occurred (ExpiredToken) when calling the ListBuckets operation: The provided token has expired."), None);
+        assert_eq!(extract_principal("An error occurred (AccessDeniedException) when calling the EnableRegion operation: Account region opt status can only be modified through Isengard."), None);
+    }
+
+    // Tests for extract_resource()
+
+    #[test]
+    fn test_extract_resource_present() {
+        assert_eq!(
+            extract_resource("An error occurred (AccessDenied) when calling the GetRole operation: User: arn:aws-us-gov:sts::111122223333:assumed-role/role-name/role-session-name is not authorized to perform: iam:GetRole on resource: role second-role-name because no identity-based policy allows the iam:GetRole action"),
+            Some("arn:*:iam::*:role/second-role-name".to_string())
+        );
+        assert_eq!(
+            extract_resource("An error occurred (AccessDenied) when calling the DeleteRole operation: User: arn:aws:sts::111122223333:assumed-role/role-name/role-session-name is not authorized to perform: iam:DeleteRole on resource: role ThirdRoleName with an explicit deny in a service control policy"),
+            Some("arn:*:iam::*:role/ThirdRoleName".to_string())
+        );
+        assert_eq!(
+            extract_resource("An error occurred (AccessDeniedException) when calling the GetObject operation: User is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::my-bucket/my-key"),
+            Some("arn:aws:s3:::my-bucket/my-key".to_string())
+        );
+        assert_eq!(
+            extract_resource("An error occurred (AccessDenied) when calling the PutObject operation: User: arn:aws-eusc:iam::111122223333:oidc-provider/tokens.actions.githubusercontent.com is not authorized to perform: SNS:Publish on resource: arn:aws-eusc:sns:eusc-de-east-1:444455556666:role-name-2 with an explicit deny in a VPC endpoint policy transitively through a service control policy"),
+            Some("arn:aws-eusc:sns:eusc-de-east-1:444455556666:role-name-2".to_string())
+        );
+        assert_eq!(
+            extract_resource("An error occurred (AccessDeniedException) when calling the GetWidget operation: User: arn:aws:iam::123456789012:user/mateojackson is not authorized to perform: widgets:GetWidget on resource: my-example-widget"),
+            Some("my-example-widget".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_resource_absent() {
+        assert_eq!(
+            extract_resource("An error occurred (AccessDeniedException) when calling the EnableRegion operation: Account region opt status can only be modified through Isengard."),
+            None
+        );
+        assert_eq!(
+            extract_resource("An error occurred (AccessDeniedException) when calling the InvokeAgent operation: User is not authorized to perform: bedrock-agentcore-runtime:InvokeAgent"),
+            None
+        );
+        // In cases where the resource is absent but the principal is present, the principal will be returned
+        assert_eq!(
+            extract_resource("An error occurred (AccessDeniedException) when calling the ListRepositories operation: User: arn:aws-cn:iam::123456789012:role/HR is not authorized to perform: codecommit:ListRepositories because no identity-based policy allows the codecommit:ListRepositories action"),
+            Some("arn:aws-cn:iam::123456789012:role/HR".to_string())
+        );
     }
 
     // Tests for is_s3_object_operation()
@@ -372,54 +476,91 @@ mod tests {
 
     #[test]
     fn test_normalize_s3_resource_object_arn_to_wildcard() {
-        let result = normalize_s3_resource("s3:GetObject", "arn:aws:s3:::bucket/path/file.txt");
-        assert_eq!(result, "arn:aws:s3:::bucket/*");
+        assert_eq!(
+            normalize_s3_resource("s3:GetObject", "arn:aws:s3:::bucket/path/file.txt"),
+            "arn:aws:s3:::bucket/*"
+        );
+        assert_eq!(
+            normalize_s3_resource("s3:GetObject", "arn:aws-us-gov:s3:::bucket/path/file.txt"),
+            "arn:aws-us-gov:s3:::bucket/*"
+        );
     }
 
     #[test]
     fn test_normalize_s3_resource_nested_path() {
-        let result =
-            normalize_s3_resource("s3:PutObject", "arn:aws:s3:::bucket/logs/2024/file.log");
-        assert_eq!(result, "arn:aws:s3:::bucket/*");
+        assert_eq!(
+            normalize_s3_resource("s3:PutObject", "arn:aws:s3:::bucket/logs/2024/file.log"),
+            "arn:aws:s3:::bucket/*"
+        );
+        assert_eq!(
+            normalize_s3_resource(
+                "s3:PutObject",
+                "arn:aws-eusc:s3:::bucket/logs/2024/file.log"
+            ),
+            "arn:aws-eusc:s3:::bucket/*"
+        );
     }
 
     #[test]
     fn test_normalize_s3_resource_bucket_arn_unchanged() {
         // No '/' means it's a bucket ARN, not an object ARN
-        let result = normalize_s3_resource("s3:GetObject", "arn:aws:s3:::bucket");
-        assert_eq!(result, "arn:aws:s3:::bucket");
+        assert_eq!(
+            normalize_s3_resource("s3:GetObject", "arn:aws:s3:::bucket"),
+            "arn:aws:s3:::bucket"
+        );
+        assert_eq!(
+            normalize_s3_resource("s3:GetObject", "arn:aws-cn:s3:::bucket"),
+            "arn:aws-cn:s3:::bucket"
+        );
     }
 
     #[test]
     fn test_normalize_s3_resource_bucket_operation_unchanged() {
         // ListBucket is a bucket operation, not an object operation
-        let result = normalize_s3_resource("s3:ListBucket", "arn:aws:s3:::bucket/file.txt");
-        assert_eq!(result, "arn:aws:s3:::bucket/file.txt");
+        assert_eq!(
+            normalize_s3_resource("s3:ListBucket", "arn:aws:s3:::bucket/file.txt"),
+            "arn:aws:s3:::bucket/file.txt"
+        );
+        assert_eq!(
+            normalize_s3_resource("s3:ListBucket", "arn:aws-us-gov:s3:::bucket/file.txt"),
+            "arn:aws-us-gov:s3:::bucket/file.txt"
+        );
     }
 
     #[test]
     fn test_normalize_s3_resource_non_s3_arn_unchanged() {
-        let result = normalize_s3_resource(
-            "dynamodb:GetItem",
-            "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable",
+        assert_eq!(
+            normalize_s3_resource(
+                "dynamodb:GetItem",
+                "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable",
+            ),
+            "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable"
         );
         assert_eq!(
-            result,
-            "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable"
+            normalize_s3_resource(
+                "dynamodb:GetItem",
+                "arn:aws-us-gov:dynamodb:us-gov-west-1:123456789012:table/MyTable",
+            ),
+            "arn:aws-us-gov:dynamodb:us-gov-west-1:123456789012:table/MyTable"
         );
     }
 
     #[test]
     fn test_normalize_s3_resource_wildcard_unchanged() {
         // Already a wildcard pattern
-        let result = normalize_s3_resource("s3:GetObject", "arn:aws:s3:::bucket/*");
-        assert_eq!(result, "arn:aws:s3:::bucket/*");
+        assert_eq!(
+            normalize_s3_resource("s3:GetObject", "arn:aws:s3:::bucket/*"),
+            "arn:aws:s3:::bucket/*"
+        );
+        assert_eq!(
+            normalize_s3_resource("s3:GetObject", "arn:aws-cn:s3:::bucket/*"),
+            "arn:aws-cn:s3:::bucket/*"
+        );
     }
 
     #[test]
     fn test_normalize_s3_resource_non_arn_unchanged() {
         // Not an ARN format (just wildcard)
-        let result = normalize_s3_resource("s3:GetObject", "*");
-        assert_eq!(result, "*");
+        assert_eq!(normalize_s3_resource("s3:GetObject", "*"), "*");
     }
 }


### PR DESCRIPTION
Autopilot fix-access-denied currently does not support non-commercial AWS partitions and regions, such as US Gov Cloud and the EU Sovereign Cloud. 

I've updated the code to assume a partition beginning with `aws-` is a valid non-commercial AWS partition, and to handle these as far as possible. In cases where we are unable to detect what the relevant partition is, I've updated the code to output resources with a wildcard `*` in the partition part of the ARN. This will ensure the policy changes work across any partition. I've also updated and expanded the test coverage in this area.

Note: I updated the use of `OnceLock` to a `LazyLock`. This reduces code duplication as the initialisation code only needs to be specified once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
