### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.1.3] - 2026-01-26
+
+### Fixed
+
+- Add type hints for fix_access_denied for strict schema checks (#117)
+
 ## [0.1.2] - 2025-12-15
 
 ## Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["iam-policy-autopilot-lints"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/iam-policy-autopilot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 # Standard Python package metadata
 [project]
 name = "iam-policy-autopilot" # The name it will have on PyPI
-version = "0.1.2"
+version = "0.1.3"
 description = "An open source Model Context Protocol (MCP) server and command-line tool that helps your AI coding assistants quickly create baseline IAM policies that you can refine as your application evolves, so you can build faster. IAM Policy Autopilot analyzes your application code locally to generate identity-based policies for application roles, enabling faster IAM policy creation and reducing access troubleshooting time. IAM Policy Autopilot supports applications built in Python, Go, and TypeScript."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Patch type hints for fix_access_denied that breaks mcp server for newer versions of mcp clients


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
