### PR TITLE
fix: add type hints for fix_access_denied for strict schema checks

### DIFF
--- a/iam-policy-autopilot-mcp-server/src/tools/fix_access_denied.rs
+++ b/iam-policy-autopilot-mcp-server/src/tools/fix_access_denied.rs
@@ -67,7 +67,7 @@ pub struct FixAccessDeniedInput {
 #[serde(rename_all = "PascalCase")]
 #[schemars(description = "Output containing the result for fixing access denied issue")]
 pub struct FixAccessDeniedOutput {
-    #[schemars(description = "Applied policy", with="FixResult")]
+    #[schemars(description = "Applied policy", with = "FixResult")]
     pub fix_result: Option<FixResult>,
 
     #[schemars(


### PR DESCRIPTION
*Issue #, if available:*

As part of `https //github.com/modelcontextprotocol/modelcontextprotocol/issues/1613` Kiro is performing strict checks for nullable types, causing errors like `Error connecting to MCP server: "nullable" cannot be used without "type"`. Updating to latest (0.13) `rmcp` does not help. Hence, explicitly adding type hints to the offending contract is the only option for now. 
