### PR TITLE
chore: version fix for 0.1.4 release

### DIFF
--- a/iam-policy-autopilot-cli/src/commands.rs
+++ b/iam-policy-autopilot-cli/src/commands.rs
@@ -144,7 +144,7 @@ async fn fix_access_denied_with_service(
 }
 
 pub fn print_version_info(verbose: bool) -> anyhow::Result<()> {
-    println!("{}", crate_version!());
+    println!("iam-policy-autopilot {}", crate_version!());
     if verbose {
         let boto3_version_metadata =
             iam_policy_autopilot_policy_generation::api::get_boto3_version_info()?;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Redo 0.1.4 release, fixed the version string which was missing the `iam-policy-autopilot `


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
