### PR TITLE
ci: fix pr checks trigger for release branches

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: 'PR Checks'
 
 on:
   pull_request:
-    branches: [ main, prerelease, releases/** ]
+    branches: [ main, prerelease, release/** ]
 
 permissions:
   contents: read


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The PR Checks were not triggered for this PR - https://github.com/awslabs/iam-policy-autopilot/pull/120. This change fixes the issue and ensure all checks are run properly for releases.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
