### PR TITLE
fix: remove operation renaming

### DIFF
--- a/iam-policy-autopilot-policy-generation/resources/config/service-configuration.json
+++ b/iam-policy-autopilot-policy-generation/resources/config/service-configuration.json
@@ -265,12 +265,6 @@
     "service-catalog-appregistry": "servicecatalog-appregistry",
     "storage-gateway": "storagegateway"
   },
-  "RenameOperations": {
-    "s3:ListObjectsV2": {
-      "service": "s3",
-      "operation": "ListObjects"
-    }
-  },
   "ResourceOverrides": {
     "iam:GetUser": {
         "user": "*"

--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -424,7 +424,6 @@ mod tests {
             rename_services_operation_action_map: HashMap::new(),
             rename_services_service_reference: HashMap::new(),
             smithy_botocore_service_name_mapping: HashMap::new(),
-            rename_operations: HashMap::new(),
             resource_overrides: HashMap::new(),
         })
     }
@@ -442,7 +441,6 @@ mod tests {
                 "RenameServicesOperationActionMap": {},
                 "RenameServicesServiceReference": {},
                 "SmithyBotocoreServiceNameMapping": {},
-                "RenameOperations": {},
                 "ResourceOverrides": {}
             }"#;
 
@@ -518,16 +516,6 @@ mod tests {
             .cloned()
             .collect(),
             smithy_botocore_service_name_mapping: HashMap::new(),
-            rename_operations: [(
-                "s3:ListObjectsV2".to_string(),
-                crate::service_configuration::OperationRename {
-                    service: "s3".to_string(),
-                    operation: "ListObjects".to_string(),
-                },
-            )]
-            .iter()
-            .cloned()
-            .collect(),
             resource_overrides: HashMap::new(),
         };
 
@@ -657,7 +645,6 @@ mod tests {
             .cloned()
             .collect(),
             smithy_botocore_service_name_mapping: HashMap::new(),
-            rename_operations: HashMap::new(),
             resource_overrides: HashMap::new(),
         };
 
@@ -767,7 +754,6 @@ mod tests {
             rename_services_operation_action_map: HashMap::new(),
             rename_services_service_reference: HashMap::new(),
             smithy_botocore_service_name_mapping: HashMap::new(),
-            rename_operations: HashMap::new(),
             resource_overrides,
         };
 
@@ -881,7 +867,6 @@ mod tests {
             rename_services_operation_action_map: HashMap::new(),
             rename_services_service_reference: HashMap::new(),
             smithy_botocore_service_name_mapping: HashMap::new(),
-            rename_operations: HashMap::new(),
             resource_overrides,
         };
 

--- a/iam-policy-autopilot-policy-generation/src/service_configuration.rs
+++ b/iam-policy-autopilot-policy-generation/src/service_configuration.rs
@@ -33,10 +33,6 @@ pub(crate) struct ServiceConfiguration {
     pub(crate) rename_services_service_reference: HashMap<String, String>,
     /// Smithy to Botocore model: service renames
     pub(crate) smithy_botocore_service_name_mapping: HashMap<String, String>,
-    // TODO: remove
-    #[allow(dead_code)]
-    /// Operation renames
-    pub(crate) rename_operations: HashMap<String, OperationRename>,
     /// Resource overrides
     pub(crate) resource_overrides: HashMap<String, HashMap<String, String>>,
 }
@@ -55,24 +51,6 @@ impl ServiceConfiguration {
     pub(crate) fn rename_service_service_reference<'a>(&self, original: &'a str) -> Cow<'a, str> {
         match self.rename_services_service_reference.get(original) {
             Some(renamed) => Cow::Owned(renamed.clone()),
-            None => Cow::Borrowed(original),
-        }
-    }
-
-    // TODO: remove
-    #[allow(dead_code)]
-    pub(crate) fn rename_operation<'a>(&self, service: &str, original: &'a str) -> Cow<'a, str> {
-        let tmp = format!("{}:{}", service, original);
-        match self.rename_operations.get(&tmp) {
-            Some(operation_rename) => {
-                log::debug!(
-                    "Renamed {} to {}:{}",
-                    original,
-                    operation_rename.service,
-                    operation_rename.operation
-                );
-                Cow::Owned(operation_rename.operation.clone())
-            }
             None => Cow::Borrowed(original),
         }
     }
@@ -151,16 +129,6 @@ mod tests {
             .collect(),
             rename_services_service_reference: HashMap::new(),
             smithy_botocore_service_name_mapping: HashMap::new(),
-            rename_operations: [(
-                "old:Operation".to_string(),
-                OperationRename {
-                    service: "new".to_string(),
-                    operation: "NewOperation".to_string(),
-                },
-            )]
-            .iter()
-            .cloned()
-            .collect(),
             resource_overrides: HashMap::new(),
         };
 
@@ -172,13 +140,6 @@ mod tests {
         assert_eq!(
             config.rename_service_operation_action_map("unchanged-service"),
             "unchanged-service"
-        );
-
-        // Test operation renaming
-        assert_eq!(config.rename_operation("old", "Operation"), "NewOperation");
-        assert_eq!(
-            config.rename_operation("unchanged", "Operation"),
-            "Operation"
         );
     }
 
@@ -200,11 +161,5 @@ mod tests {
                 .get("stepfunctions"),
             Some(&"states".to_string())
         );
-
-        // Test operation rename
-        if let Some(rename_op) = config.rename_operations.get("s3:ListObjectsV2") {
-            assert_eq!(rename_op.service, "s3");
-            assert_eq!(rename_op.operation, "ListObjects");
-        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #102

*Description of changes:*
Removes operation renaming, which was already unused. Note how service references has entries for both `ListObjects` and `ListObjectsV2` (the only wrongly renamed operation): https://servicereference.us-east-1.amazonaws.com/v1/s3/s3.json


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
