### PR TITLE
chore: add cliff.toml for standardized changelog generation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,77 @@
+# git-cliff configuration for iam-policy-autopilot
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+# template for the changelog body
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first | trim }}\
+            {% if commit.remote.pr_number %} (#{{ commit.remote.pr_number }})\
+            {% endif %}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# template for the changelog footer
+footer = ""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+    # Remove issue/PR numbers from commit messages for cleaner grouping
+    { pattern = '\(#\d+\)', replace = "" },
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^style", group = "Changed" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^build", group = "Build" },
+    { body = ".*security", group = "Security" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# regex for matching git tags
+tag_pattern = "v?[0-9].*"
+# regex for skipping tags
+skip_tags = ""
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"
+
+[remote.github]
+owner = "awslabs"
+repo = "iam-policy-autopilot"


### PR DESCRIPTION
## Summary
Adds a `cliff.toml` configuration file to standardize changelog generation using [git-cliff](https://git-cliff.org/).

## Changes
- Created `cliff.toml` with configuration that matches the existing CHANGELOG.md format
- Groups commits by type: Added, Fixed, Changed, Documentation, etc.
- Parses conventional commits (feat, fix, docs, chore, ci, etc.)
- Includes PR numbers via GitHub integration
- Uses date format `YYYY-MM-DD` matching current style

## Usage
```bash
# Generate changelog for unreleased changes
git-cliff --unreleased

# Generate full changelog
git-cliff

# Generate changelog for a specific version
git-cliff --tag v0.1.4
```

## Example Output
```markdown
## [Unreleased]

### Added

- Action filtering for \`--explain\` (#122)
- Add \`--explain\` (#84)

### Fixed

- Add type hints for fix_access_denied for strict schema checks (#117)
```

Fixes #125