### PR TITLE
refactor: replace duplicated paginator methods with shared `PaginatorCallPattern`

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/extraction/go/waiter_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/go/waiter_extractor.rs
@@ -10,7 +10,7 @@ use crate::extraction::shared::extraction_utils::{
     WaiterCallInfo, WaiterCallPattern, WaiterCreationInfo,
 };
 use crate::extraction::{AstWithSourceFile, Parameter, ParameterValue, SdkMethodCall};
-use crate::{Location, ServiceModelIndex};
+use crate::{Language, Location, ServiceModelIndex};
 use ast_grep_language::Go;
 
 /// Extractor for Go AWS SDK waiter patterns
@@ -54,11 +54,11 @@ impl<'a> GoWaiterExtractor<'a> {
                 }
                 .create_synthetic_calls(
                     self.service_index,
+                    Language::Go,
                     |params| self.filter_waiter_parameters(params),
                     |service_name, operation_name| {
                         self.get_required_parameters(service_name, operation_name)
                     },
-                    std::string::ToString::to_string, // Go uses operation name directly
                 );
                 synthetic_calls.extend(calls);
                 matched_waiter_indices.insert(waiter_idx);
@@ -70,11 +70,11 @@ impl<'a> GoWaiterExtractor<'a> {
             if !matched_waiter_indices.contains(&idx) {
                 let calls = WaiterCallPattern::CreationOnly(waiter).create_synthetic_calls(
                     self.service_index,
+                    Language::Go,
                     |params| self.filter_waiter_parameters(params),
                     |service_name, operation_name| {
                         self.get_required_parameters(service_name, operation_name)
                     },
-                    std::string::ToString::to_string, // Go uses operation name directly
                 );
                 synthetic_calls.extend(calls);
             }

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/waiters_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/waiters_extractor.rs
@@ -7,7 +7,6 @@
 use std::path::Path;
 
 use crate::extraction::python::common::{ArgumentExtractor, ParameterFilter};
-use crate::extraction::sdk_model::ServiceDiscovery;
 use crate::extraction::shared::{
     ChainedWaiterCallInfo, WaiterCallInfo, WaiterCallPattern, WaiterCreationInfo,
 };
@@ -74,6 +73,7 @@ impl<'a> WaitersExtractor<'a> {
                 }
                 .create_synthetic_calls(
                     self.service_index,
+                    Language::Python,
                     ParameterFilter::filter_waiter_parameters,
                     |service_name, operation_name| {
                         self.get_required_parameters(
@@ -81,9 +81,6 @@ impl<'a> WaitersExtractor<'a> {
                             operation_name,
                             self.service_index,
                         )
-                    },
-                    |operation_name| {
-                        ServiceDiscovery::operation_to_method_name(operation_name, Language::Python)
                     },
                 );
                 synthetic_calls.extend(matched_calls);
@@ -96,6 +93,7 @@ impl<'a> WaitersExtractor<'a> {
             let chained_synthetic_calls = WaiterCallPattern::Chained(&chained_call)
                 .create_synthetic_calls(
                     self.service_index,
+                    Language::Python,
                     ParameterFilter::filter_waiter_parameters,
                     |service_name, operation_name| {
                         self.get_required_parameters(
@@ -103,9 +101,6 @@ impl<'a> WaitersExtractor<'a> {
                             operation_name,
                             self.service_index,
                         )
-                    },
-                    |operation_name| {
-                        ServiceDiscovery::operation_to_method_name(operation_name, Language::Python)
                     },
                 );
             synthetic_calls.extend(chained_synthetic_calls);
@@ -118,18 +113,13 @@ impl<'a> WaitersExtractor<'a> {
                 let unmatched_calls = WaiterCallPattern::CreationOnly(waiter)
                     .create_synthetic_calls(
                         self.service_index,
+                        Language::Python,
                         ParameterFilter::filter_waiter_parameters,
                         |service_name, operation_name| {
                             self.get_required_parameters(
                                 service_name,
                                 operation_name,
                                 self.service_index,
-                            )
-                        },
-                        |operation_name| {
-                            ServiceDiscovery::operation_to_method_name(
-                                operation_name,
-                                Language::Python,
                             )
                         },
                     );


### PR DESCRIPTION
Issue #, if available: Follow-up to #139

Description of changes:

Replace the duplicated synthetic call creation methods in Python and Go paginator extractors with a shared `PaginatorCallPattern` enum in `extraction_utils.rs`. This follows the same pattern established in PR #139 for waiter extraction.

This eliminates 5 methods related to synthetic call creation (~170 lines of duplicated code) and makes the paginator extraction logic consistent with the waiter extraction approach.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
