### PR TITLE
feat: add LSP client for Python type information extraction

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -186,6 +186,32 @@ jobs:
         with:
           args: "format --check ."
 
+  lsp-integration:
+    name: LSP Integration Tests
+    needs: [changes]
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install LSP test dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install 'ty>=0.0.39,<0.1' 'boto3-stubs[essential]'
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+
+      - name: Run LSP integration tests
+        run: cargo test -p iam-policy-autopilot-policy-generation --features integ-test -- --ignored
+
   unused-deps:
     name: Unused Dependencies (cargo-machete)
     needs: [changes]

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,7 +203,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install LSP test dependencies
-        run: pip install --break-system-packages 'ty>=0.0.39,<0.1' boto3 'boto3-stubs[essential]'
+        run: |
+          python3 -m venv .lsp-venv
+          .lsp-venv/bin/pip install 'ty>=0.0.39,<0.1' boto3 'boto3-stubs[essential]'
+          echo "${{ github.workspace }}/.lsp-venv/bin" >> $GITHUB_PATH
 
       - name: Run LSP integration tests
         run: cargo test -p iam-policy-autopilot-policy-generation --features integ-test -- --ignored

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,11 +203,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install LSP test dependencies
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install 'ty>=0.0.39,<0.1' 'boto3-stubs[essential]'
-          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+        run: pip install --break-system-packages 'ty>=0.0.39,<0.1' boto3 'boto3-stubs[essential]'
 
       - name: Run LSP integration tests
         run: cargo test -p iam-policy-autopilot-policy-generation --features integ-test -- --ignored

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -209,7 +209,7 @@ jobs:
           echo "${{ github.workspace }}/.lsp-venv/bin" >> $GITHUB_PATH
 
       - name: Run LSP integration tests
-        run: cargo test -p iam-policy-autopilot-policy-generation --features integ-test -- --ignored
+        run: cargo test -p iam-policy-autopilot-policy-generation --features integ-test --test lsp_integration_tests -- --ignored
 
   unused-deps:
     name: Unused Dependencies (cargo-machete)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lsp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b8fd1e175c5ee3108095da452e816519de618beccea23aa053c00cf5e344b9"
+dependencies = [
+ "futures",
+ "lsp-types",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "waitpid-any",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +777,12 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1601,7 +1627,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -1786,6 +1812,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2057,6 +2092,7 @@ dependencies = [
  "ast-grep-config",
  "ast-grep-core",
  "ast-grep-language",
+ "async-lsp",
  "async-trait",
  "aws-lc-rs",
  "convert_case",
@@ -2071,6 +2107,7 @@ dependencies = [
  "iam-policy-autopilot-common",
  "iam-policy-autopilot-policy-generation",
  "log",
+ "lsp-types",
  "paste",
  "pem",
  "proptest",
@@ -2085,7 +2122,9 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serial_test",
  "strsim",
+ "temp-env",
  "tempfile",
  "test-log",
  "thiserror 1.0.69",
@@ -2093,7 +2132,9 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-test",
  "tokio-util",
+ "tower",
  "walkdir",
+ "which",
  "wiremock",
 ]
 
@@ -2533,6 +2574,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2563,6 +2610,19 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lsp-types"
+version = "0.95.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "matchers"
@@ -2614,7 +2674,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3015,7 +3075,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec 0.8.0",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -3234,7 +3294,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3535,14 +3595,27 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3763,7 +3836,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3850,6 +3923,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4104,6 +4188,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4112,7 +4206,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4405,7 +4499,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -4900,6 +4994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "waitpid-any"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18aa3ce681e189f125c4c1e1388c03285e2fd434ef52c7203084012ac29c5e4a"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5038,7 +5142,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5071,6 +5175,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
 ]
 
 [[package]]
@@ -5188,6 +5304,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5367,6 +5492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5453,7 +5584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/iam-policy-autopilot-policy-generation/Cargo.toml
+++ b/iam-policy-autopilot-policy-generation/Cargo.toml
@@ -24,24 +24,22 @@ reqwest.workspace = true
 rust-embed.workspace = true
 schemars.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
 async-trait.workspace = true
 strsim.workspace = true
 derive-new.workspace = true
+lsp-types = "0.95"
+which = "6.0"
+tokio = { workspace = true, features = ["process", "io-util"] }
+tokio-util.workspace = true
 
 
 # Build dependencies
 [build-dependencies]
 serde.workspace = true
-
-# Async runtime
 tokio.workspace = true
 async-trait.workspace = true
 tokio-util.workspace = true
-
-# JSON processing
 serde_json.workspace = true
-
 aws-lc-rs.workspace = true
 git2.workspace = true
 relative-path.workspace = true
@@ -61,6 +59,8 @@ proptest.workspace = true
 test-log = "0.2"
 env_logger.workspace = true
 wiremock = "0.6"
+mockall = "0.12"
+serial_test = "3.0"
 iam-policy-autopilot-policy-generation = { path = ".", features = ["integ-test"]}
 
 # Documentation configuration

--- a/iam-policy-autopilot-policy-generation/Cargo.toml
+++ b/iam-policy-autopilot-policy-generation/Cargo.toml
@@ -28,10 +28,15 @@ reqwest.workspace = true
 rust-embed.workspace = true
 schemars.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
 async-trait.workspace = true
 strsim.workspace = true
 derive-new.workspace = true
+async-lsp = { version = "0.2", features = ["tokio"] }
+lsp-types = "0.95"
+tower = "0.5"
+which = "6.0"
+tokio = { workspace = true, features = ["process", "io-util"] }
+tokio-util.workspace = true
 hcl-rs.workspace = true
 walkdir.workspace = true
 
@@ -39,15 +44,10 @@ walkdir.workspace = true
 [build-dependencies]
 serde.workspace = true
 regex.workspace = true
-
-# Async runtime
 tokio.workspace = true
 async-trait.workspace = true
 tokio-util.workspace = true
-
-# JSON processing
 serde_json.workspace = true
-
 aws-lc-rs.workspace = true
 git2.workspace = true
 relative-path.workspace = true
@@ -70,6 +70,8 @@ paste.workspace = true
 test-log = "0.2"
 env_logger.workspace = true
 wiremock = "0.6"
+serial_test = "3.0"
+temp-env = { version = "0.3", features = ["async_closure"] }
 assert_cmd.workspace = true
 # TLS integration test: verifies the HTTP client respects the OS certificate store
 # (corporate CAs trusted via SSL_CERT_FILE) when connecting to the service reference endpoint

--- a/iam-policy-autopilot-policy-generation/src/lib.rs
+++ b/iam-policy-autopilot-policy-generation/src/lib.rs
@@ -31,6 +31,9 @@ pub mod policy_generation;
 // Export api for public use
 pub mod api;
 
+// LSP client for Python type information
+pub mod lsp;
+
 use std::fmt::Display;
 use std::path::PathBuf;
 

--- a/iam-policy-autopilot-policy-generation/src/lib.rs
+++ b/iam-policy-autopilot-policy-generation/src/lib.rs
@@ -30,6 +30,9 @@ pub mod policy_generation;
 // Export api for public use
 pub mod api;
 
+// LSP client for Python type information
+pub mod lsp;
+
 use std::fmt::Display;
 use std::path::PathBuf;
 

--- a/iam-policy-autopilot-policy-generation/src/lib.rs
+++ b/iam-policy-autopilot-policy-generation/src/lib.rs
@@ -30,7 +30,7 @@ pub mod policy_generation;
 // Export api for public use
 pub mod api;
 
-// LSP client for Python type information
+// LSP client for type information extraction
 pub mod lsp;
 
 use std::fmt::Display;

--- a/iam-policy-autopilot-policy-generation/src/lsp/error.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/error.rs
@@ -1,0 +1,36 @@
+//! Error types for LSP operations.
+
+use std::time::Duration;
+use thiserror::Error;
+
+/// Errors that can occur during LSP operations.
+#[derive(Debug, Error)]
+pub enum LspError {
+    /// The ty command was not found in PATH.
+    #[error("ty command not found in PATH")]
+    TyNotFound,
+
+    /// Failed to start the ty server process.
+    #[error("Failed to start ty server: {0}")]
+    StartupFailed(String),
+
+    /// Failed to initialize the ty server.
+    #[error("Failed to initialize ty server: {0}")]
+    InitializeFailed(String),
+
+    /// An LSP operation timed out.
+    #[error("LSP operation timed out after {0:?}")]
+    Timeout(Duration),
+
+    /// Failed to send a message to the LSP server.
+    #[error("Failed to send message: {0}")]
+    SendFailed(#[from] std::io::Error),
+
+    /// Failed to parse an LSP response.
+    #[error("Failed to parse LSP response: {0}")]
+    ParseFailed(String),
+
+    /// The LSP server returned an error.
+    #[error("LSP server returned error: {0}")]
+    ServerError(String),
+}

--- a/iam-policy-autopilot-policy-generation/src/lsp/error.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/error.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+use thiserror::Error;
+
+/// Errors that can occur during LSP operations.
+#[derive(Debug, Error)]
+pub enum LspError {
+    /// The language server binary was not found in PATH.
+    #[error("{0} not found in PATH")]
+    ServerNotFound(String),
+
+    /// Failed to start the language server process.
+    #[error("Failed to start language server: {0}")]
+    StartupFailed(String),
+
+    /// Failed to initialize the language server.
+    #[error("Failed to initialize language server: {0}")]
+    InitializeFailed(String),
+
+    /// An LSP operation timed out.
+    #[error("LSP operation timed out after {0:?}")]
+    Timeout(Duration),
+
+    /// Failed to send a message to the language server.
+    #[error("Failed to send message: {0}")]
+    SendFailed(#[from] std::io::Error),
+
+    /// Failed to parse an LSP response.
+    #[error("Failed to parse LSP response: {0}")]
+    ParseFailed(String),
+
+    /// The language server returned an error.
+    #[error("Language server error: {0}")]
+    ServerError(String),
+}

--- a/iam-policy-autopilot-policy-generation/src/lsp/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/mod.rs
@@ -1,0 +1,819 @@
+//! LSP (Language Server Protocol) client for Python type information.
+//!
+//! This module provides a minimal, standalone LSP client for communicating with
+//! the [ty](https://github.com/astral-sh/ty) Python type checker. The client uses
+//! JSON-RPC 2.0 over stdin/stdout to query type information via hover requests.
+//!
+//! # Overview
+//!
+//! The LSP client automatically detects and uses ty when available on the system,
+//! requiring no configuration. It manages the ty server process lifecycle, handles
+
+#![allow(dead_code)]
+//! document synchronization, and provides async APIs for querying type information.
+//!
+//! ## Key Features
+//!
+//! - **Automatic ty detection**: Checks PATH for ty availability
+//! - **Process management**: Spawns, initializes, and cleanly shuts down ty server
+//! - **Document handling**: Opens Python files for analysis with proper synchronization
+//! - **Type queries**: Retrieves type information at specific code positions via hover
+//! - **Async-first**: Built on tokio for efficient async I/O operations
+//! - **Error handling**: Comprehensive error types with timeout protection
+//!
+//! # Usage
+//!
+//! ## Basic Example
+//!
+//! ```no_run
+//! use iam_policy_autopilot_policy_generation::lsp::TyLspClient;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create and initialize a ty LSP client
+//! let mut client = TyLspClient::new("/path/to/workspace").await?;
+//!
+//! // Open a Python file for analysis
+//! let content = "import boto3\ns3 = boto3.client('s3')";
+//! client.open_document("/path/to/file.py", content).await?;
+//!
+//! // Query type information at a specific position (line 1, character 5)
+//! if let Some(type_info) = client.hover("file:///path/to/file.py", 1, 5).await? {
+//!     println!("Type: {}", type_info);
+//! }
+//!
+//! // Shutdown gracefully
+//! client.shutdown().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Multiple Documents
+//!
+//! ```no_run
+//! use iam_policy_autopilot_policy_generation::lsp::TyLspClient;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut client = TyLspClient::new("/path/to/workspace").await?;
+//!
+//! // Open multiple Python files in the same workspace
+//! client.open_document("/path/to/workspace/app.py", "import boto3").await?;
+//! client.open_document("/path/to/workspace/utils.py", "def helper(): pass").await?;
+//!
+//! // Query type information from any opened document
+//! let type1 = client.hover("file:///path/to/workspace/app.py", 0, 7).await?;
+//! let type2 = client.hover("file:///path/to/workspace/utils.py", 0, 4).await?;
+//!
+//! client.shutdown().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Error Handling
+//!
+//! ```no_run
+//! use iam_policy_autopilot_policy_generation::lsp::{TyLspClient, LspError};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! match TyLspClient::new("/path/to/workspace").await {
+//!     Ok(mut client) => {
+//!         // Use the client
+//!         client.shutdown().await?;
+//!     }
+//!     Err(LspError::TyNotFound) => {
+//!         eprintln!("ty is not installed or not in PATH");
+//!     }
+//!     Err(LspError::Timeout(duration)) => {
+//!         eprintln!("ty server initialization timed out after {:?}", duration);
+//!     }
+//!     Err(e) => {
+//!         eprintln!("Failed to start ty server: {}", e);
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Public API
+//!
+//! ## Types
+//!
+//! - [`TyLspClient`]: Main client struct for managing ty server and querying type information
+//! - [`LspError`]: Error type for all LSP operations
+//!
+//! # Error Conditions
+//!
+//! The LSP client can fail in several ways:
+//!
+//! ## Startup Errors
+//!
+//! - **[`LspError::TyNotFound`]**: ty command not found in PATH
+//!   - Occurs when ty is not installed or not accessible
+//!   - Check: `which ty` or `ty --version`
+//!
+//! - **[`LspError::StartupFailed`]**: Failed to spawn or initialize ty server
+//!   - Process spawn failed (permissions, missing dependencies)
+//!   - Failed to get stdin/stdout handles
+//!   - Invalid workspace path (non-UTF-8 characters)
+//!
+//! - **[`LspError::InitializeFailed`]**: Initialize request failed
+//!   - ty server rejected initialization
+//!   - ty server returned error response
+//!   - Communication failure during initialization
+//!
+//! ## Communication Errors
+//!
+//! - **[`LspError::Timeout`]**: Operation exceeded timeout duration
+//!   - Initialize: 10 seconds
+//!   - Hover: 5 seconds
+//!   - Shutdown: 2 seconds
+//!   - May indicate ty server is unresponsive or overloaded
+//!
+//! - **[`LspError::SendFailed`]**: Failed to send message to ty server
+//!   - Broken pipe (ty server crashed)
+//!   - I/O error writing to stdin
+//!
+//! - **[`LspError::ParseFailed`]**: Failed to parse LSP response
+//!   - Malformed JSON from ty server
+//!   - Invalid Content-Length header
+//!   - Unexpected response format
+//!
+//! ## Server Errors
+//!
+//! - **[`LspError::ServerError`]**: ty server returned error response
+//!   - Invalid request parameters
+//!   - Document not found
+//!   - Internal ty server error
+//!
+//! # Protocol Details
+//!
+//! ## LSP Communication Flow
+//!
+//! 1. **Initialize**: Client sends initialize request with workspace root
+//! 2. **Initialized**: Client sends initialized notification after receiving response
+//! 3. **Document Open**: Client sends textDocument/didOpen for each file
+//! 4. **Analysis Wait**: Client waits 1 second for ty to analyze document
+//! 5. **Hover Query**: Client sends textDocument/hover requests for type information
+//! 6. **Shutdown**: Client sends shutdown request and exit notification
+//!
+//! ## Message Format
+//!
+//! All LSP messages use JSON-RPC 2.0 with Content-Length header:
+//!
+//! ```text
+//! Content-Length: <byte_count>\r\n
+//! \r\n
+//! <JSON payload>
+//! ```
+//!
+//! ## Position Coordinates
+//!
+//! - **Line numbers**: Zero-based (first line is 0)
+//! - **Character positions**: Zero-based (first character is 0)
+//! - **Character encoding**: UTF-16 code units (LSP standard)
+//!
+//! # Requirements
+//!
+//! - **ty**: Must be installed and available in PATH
+//!   - Install: `pip install ty` or `cargo install ty`
+//!   - Verify: `ty --version`
+//!
+//! - **Tokio runtime**: Async operations require tokio runtime
+//!   - Client methods are async and must be awaited
+//!   - Use `tokio::runtime::Runtime` or `#[tokio::main]`
+//!
+//! # Implementation Notes
+//!
+//! ## Document Lifecycle
+//!
+//! - Documents must be opened before querying hover information
+//! - The client tracks opened documents to avoid duplicate opens
+//! - Documents remain open until client shutdown
+//! - ty analyzes documents asynchronously (1 second wait after open)
+//!
+//! ## Process Management
+//!
+//! - ty server process is spawned with stdin/stdout pipes
+//! - Process is automatically killed when client is dropped
+//! - Graceful shutdown sends shutdown request and exit notification
+//! - Drop implementation ensures process cleanup even on panic
+//!
+//! ## Timeouts
+//!
+//! All operations have timeouts to prevent hanging:
+//! - Initialize: 10 seconds (ty needs time to start and analyze workspace)
+//! - Hover: 5 seconds (type queries should be fast)
+//! - Shutdown: 2 seconds (graceful shutdown should be quick)
+//!
+//! ## Thread Safety
+//!
+//! - `TyLspClient` is not `Send` or `Sync` due to process handles
+//! - Use within a single async task or protect with `Arc<Mutex<>>`
+//! - Request IDs use `AtomicU64` for thread-safe incrementing
+
+mod error;
+mod protocol;
+
+// Test utilities are available in both unit tests and integration tests
+#[cfg(any(test, feature = "integ-test"))]
+pub mod test_utils;
+
+pub use error::LspError;
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::atomic::AtomicU64;
+use tokio::io::BufReader;
+use tokio::process::{Child, ChildStdin, ChildStdout};
+
+/// LSP client for the ty Python type checker.
+///
+/// This client manages a ty server process and provides async methods for
+/// opening documents and querying type information via hover requests.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct TyLspClient {
+    process: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    request_id: AtomicU64,
+    workspace_root: String,
+    opened_documents: HashSet<String>,
+}
+
+impl TyLspClient {
+    /// Create and initialize a new ty LSP client.
+    ///
+    /// This method:
+    /// 1. Checks if ty is available in PATH
+    /// 2. Spawns the ty server process
+    /// 3. Sends an initialize request
+    /// 4. Waits for the initialize response
+    /// 5. Sends an initialized notification
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - ty is not found in PATH
+    /// - The ty server fails to start
+    /// - The initialize request times out or fails
+    pub async fn new(workspace_root: impl AsRef<Path>) -> Result<Self, LspError> {
+        use std::process::Stdio;
+        use tokio::process::Command;
+        use tokio::time::{timeout, Duration};
+
+        // Check if ty is in PATH
+        let ty_path = which::which("ty").map_err(|_| {
+            log::warn!("ty command not found in PATH");
+            LspError::TyNotFound
+        })?;
+
+        log::debug!("Found ty at: {ty_path:?}");
+        log::debug!(
+            "Starting ty server with workspace: {}",
+            workspace_root.as_ref().display()
+        );
+
+        // Spawn ty server process with stdin/stdout pipes
+        let mut process = Command::new(ty_path)
+            .arg("server")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| LspError::StartupFailed(format!("Failed to spawn process: {e}")))?;
+
+        log::debug!("ty server process spawned with PID: {:?}", process.id());
+
+        // Get stdin and stdout handles
+        let mut stdin = process
+            .stdin
+            .take()
+            .ok_or_else(|| LspError::StartupFailed("Failed to get stdin handle".into()))?;
+        let stdout = process
+            .stdout
+            .take()
+            .ok_or_else(|| LspError::StartupFailed("Failed to get stdout handle".into()))?;
+        let mut stdout = BufReader::new(stdout);
+
+        // Send initialize request with 10s timeout
+        let workspace_root_str = workspace_root
+            .as_ref()
+            .to_str()
+            .ok_or_else(|| LspError::StartupFailed("Invalid workspace path".into()))?;
+
+        let init_request = protocol::create_initialize_request(1, workspace_root_str);
+
+        log::debug!("Sending initialize request");
+
+        let (stdin, stdout) = timeout(Duration::from_secs(10), async {
+            // Send initialize request
+            protocol::send_message(&mut stdin, &init_request)
+                .await
+                .map_err(|e| LspError::InitializeFailed(format!("Failed to send request: {e}")))?;
+
+            // Wait for initialize response
+            let response = protocol::read_message(&mut stdout, Duration::from_secs(10))
+                .await
+                .map_err(|e| LspError::InitializeFailed(format!("Failed to read response: {e}")))?;
+
+            log::debug!("Received initialize response: {response:?}");
+
+            // Check for error in response
+            if let Some(error) = response.get("error") {
+                return Err(LspError::InitializeFailed(format!(
+                    "Server returned error: {error}"
+                )));
+            }
+
+            // Verify we got a result
+            if response.get("result").is_none() {
+                return Err(LspError::InitializeFailed(
+                    "No result in initialize response".into(),
+                ));
+            }
+
+            // Send initialized notification
+            let initialized_notification = serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "initialized",
+                "params": {}
+            });
+
+            log::debug!("Sending initialized notification");
+
+            protocol::send_message(&mut stdin, &initialized_notification)
+                .await
+                .map_err(|e| {
+                    LspError::InitializeFailed(format!("Failed to send notification: {e}"))
+                })?;
+
+            Ok::<_, LspError>((stdin, stdout))
+        })
+        .await
+        .map_err(|_| LspError::Timeout(Duration::from_secs(10)))??;
+
+        log::info!("ty LSP client initialized successfully");
+
+        Ok(Self {
+            process,
+            stdin,
+            stdout,
+            request_id: AtomicU64::new(2), // Start at 2 since we used 1 for initialize
+            workspace_root: workspace_root_str.to_string(),
+            opened_documents: HashSet::new(),
+        })
+    }
+
+    /// Open a document for analysis.
+    ///
+    /// Sends a textDocument/didOpen notification to the ty server and waits
+    /// 1 second for ty to analyze the document.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the notification fails to send.
+    pub async fn open_document(
+        &mut self,
+        file_path: impl AsRef<Path>,
+        content: &str,
+    ) -> Result<(), LspError> {
+        use tokio::time::{sleep, Duration};
+
+        // Convert file path to file:// URI
+        let file_uri = lsp_types::Url::from_file_path(file_path.as_ref())
+            .map(|url| url.to_string())
+            .map_err(|()| {
+                LspError::ParseFailed(format!("Invalid file path: {:?}", file_path.as_ref()))
+            })?;
+
+        log::debug!("Opening document: {file_uri}");
+
+        // Check if document is already opened
+        if self.opened_documents.contains(&file_uri) {
+            log::debug!("Document already opened: {file_uri}");
+            return Ok(());
+        }
+
+        // Create textDocument/didOpen notification
+        let did_open_notification = protocol::create_did_open_notification(&file_uri, content);
+
+        // Send the notification
+        protocol::send_message(&mut self.stdin, &did_open_notification)
+            .await
+            .map_err(|e| {
+                LspError::SendFailed(std::io::Error::other(format!(
+                    "Failed to send didOpen notification: {e}"
+                )))
+            })?;
+
+        // Track the opened document
+        self.opened_documents.insert(file_uri.clone());
+
+        log::debug!("Waiting 1 second for ty to analyze document");
+
+        // Wait 1 second for ty to analyze the document
+        sleep(Duration::from_secs(1)).await;
+
+        log::debug!("Document opened successfully: {file_uri}");
+
+        Ok(())
+    }
+
+    /// Query hover information at a specific position.
+    ///
+    /// Sends a textDocument/hover request and returns the type information
+    /// if available.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_uri` - The file URI (e.g., "file:///path/to/file.py")
+    /// * `line` - Zero-based line number
+    /// * `character` - Zero-based character position
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(String)` with type information if available, or `None`
+    /// if the hover response is empty.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request times out or fails.
+    pub async fn hover(
+        &mut self,
+        file_uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<String>, LspError> {
+        use std::sync::atomic::Ordering;
+        use tokio::time::{timeout, Duration};
+
+        // Get next request ID
+        let request_id = self.request_id.fetch_add(1, Ordering::SeqCst);
+
+        log::debug!("Sending hover request for {file_uri}:{line}:{character} (id={request_id})");
+
+        // Create hover request
+        let hover_request = protocol::create_hover_request(request_id, file_uri, line, character);
+
+        // Send request and wait for response with 5s timeout
+        let start_time = std::time::Instant::now();
+        let total_timeout = Duration::from_secs(5);
+
+        let response = timeout(total_timeout, async {
+            // Send the request
+            protocol::send_message(&mut self.stdin, &hover_request)
+                .await
+                .map_err(|e| {
+                    LspError::SendFailed(std::io::Error::other(format!(
+                        "Failed to send hover request: {e}"
+                    )))
+                })?;
+
+            // Wait for response with matching ID
+            // LSP servers may send notifications or other responses, so we need to loop
+            // Use shorter timeouts per read to avoid blocking too long on any single message
+            loop {
+                // Calculate remaining time for this operation
+                let elapsed = start_time.elapsed();
+                if elapsed >= total_timeout {
+                    return Err(LspError::Timeout(total_timeout));
+                }
+
+                let remaining = total_timeout
+                    .checked_sub(elapsed)
+                    .expect("elapsed time should not exceed total timeout");
+                // Use shorter timeout per read (min of 1s or remaining time)
+                let read_timeout = std::cmp::min(Duration::from_secs(1), remaining);
+
+                let message = protocol::read_message(&mut self.stdout, read_timeout).await?;
+
+                // Check if this is a response (has "id" field)
+                if let Some(response_id) = message.get("id") {
+                    // Check if the ID matches our request
+                    if response_id.as_u64() == Some(request_id) {
+                        log::debug!("Found matching response for request {request_id}");
+                        return Ok::<serde_json::Value, LspError>(message);
+                    }
+                    log::warn!(
+                        "Received response with mismatched ID: expected {request_id}, got {response_id:?}"
+                    );
+                    // Continue reading - this might be a response to a different request
+                    continue;
+                }
+                // This is a notification (no ID field) - log and skip it
+                if let Some(method) = message.get("method") {
+                    log::debug!(
+                        "Received notification while waiting for response: {method}"
+                    );
+                } else {
+                    log::debug!("Received message without ID or method: {message:?}");
+                }
+            }
+        })
+        .await
+        .map_err(|_| LspError::Timeout(total_timeout))??;
+
+        log::debug!("Received hover response: {response:?}");
+
+        // Check for error in response
+        if let Some(error) = response.get("error") {
+            return Err(LspError::ServerError(format!(
+                "Hover request failed: {error}"
+            )));
+        }
+
+        // Extract type information from the result
+        let result = response.get("result");
+
+        // If result is null or missing, return None
+        if result.is_none_or(serde_json::Value::is_null) {
+            log::debug!("Hover response has no result");
+            return Ok(None);
+        }
+
+        let result = result.expect("result was just checked");
+
+        // Extract contents field
+        let contents = result.get("contents");
+
+        // If contents is null or missing, return None
+        if contents.is_none_or(serde_json::Value::is_null) {
+            log::debug!("Hover response has no contents");
+            return Ok(None);
+        }
+
+        let contents = contents.expect("contents was just checked");
+
+        // Extract type information from contents
+        // Contents can be:
+        // 1. A string
+        // 2. An object with "value" field (markdown/plaintext)
+        // 3. An array of strings or objects
+        let type_info = if let Some(value_str) = contents.as_str() {
+            // Case 1: contents is a string
+            Some(value_str.to_string())
+        } else if let Some(value_obj) = contents.as_object() {
+            // Case 2: contents is an object with "value" field
+            value_obj
+                .get("value")
+                .and_then(|v| v.as_str())
+                .map(std::string::ToString::to_string)
+        } else if let Some(value_array) = contents.as_array() {
+            // Case 3: contents is an array - join all values
+            let values: Vec<String> = value_array
+                .iter()
+                .filter_map(|item| {
+                    if let Some(s) = item.as_str() {
+                        Some(s.to_string())
+                    } else if let Some(obj) = item.as_object() {
+                        obj.get("value")
+                            .and_then(|v| v.as_str())
+                            .map(std::string::ToString::to_string)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if values.is_empty() {
+                None
+            } else {
+                Some(values.join("\n"))
+            }
+        } else {
+            None
+        };
+
+        if type_info.is_some() {
+            log::debug!("Extracted type info: {type_info:?}");
+        } else {
+            log::debug!("No type info found in hover response");
+        }
+
+        Ok(type_info)
+    }
+
+    /// Shutdown the LSP server gracefully.
+    ///
+    /// Sends a shutdown request followed by an exit notification, then waits
+    /// for the process to exit.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the shutdown request times out or fails.
+    /// Shutdown the LSP server gracefully.
+    ///
+    /// This method:
+    /// 1. Sends a shutdown request with 2s timeout
+    /// 2. Sends an exit notification
+    /// 3. Waits for the process to exit
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The shutdown request times out
+    /// - Communication with the server fails
+    pub async fn shutdown(mut self) -> Result<(), LspError> {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        log::debug!("Shutting down ty LSP server");
+
+        // Get the next request ID
+        let request_id = self
+            .request_id
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        // Send shutdown request
+        let shutdown_request = protocol::create_shutdown_request(request_id);
+        protocol::send_message(&mut self.stdin, &shutdown_request).await?;
+
+        log::debug!("Sent shutdown request, waiting for response");
+
+        // Wait for shutdown response with 2s timeout
+        let _response = timeout(
+            Duration::from_secs(2),
+            protocol::read_message(&mut self.stdout, Duration::from_secs(2)),
+        )
+        .await
+        .map_err(|_| LspError::Timeout(Duration::from_secs(2)))??;
+
+        log::debug!("Received shutdown response, sending exit notification");
+
+        // Send exit notification
+        let exit_notification = protocol::create_exit_notification();
+        protocol::send_message(&mut self.stdin, &exit_notification).await?;
+
+        log::debug!("Sent exit notification, waiting for process to exit");
+
+        // Wait for the process to exit
+        let status = self.process.wait().await.map_err(LspError::SendFailed)?;
+
+        log::debug!("ty LSP server exited with status: {status:?}");
+
+        Ok(())
+    }
+}
+
+impl Drop for TyLspClient {
+    fn drop(&mut self) {
+        log::debug!("Dropping TyLspClient, ensuring ty server process is terminated");
+
+        // Ensure process is killed if not already shut down
+        let _ = self.process.start_kill();
+
+        // Wait briefly for process to exit (non-blocking check)
+        // We use try_wait() in a loop since Drop is synchronous
+        for _ in 0..10 {
+            if let Ok(Some(status)) = self.process.try_wait() {
+                // Process has exited
+                log::debug!("ty server process exited with status: {status:?}");
+                break;
+            }
+            // Brief sleep to give process time to exit
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_hover_response_parsing_string_contents() {
+        // Test parsing hover response with string contents
+        use serde_json::json;
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "contents": "str"
+            }
+        });
+
+        // Extract type info using the same logic as hover()
+        let result = response.get("result").unwrap();
+        let contents = result.get("contents").unwrap();
+        let type_info = contents.as_str().map(|s| s.to_string());
+
+        assert_eq!(type_info, Some("str".to_string()));
+    }
+
+    #[test]
+    fn test_hover_response_parsing_object_contents() {
+        // Test parsing hover response with object contents (markdown format)
+        use serde_json::json;
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "contents": {
+                    "kind": "markdown",
+                    "value": "```python\ns3_client: S3Client\n```"
+                }
+            }
+        });
+
+        // Extract type info using the same logic as hover()
+        let result = response.get("result").unwrap();
+        let contents = result.get("contents").unwrap();
+        let type_info = contents
+            .as_object()
+            .and_then(|obj| obj.get("value"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        assert_eq!(
+            type_info,
+            Some("```python\ns3_client: S3Client\n```".to_string())
+        );
+    }
+
+    #[test]
+    fn test_hover_response_parsing_null_result() {
+        // Test parsing hover response with null result
+        use serde_json::json;
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": null
+        });
+
+        // Extract type info using the same logic as hover()
+        let result = response.get("result");
+        let is_null = result.is_none() || result.unwrap().is_null();
+
+        assert!(is_null);
+    }
+
+    #[test]
+    fn test_hover_response_parsing_null_contents() {
+        // Test parsing hover response with null contents
+        use serde_json::json;
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "contents": null
+            }
+        });
+
+        // Extract type info using the same logic as hover()
+        let result = response.get("result").unwrap();
+        let contents = result.get("contents");
+        let is_null = contents.is_none() || contents.unwrap().is_null();
+
+        assert!(is_null);
+    }
+
+    #[test]
+    fn test_hover_response_parsing_array_contents() {
+        // Test parsing hover response with array contents
+        use serde_json::json;
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "contents": [
+                    "Type: str",
+                    {"kind": "markdown", "value": "Additional info"}
+                ]
+            }
+        });
+
+        // Extract type info using the same logic as hover()
+        let result = response.get("result").unwrap();
+        let contents = result.get("contents").unwrap();
+
+        if let Some(array) = contents.as_array() {
+            let values: Vec<String> = array
+                .iter()
+                .filter_map(|item| {
+                    if let Some(s) = item.as_str() {
+                        Some(s.to_string())
+                    } else if let Some(obj) = item.as_object() {
+                        obj.get("value")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let type_info = if values.is_empty() {
+                None
+            } else {
+                Some(values.join("\n"))
+            };
+
+            assert_eq!(type_info, Some("Type: str\nAdditional info".to_string()));
+        } else {
+            panic!("Expected array contents");
+        }
+    }
+}

--- a/iam-policy-autopilot-policy-generation/src/lsp/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/mod.rs
@@ -320,6 +320,11 @@ impl<C: LspServerConfig> LspClient<C> {
     }
 
     /// Shutdown the LSP server gracefully.
+    ///
+    /// This method:
+    /// 1. Sends a shutdown request with a configurable timeout
+    /// 2. Sends an exit notification
+    /// 3. Waits for the process to exit
     pub async fn shutdown(mut self) -> Result<(), LspError> {
         timeout(self.options.shutdown_timeout, self.server.shutdown(()))
             .await

--- a/iam-policy-autopilot-policy-generation/src/lsp/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/mod.rs
@@ -1,0 +1,464 @@
+//! LSP (Language Server Protocol) client for type information extraction.
+//!
+//! This module provides a generic, async LSP client built on [`async_lsp`] that can
+//! communicate with any language server. It currently supports the
+//! [ty](https://github.com/astral-sh/ty) Python type checker, and is designed to be
+//! extended to other servers (e.g., gopls for Go) via the [`LspServerConfig`] trait.
+
+mod error;
+
+#[cfg(any(test, feature = "integ-test"))]
+pub mod test_utils;
+
+pub use error::LspError;
+
+use std::collections::HashSet;
+use std::ops::ControlFlow;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_lsp::concurrency::ConcurrencyLayer;
+use async_lsp::panic::CatchUnwindLayer;
+use async_lsp::router::Router;
+use async_lsp::tracing::TracingLayer;
+use async_lsp::{LanguageServer, MainLoop, ServerSocket};
+use lsp_types::notification::PublishDiagnostics;
+use lsp_types::{
+    ClientCapabilities, DidOpenTextDocumentParams, HoverParams, InitializeParams,
+    InitializedParams, Position, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams, Url, WorkDoneProgressParams,
+};
+use tokio::sync::Notify;
+use tokio::time::timeout;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use tower::ServiceBuilder;
+
+/// Configuration for a specific language server.
+pub trait LspServerConfig {
+    /// Binary name to locate in PATH (e.g., "ty", "gopls").
+    fn binary_name(&self) -> &'static str;
+
+    /// Command-line arguments to start the server (e.g., &["server"], &["serve"]).
+    fn args(&self) -> &[&str];
+
+    /// LSP language identifier (e.g., "python", "go").
+    fn language_id(&self) -> &'static str;
+
+    /// Check if the server binary is available in PATH.
+    fn is_available(&self) -> bool {
+        which::which(self.binary_name()).is_ok()
+    }
+}
+
+/// Configuration for the ty Python type checker.
+pub struct TyConfig;
+
+impl LspServerConfig for TyConfig {
+    fn binary_name(&self) -> &'static str {
+        "ty"
+    }
+
+    fn args(&self) -> &[&str] {
+        &["server"]
+    }
+
+    fn language_id(&self) -> &'static str {
+        "python"
+    }
+}
+
+/// Options for configuring `LspClient` behavior.
+#[derive(Debug)]
+pub struct LspClientOptions {
+    /// Time to wait after opening a document for the server to analyze it.
+    pub open_document_timeout: Duration,
+    /// Timeout for the initialize handshake.
+    pub initialize_timeout: Duration,
+    /// Timeout for hover requests.
+    pub hover_timeout: Duration,
+    /// Timeout for shutdown.
+    pub shutdown_timeout: Duration,
+}
+
+impl Default for LspClientOptions {
+    fn default() -> Self {
+        Self {
+            open_document_timeout: Duration::from_secs(1),
+            initialize_timeout: Duration::from_secs(10),
+            hover_timeout: Duration::from_secs(5),
+            shutdown_timeout: Duration::from_secs(2),
+        }
+    }
+}
+
+struct ClientState {
+    diagnosed_uris: Arc<Mutex<HashSet<Url>>>,
+    diagnostics_notify: Arc<Notify>,
+}
+struct Stop;
+
+/// Generic LSP client parameterized by server configuration.
+///
+/// Manages the server process lifecycle, handles LSP protocol communication
+/// via `async-lsp`, and provides methods for opening documents and querying
+/// type information.
+#[derive(Debug)]
+pub struct LspClient<C: LspServerConfig> {
+    config: C,
+    options: LspClientOptions,
+    server: ServerSocket,
+    mainloop_handle: Option<tokio::task::JoinHandle<()>>,
+    child: tokio::process::Child,
+    opened_documents: HashSet<String>,
+    diagnosed_uris: Arc<Mutex<HashSet<Url>>>,
+    diagnostics_notify: Arc<Notify>,
+}
+
+impl<C: LspServerConfig> LspClient<C> {
+    /// Create and initialize a new LSP client with default options.
+    pub async fn new(config: C, workspace_root: impl AsRef<Path>) -> Result<Self, LspError> {
+        Self::with_options(config, workspace_root, LspClientOptions::default()).await
+    }
+
+    /// Create and initialize a new LSP client with custom options.
+    pub async fn with_options(
+        config: C,
+        workspace_root: impl AsRef<Path>,
+        options: LspClientOptions,
+    ) -> Result<Self, LspError> {
+        let binary_path = which::which(config.binary_name())
+            .map_err(|_| LspError::ServerNotFound(config.binary_name().to_string()))?;
+
+        let mut child = tokio::process::Command::new(binary_path)
+            .args(config.args())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| LspError::StartupFailed(format!("Failed to spawn process: {e}")))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| LspError::StartupFailed("Failed to get stdout handle".into()))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| LspError::StartupFailed("Failed to get stdin handle".into()))?;
+
+        let diagnosed_uris = Arc::new(Mutex::new(HashSet::<Url>::new()));
+        let diagnostics_notify = Arc::new(Notify::new());
+        let handler_uris = Arc::clone(&diagnosed_uris);
+        let handler_notify = Arc::clone(&diagnostics_notify);
+
+        let (mainloop, mut server) = MainLoop::new_client(|_server| {
+            let mut router = Router::new(ClientState {
+                diagnosed_uris: handler_uris,
+                diagnostics_notify: handler_notify,
+            });
+            router
+                .notification::<PublishDiagnostics>(|state, params| {
+                    state
+                        .diagnosed_uris
+                        .lock()
+                        .expect("diagnosed_uris mutex poisoned")
+                        .insert(params.uri);
+                    state.diagnostics_notify.notify_waiters();
+                    ControlFlow::Continue(())
+                })
+                .notification::<lsp_types::notification::Progress>(|_, _| ControlFlow::Continue(()))
+                .unhandled_notification(|_, method| {
+                    log::debug!("Unhandled notification from server: {method:?}");
+                    ControlFlow::Continue(())
+                })
+                .event(|_, _: Stop| ControlFlow::Break(Ok(())));
+            ServiceBuilder::new()
+                .layer(TracingLayer::default())
+                .layer(CatchUnwindLayer::default())
+                .layer(ConcurrencyLayer::default())
+                .service(router)
+        });
+
+        let stdout = stdout.compat();
+        let stdin = stdin.compat_write();
+
+        let mainloop_handle = tokio::spawn(async move {
+            if let Err(e) = mainloop.run_buffered(stdout, stdin).await {
+                log::error!("LSP main loop error: {e}");
+            }
+        });
+
+        let workspace_root_str = workspace_root
+            .as_ref()
+            .to_str()
+            .ok_or_else(|| LspError::StartupFailed("Invalid workspace path (non-UTF8)".into()))?;
+        let workspace_uri = Url::from_file_path(workspace_root_str)
+            .map_err(|()| LspError::StartupFailed("Invalid workspace path".into()))?;
+
+        #[allow(deprecated)]
+        let init_params = InitializeParams {
+            process_id: Some(std::process::id()),
+            root_uri: Some(workspace_uri.clone()),
+            capabilities: ClientCapabilities::default(),
+            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
+                uri: workspace_uri,
+                name: workspace_root
+                    .as_ref()
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("workspace")
+                    .to_string(),
+            }]),
+            ..Default::default()
+        };
+
+        timeout(options.initialize_timeout, server.initialize(init_params))
+            .await
+            .map_err(|_| LspError::Timeout(options.initialize_timeout))?
+            .map_err(|e| LspError::InitializeFailed(format!("{e}")))?;
+
+        server
+            .initialized(InitializedParams {})
+            .map_err(|e| LspError::InitializeFailed(format!("Failed to send initialized: {e}")))?;
+
+        Ok(Self {
+            config,
+            options,
+            server,
+            mainloop_handle: Some(mainloop_handle),
+            child,
+            opened_documents: HashSet::new(),
+            diagnosed_uris,
+            diagnostics_notify,
+        })
+    }
+
+    /// Open a document for analysis.
+    ///
+    /// Sends a `textDocument/didOpen` notification and waits for the configured
+    /// delay to allow the server to analyze the document.
+    pub async fn open_document(
+        &mut self,
+        file_path: impl AsRef<Path>,
+        content: &str,
+    ) -> Result<(), LspError> {
+        let uri = Url::from_file_path(file_path.as_ref()).map_err(|()| {
+            LspError::ParseFailed(format!("Invalid file path: {:?}", file_path.as_ref()))
+        })?;
+
+        let uri_string = uri.to_string();
+        if self.opened_documents.contains(&uri_string) {
+            return Ok(());
+        }
+
+        self.server
+            .did_open(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: self.config.language_id().to_string(),
+                    version: 1,
+                    text: content.to_string(),
+                },
+            })
+            .map_err(|e| LspError::SendFailed(std::io::Error::other(format!("{e}"))))?;
+
+        self.opened_documents.insert(uri_string);
+
+        let deadline = tokio::time::sleep(self.options.open_document_timeout);
+        tokio::pin!(deadline);
+        loop {
+            let notified = self.diagnostics_notify.notified();
+            tokio::pin!(notified);
+
+            if self
+                .diagnosed_uris
+                .lock()
+                .expect("diagnosed_uris mutex poisoned")
+                .contains(&uri)
+            {
+                break;
+            }
+            tokio::select! {
+                () = &mut notified => {},
+                () = &mut deadline => break,
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Query hover information at a specific position.
+    ///
+    /// Returns the extracted type information string if available.
+    pub async fn hover(
+        &mut self,
+        file_uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<String>, LspError> {
+        let uri = file_uri
+            .parse::<Url>()
+            .map_err(|e| LspError::ParseFailed(format!("Invalid URI: {e}")))?;
+
+        let params = HoverParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position::new(line, character),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+
+        let response = timeout(self.options.hover_timeout, self.server.hover(params))
+            .await
+            .map_err(|_| LspError::Timeout(self.options.hover_timeout))?
+            .map_err(|e| LspError::ServerError(format!("{e}")))?;
+
+        Ok(response.and_then(|hover| extract_type_from_hover(&hover)))
+    }
+
+    /// Shutdown the LSP server gracefully.
+    pub async fn shutdown(mut self) -> Result<(), LspError> {
+        timeout(self.options.shutdown_timeout, self.server.shutdown(()))
+            .await
+            .map_err(|_| LspError::Timeout(self.options.shutdown_timeout))?
+            .map_err(|e| LspError::ServerError(format!("Shutdown failed: {e}")))?;
+
+        self.server
+            .exit(())
+            .map_err(|e| LspError::SendFailed(std::io::Error::other(format!("{e}"))))?;
+
+        let _ = self.server.emit(Stop);
+
+        if let Some(handle) = self.mainloop_handle.take() {
+            let _ = handle.await;
+        }
+
+        let _ = self.child.wait().await;
+
+        Ok(())
+    }
+}
+
+impl<C: LspServerConfig> Drop for LspClient<C> {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+/// Extract a human-readable type string from an LSP Hover response.
+#[must_use]
+pub fn extract_type_from_hover(hover: &lsp_types::Hover) -> Option<String> {
+    use lsp_types::{HoverContents, MarkedString, MarkupContent};
+
+    match &hover.contents {
+        HoverContents::Scalar(marked) => match marked {
+            MarkedString::String(s) => non_empty(s),
+            MarkedString::LanguageString(ls) => non_empty(&ls.value),
+        },
+        HoverContents::Markup(MarkupContent { value, .. }) => non_empty(value),
+        HoverContents::Array(items) => {
+            let values: Vec<String> = items
+                .iter()
+                .filter_map(|item| match item {
+                    MarkedString::String(s) => non_empty(s),
+                    MarkedString::LanguageString(ls) => non_empty(&ls.value),
+                })
+                .collect();
+            if values.is_empty() {
+                None
+            } else {
+                Some(values.join("\n"))
+            }
+        }
+    }
+}
+
+fn non_empty(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+/// Convenience type alias for the ty Python type checker client.
+pub type TyLspClient = LspClient<TyConfig>;
+
+impl TyLspClient {
+    /// Create a new ty LSP client with default options.
+    pub async fn create(workspace_root: impl AsRef<Path>) -> Result<Self, LspError> {
+        Self::new(TyConfig, workspace_root).await
+    }
+
+    /// Create a new ty LSP client with custom options.
+    pub async fn create_with_options(
+        workspace_root: impl AsRef<Path>,
+        options: LspClientOptions,
+    ) -> Result<Self, LspError> {
+        Self::with_options(TyConfig, workspace_root, options).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::{
+        Hover, HoverContents, LanguageString, MarkedString, MarkupContent, MarkupKind,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        Hover {
+            contents: HoverContents::Scalar(MarkedString::String("str".into())),
+            range: None,
+        },
+        Some("str".into())
+    )]
+    #[case(
+        Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: "```python\ns3_client: S3Client\n```".into(),
+            }),
+            range: None,
+        },
+        Some("```python\ns3_client: S3Client\n```".into())
+    )]
+    #[case(
+        Hover {
+            contents: HoverContents::Scalar(MarkedString::String(String::new())),
+            range: None,
+        },
+        None
+    )]
+    #[case(
+        Hover {
+            contents: HoverContents::Scalar(MarkedString::LanguageString(LanguageString {
+                language: "python".into(),
+                value: "int".into(),
+            })),
+            range: None,
+        },
+        Some("int".into())
+    )]
+    #[case(
+        Hover {
+            contents: HoverContents::Array(vec![
+                MarkedString::String("Type: str".into()),
+                MarkedString::LanguageString(LanguageString {
+                    language: "python".into(),
+                    value: "extra".into(),
+                }),
+            ]),
+            range: None,
+        },
+        Some("Type: str\nextra".into())
+    )]
+    fn test_extract_type_from_hover(#[case] hover: Hover, #[case] expected: Option<String>) {
+        assert_eq!(extract_type_from_hover(&hover), expected);
+    }
+}

--- a/iam-policy-autopilot-policy-generation/src/lsp/protocol.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/protocol.rs
@@ -1,0 +1,680 @@
+//! JSON-RPC protocol implementation for LSP communication.
+//!
+//! This module handles the low-level details of formatting and parsing LSP messages
+//! using JSON-RPC 2.0 over stdin/stdout.
+
+#![allow(dead_code)]
+
+use crate::lsp::error::LspError;
+use std::time::Duration;
+use tokio::io::BufReader;
+
+/// Format a JSON-RPC message with Content-Length header.
+///
+/// LSP messages follow this format:
+/// ```text
+/// Content-Length: <byte_count>\r\n
+/// \r\n
+/// <JSON payload>
+/// ```
+pub fn format_message(message: &serde_json::Value) -> Vec<u8> {
+    // Serialize the JSON message to a string
+    let json_str = serde_json::to_string(message).expect("Failed to serialize JSON");
+
+    // Get the byte length of the UTF-8 encoded JSON
+    let content_length = json_str.len();
+
+    log::trace!("Formatting LSP message: {content_length} bytes");
+
+    // Format the complete message with Content-Length header
+    format!("Content-Length: {content_length}\r\n\r\n{json_str}").into_bytes()
+}
+
+/// Read and parse a single LSP message from stdout.
+///
+/// Reads the Content-Length header, then reads the exact number of bytes
+/// specified, and parses the JSON payload.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The operation times out
+/// - The Content-Length header is malformed
+/// - The JSON payload is invalid
+pub async fn read_message<R>(
+    reader: &mut BufReader<R>,
+    timeout_duration: Duration,
+) -> Result<serde_json::Value, LspError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncBufReadExt;
+    use tokio::io::AsyncReadExt;
+    use tokio::time::timeout;
+
+    // Wrap the entire operation in a timeout
+    timeout(timeout_duration, async {
+        log::trace!("Reading LSP message with timeout: {timeout_duration:?}");
+
+        // Read Content-Length header
+        let mut header_line = String::new();
+        reader
+            .read_line(&mut header_line)
+            .await
+            .map_err(|e| LspError::ParseFailed(format!("Failed to read header: {e}")))?;
+
+        // Parse content length from "Content-Length: N\r\n"
+        let content_length = header_line
+            .trim()
+            .strip_prefix("Content-Length:")
+            .ok_or_else(|| {
+                log::warn!("Invalid LSP header format: {header_line}");
+                LspError::ParseFailed(format!("Invalid header format: {header_line}"))
+            })?
+            .trim()
+            .parse::<usize>()
+            .map_err(|e| {
+                log::warn!("Invalid content length in header: {e}");
+                LspError::ParseFailed(format!("Invalid content length: {e}"))
+            })?;
+
+        log::trace!("Reading {content_length} bytes of LSP message payload");
+
+        // Read empty line (\r\n)
+        let mut empty_line = String::new();
+        reader
+            .read_line(&mut empty_line)
+            .await
+            .map_err(|e| LspError::ParseFailed(format!("Failed to read separator: {e}")))?;
+
+        // Read exact number of bytes for the JSON payload
+        let mut buffer = vec![0u8; content_length];
+        reader.read_exact(&mut buffer).await.map_err(|e| {
+            log::error!("Failed to read LSP message payload: {e}");
+            LspError::ParseFailed(format!("Failed to read payload: {e}"))
+        })?;
+
+        // Parse JSON
+        let value = serde_json::from_slice(&buffer).map_err(|e| {
+            log::error!("Failed to parse LSP JSON payload: {e}");
+            LspError::ParseFailed(format!("Invalid JSON: {e}"))
+        })?;
+
+        log::trace!("Successfully parsed LSP message");
+        Ok(value)
+    })
+    .await
+    .map_err(|_| {
+        log::warn!("LSP message read timed out after {timeout_duration:?}");
+        LspError::Timeout(timeout_duration)
+    })?
+}
+
+/// Send a message to the LSP server stdin.
+///
+/// # Errors
+///
+/// Returns an error if the write operation fails.
+pub async fn send_message<W>(writer: &mut W, message: &serde_json::Value) -> Result<(), LspError>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncWriteExt;
+
+    log::trace!(
+        "Sending LSP message: method={}",
+        message
+            .get("method")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown")
+    );
+
+    // Format the message with Content-Length header
+    let formatted = format_message(message);
+
+    // Write to stdin
+    writer.write_all(&formatted).await.map_err(|e| {
+        log::error!("Failed to write LSP message: {e}");
+        LspError::SendFailed(e)
+    })?;
+
+    // Flush to ensure the message is sent immediately
+    writer.flush().await.map_err(|e| {
+        log::error!("Failed to flush LSP message: {e}");
+        LspError::SendFailed(e)
+    })?;
+
+    log::trace!("LSP message sent successfully");
+    Ok(())
+}
+
+/// Create an initialize request using lsp-types.
+///
+/// # Arguments
+///
+/// * `id` - The JSON-RPC request ID
+/// * `workspace_root` - The workspace root directory path
+///
+/// # Notes
+///
+/// This function uses `workspace_folders` (the modern LSP approach) for specifying
+/// the workspace. The deprecated `root_uri` field is not set and will be serialized
+/// as `null`, which is correct per the LSP specification when `workspace_folders` is provided.
+#[allow(deprecated)]
+pub fn create_initialize_request(id: u64, workspace_root: &str) -> serde_json::Value {
+    use lsp_types::{ClientCapabilities, InitializeParams, Url, WorkspaceFolder};
+    use serde_json::json;
+
+    let workspace_uri = Url::from_file_path(workspace_root).expect("Invalid workspace path");
+
+    let params = InitializeParams {
+        process_id: Some(std::process::id()),
+        workspace_folders: Some(vec![WorkspaceFolder {
+            uri: workspace_uri,
+            name: workspace_root
+                .split('/')
+                .next_back()
+                .unwrap_or("workspace")
+                .to_string(),
+        }]),
+        capabilities: ClientCapabilities::default(),
+        ..Default::default()
+    };
+
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "initialize",
+        "params": params
+    })
+}
+
+/// Create a textDocument/didOpen notification using lsp-types.
+///
+/// # Arguments
+///
+/// * `file_uri` - The file URI (e.g., "file:///path/to/file.py")
+/// * `content` - The file content
+pub fn create_did_open_notification(file_uri: &str, content: &str) -> serde_json::Value {
+    use lsp_types::{DidOpenTextDocumentParams, TextDocumentItem, Url};
+    use serde_json::json;
+
+    let params = DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: Url::parse(file_uri).expect("Invalid file URI"),
+            language_id: "python".to_string(),
+            version: 1,
+            text: content.to_string(),
+        },
+    };
+
+    json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": params
+    })
+}
+
+/// Create a textDocument/hover request using lsp-types.
+///
+/// # Arguments
+///
+/// * `id` - The JSON-RPC request ID
+/// * `file_uri` - The file URI
+/// * `line` - Zero-based line number
+/// * `character` - Zero-based character position
+pub fn create_hover_request(
+    id: u64,
+    file_uri: &str,
+    line: u32,
+    character: u32,
+) -> serde_json::Value {
+    use lsp_types::{
+        HoverParams, Position, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+    };
+    use serde_json::json;
+
+    let params = HoverParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::parse(file_uri).expect("Invalid file URI"),
+            },
+            position: Position { line, character },
+        },
+        work_done_progress_params: Default::default(),
+    };
+
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "textDocument/hover",
+        "params": params
+    })
+}
+
+/// Create a shutdown request.
+///
+/// # Arguments
+///
+/// * `id` - The JSON-RPC request ID
+pub fn create_shutdown_request(id: u64) -> serde_json::Value {
+    use serde_json::json;
+
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "shutdown"
+    })
+}
+
+/// Create an exit notification.
+pub fn create_exit_notification() -> serde_json::Value {
+    use serde_json::json;
+
+    json!({
+        "jsonrpc": "2.0",
+        "method": "exit"
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::io::AsyncWriteExt;
+
+    #[test]
+    fn test_format_message_simple() {
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+        });
+
+        let formatted = format_message(&message);
+        let formatted_str = String::from_utf8(formatted).unwrap();
+
+        // Verify the format: Content-Length header, blank line, then JSON
+        assert!(formatted_str.starts_with("Content-Length: "));
+        assert!(formatted_str.contains("\r\n\r\n"));
+
+        // Extract the content length from the header
+        let parts: Vec<&str> = formatted_str.split("\r\n\r\n").collect();
+        assert_eq!(parts.len(), 2);
+
+        let header = parts[0];
+        let json_body = parts[1];
+
+        // Parse the content length
+        let content_length: usize = header
+            .strip_prefix("Content-Length: ")
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        // Verify the content length matches the actual JSON body length
+        assert_eq!(content_length, json_body.len());
+
+        // Verify the JSON body can be parsed back
+        let parsed: serde_json::Value = serde_json::from_str(json_body).unwrap();
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["id"], 1);
+        assert_eq!(parsed["method"], "initialize");
+    }
+
+    #[test]
+    fn test_format_message_with_special_characters() {
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "params": {
+                "text": "Hello\nWorld\t\"quoted\""
+            }
+        });
+
+        let formatted = format_message(&message);
+        let formatted_str = String::from_utf8(formatted).unwrap();
+
+        // Extract content length and body
+        let parts: Vec<&str> = formatted_str.split("\r\n\r\n").collect();
+        let header = parts[0];
+        let json_body = parts[1];
+
+        let content_length: usize = header
+            .strip_prefix("Content-Length: ")
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        // Verify UTF-8 byte length is correct (not character count)
+        assert_eq!(content_length, json_body.len());
+
+        // Verify the JSON can be parsed and special characters are preserved
+        let parsed: serde_json::Value = serde_json::from_str(json_body).unwrap();
+        assert_eq!(parsed["params"]["text"], "Hello\nWorld\t\"quoted\"");
+    }
+
+    #[test]
+    fn test_format_message_with_unicode() {
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "params": {
+                "text": "Hello 世界 🚀"
+            }
+        });
+
+        let formatted = format_message(&message);
+        let formatted_str = String::from_utf8(formatted).unwrap();
+
+        // Extract content length and body
+        let parts: Vec<&str> = formatted_str.split("\r\n\r\n").collect();
+        let header = parts[0];
+        let json_body = parts[1];
+
+        let content_length: usize = header
+            .strip_prefix("Content-Length: ")
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        // Verify byte length is correct (Unicode characters take multiple bytes)
+        assert_eq!(content_length, json_body.len());
+        // The byte length should be greater than the character count
+        assert!(content_length > "Hello 世界 🚀".chars().count());
+
+        // Verify the JSON can be parsed and Unicode is preserved
+        let parsed: serde_json::Value = serde_json::from_str(json_body).unwrap();
+        assert_eq!(parsed["params"]["text"], "Hello 世界 🚀");
+    }
+
+    #[tokio::test]
+    async fn test_read_message_simple() {
+        // Create a mock LSP message
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"capabilities": {}}
+        });
+
+        // Format it as an LSP message
+        let formatted = format_message(&message);
+
+        // Create a mock reader from the formatted bytes
+        let cursor = std::io::Cursor::new(formatted);
+        let mut reader = BufReader::new(cursor);
+
+        // Read and parse the message
+        let parsed = read_message(&mut reader, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        // Verify we got the same JSON back
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["id"], 1);
+        assert!(parsed["result"].is_object());
+    }
+
+    #[tokio::test]
+    async fn test_read_message_with_unicode() {
+        // Create a message with Unicode content
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "contents": {
+                    "value": "Type: str 世界 🚀"
+                }
+            }
+        });
+
+        let formatted = format_message(&message);
+        let cursor = std::io::Cursor::new(formatted);
+        let mut reader = BufReader::new(cursor);
+
+        let parsed = read_message(&mut reader, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert_eq!(parsed["result"]["contents"]["value"], "Type: str 世界 🚀");
+    }
+
+    #[tokio::test]
+    async fn test_read_message_malformed_header() {
+        // Create a message with invalid header
+        let invalid_message = b"Invalid-Header: 10\r\n\r\n{}";
+        let cursor = std::io::Cursor::new(invalid_message);
+        let mut reader = BufReader::new(cursor);
+
+        let result = read_message(&mut reader, Duration::from_secs(5)).await;
+
+        assert!(result.is_err());
+        match result {
+            Err(LspError::ParseFailed(msg)) => {
+                assert!(msg.contains("Invalid header format"));
+            }
+            _ => panic!("Expected ParseFailed error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_message_invalid_content_length() {
+        // Create a message with non-numeric content length
+        let invalid_message = b"Content-Length: abc\r\n\r\n{}";
+        let cursor = std::io::Cursor::new(invalid_message);
+        let mut reader = BufReader::new(cursor);
+
+        let result = read_message(&mut reader, Duration::from_secs(5)).await;
+
+        assert!(result.is_err());
+        match result {
+            Err(LspError::ParseFailed(msg)) => {
+                assert!(msg.contains("Invalid content length"));
+            }
+            _ => panic!("Expected ParseFailed error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_message_invalid_json() {
+        // Create a message with invalid JSON
+        let invalid_json = b"Content-Length: 9\r\n\r\n{invalid}";
+        let cursor = std::io::Cursor::new(invalid_json);
+        let mut reader = BufReader::new(cursor);
+
+        let result = read_message(&mut reader, Duration::from_secs(5)).await;
+
+        assert!(result.is_err());
+        match result {
+            Err(LspError::ParseFailed(msg)) => {
+                // The error message should mention JSON parsing failure
+                assert!(msg.contains("Invalid JSON") || msg.contains("JSON"));
+            }
+            _ => panic!("Expected ParseFailed error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_message_timeout() {
+        // Create a pipe that will never have data available
+        let (mut writer, reader) = tokio::io::duplex(64);
+        let mut buf_reader = BufReader::new(reader);
+
+        // Spawn a task that writes data after the timeout
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let _ = writer.write_all(b"Content-Length: 2\r\n\r\n{}").await;
+        });
+
+        // Try to read with a very short timeout
+        let result = read_message(&mut buf_reader, Duration::from_millis(50)).await;
+
+        assert!(result.is_err());
+        match result {
+            Err(LspError::Timeout(duration)) => {
+                assert_eq!(duration, Duration::from_millis(50));
+            }
+            _ => panic!("Expected Timeout error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_message_simple() {
+        // Create a duplex stream to simulate stdin/stdout
+        let (writer, mut reader) = tokio::io::duplex(1024);
+        let mut stdin = writer;
+
+        // Create a simple message
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+        });
+
+        // Send the message
+        send_message(&mut stdin, &message).await.unwrap();
+
+        // Read back what was written
+        let mut buf_reader = BufReader::new(&mut reader);
+        let received = read_message(&mut buf_reader, Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        // Verify the message was sent correctly
+        assert_eq!(received["jsonrpc"], "2.0");
+        assert_eq!(received["id"], 1);
+        assert_eq!(received["method"], "initialize");
+    }
+
+    #[tokio::test]
+    async fn test_send_message_with_unicode() {
+        // Create a duplex stream
+        let (writer, mut reader) = tokio::io::duplex(1024);
+        let mut stdin = writer;
+
+        // Create a message with Unicode content
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "params": {
+                "text": "Hello 世界 🚀"
+            }
+        });
+
+        // Send the message
+        send_message(&mut stdin, &message).await.unwrap();
+
+        // Read back what was written
+        let mut buf_reader = BufReader::new(&mut reader);
+        let received = read_message(&mut buf_reader, Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        // Verify Unicode was preserved
+        assert_eq!(received["params"]["text"], "Hello 世界 🚀");
+    }
+
+    #[test]
+    fn test_create_initialize_request() {
+        use std::env;
+
+        // Create a temporary directory for testing
+        let temp_dir = env::temp_dir();
+        let workspace_path = temp_dir.to_str().unwrap();
+
+        let request = create_initialize_request(1, workspace_path);
+
+        // Verify JSON-RPC structure
+        assert_eq!(request["jsonrpc"], "2.0");
+        assert_eq!(request["id"], 1);
+        assert_eq!(request["method"], "initialize");
+
+        // Verify params structure
+        assert!(request["params"].is_object());
+        assert!(request["params"]["processId"].is_number());
+        assert!(request["params"]["capabilities"].is_object());
+
+        // Check workspaceFolders field
+        assert!(request["params"]["workspaceFolders"].is_array());
+        let workspace_folders = request["params"]["workspaceFolders"].as_array().unwrap();
+        assert_eq!(workspace_folders.len(), 1);
+
+        // Verify the workspace folder structure
+        let workspace_folder = &workspace_folders[0];
+        assert!(workspace_folder["uri"].is_string());
+        assert!(workspace_folder["name"].is_string());
+
+        // Verify URI is a file:// URI
+        let uri = workspace_folder["uri"].as_str().unwrap();
+        assert!(uri.starts_with("file://"));
+    }
+
+    #[test]
+    fn test_create_did_open_notification() {
+        let file_uri = "file:///tmp/test.py";
+        let content = "import boto3\ns3 = boto3.client('s3')";
+
+        let notification = create_did_open_notification(file_uri, content);
+
+        // Verify JSON-RPC structure (notifications don't have id)
+        assert_eq!(notification["jsonrpc"], "2.0");
+        assert!(notification["id"].is_null());
+        assert_eq!(notification["method"], "textDocument/didOpen");
+
+        // Verify params structure
+        assert!(notification["params"].is_object());
+        assert_eq!(notification["params"]["textDocument"]["uri"], file_uri);
+        assert_eq!(
+            notification["params"]["textDocument"]["languageId"],
+            "python"
+        );
+        assert_eq!(notification["params"]["textDocument"]["version"], 1);
+        assert_eq!(notification["params"]["textDocument"]["text"], content);
+    }
+
+    #[test]
+    fn test_create_hover_request() {
+        let file_uri = "file:///tmp/test.py";
+        let line = 5;
+        let character = 10;
+
+        let request = create_hover_request(42, file_uri, line, character);
+
+        // Verify JSON-RPC structure
+        assert_eq!(request["jsonrpc"], "2.0");
+        assert_eq!(request["id"], 42);
+        assert_eq!(request["method"], "textDocument/hover");
+
+        // Verify params structure - lsp-types flattens textDocumentPositionParams
+        assert!(request["params"].is_object());
+        assert_eq!(request["params"]["textDocument"]["uri"], file_uri);
+        assert_eq!(request["params"]["position"]["line"], line);
+        assert_eq!(request["params"]["position"]["character"], character);
+    }
+
+    #[test]
+    fn test_create_shutdown_request() {
+        let request = create_shutdown_request(99);
+
+        // Verify JSON-RPC structure
+        assert_eq!(request["jsonrpc"], "2.0");
+        assert_eq!(request["id"], 99);
+        assert_eq!(request["method"], "shutdown");
+
+        // Shutdown request has no params
+        assert!(request["params"].is_null());
+    }
+
+    #[test]
+    fn test_create_exit_notification() {
+        let notification = create_exit_notification();
+
+        // Verify JSON-RPC structure (notifications don't have id)
+        assert_eq!(notification["jsonrpc"], "2.0");
+        assert!(notification["id"].is_null());
+        assert_eq!(notification["method"], "exit");
+
+        // Exit notification has no params
+        assert!(notification["params"].is_null());
+    }
+}

--- a/iam-policy-autopilot-policy-generation/src/lsp/test_utils.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/test_utils.rs
@@ -1,0 +1,113 @@
+//! Test utilities and fixtures for LSP client testing.
+//!
+//! This module provides helper functions and fixtures for testing the LSP client.
+
+/// Sample Python code fixtures for testing.
+pub mod fixtures {
+    /// Simple Python code with boto3 import and S3 client creation.
+    pub const SIMPLE_BOTO3: &str = r#"import boto3
+
+s3_client = boto3.client('s3')
+response = s3_client.list_buckets()
+"#;
+
+    /// Python code with type annotations.
+    pub const WITH_TYPE_ANNOTATIONS: &str = r#"import boto3
+from mypy_boto3_s3 import S3Client
+
+def get_s3_client() -> S3Client:
+    return boto3.client('s3')
+
+client: S3Client = get_s3_client()
+"#;
+
+    /// Python code with multiple AWS service clients.
+    pub const MULTIPLE_SERVICES: &str = r#"import boto3
+
+s3 = boto3.client('s3')
+dynamodb = boto3.client('dynamodb')
+lambda_client = boto3.client('lambda')
+"#;
+
+    /// Python code with resource API usage.
+    pub const RESOURCE_API: &str = r#"import boto3
+
+s3 = boto3.resource('s3')
+bucket = s3.Bucket('my-bucket')
+bucket.upload_file('local.txt', 'remote.txt')
+"#;
+
+    /// Empty Python file.
+    pub const EMPTY: &str = "";
+
+    /// Python code with syntax error (for error handling tests).
+    pub const SYNTAX_ERROR: &str = r#"import boto3
+
+def broken_function(
+    # Missing closing parenthesis
+"#;
+}
+
+/// Helper function to check if ty is available in PATH.
+///
+/// This can be used to conditionally skip tests that require ty.
+pub fn is_ty_available() -> bool {
+    which::which("ty").is_ok()
+}
+
+/// Helper function to check if boto3-stubs are installed.
+///
+/// This checks if the mypy_boto3_s3 package is available, which indicates
+/// that boto3-stubs are installed. Without stubs, ty won't provide AWS-specific
+/// type information.
+pub fn is_boto3_stubs_available() -> bool {
+    std::process::Command::new("python3")
+        .args(["-c", "import mypy_boto3_s3"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Helper function to check if both ty and boto3-stubs are available.
+///
+/// For the LSP client to be useful for AWS type information, both ty and
+/// boto3-stubs must be installed.
+pub fn is_lsp_ready() -> bool {
+    is_ty_available() && is_boto3_stubs_available()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_ty_available() {
+        // This test just verifies the function doesn't panic
+        let _ = is_ty_available();
+    }
+
+    #[test]
+    fn test_is_boto3_stubs_available() {
+        // This test verifies the function doesn't panic
+        let result = is_boto3_stubs_available();
+        eprintln!("boto3-stubs available: {}", result);
+    }
+
+    #[test]
+    fn test_is_lsp_ready() {
+        // This test verifies the function doesn't panic
+        let result = is_lsp_ready();
+        eprintln!("LSP ready (ty + boto3-stubs): {}", result);
+    }
+
+    #[test]
+    fn test_fixtures_are_valid_strings() {
+        // Verify all fixtures are valid UTF-8 strings
+        assert!(!fixtures::SIMPLE_BOTO3.is_empty());
+        assert!(!fixtures::WITH_TYPE_ANNOTATIONS.is_empty());
+        assert!(!fixtures::MULTIPLE_SERVICES.is_empty());
+        assert!(!fixtures::RESOURCE_API.is_empty());
+        assert!(fixtures::EMPTY.is_empty());
+        assert!(!fixtures::SYNTAX_ERROR.is_empty());
+    }
+}

--- a/iam-policy-autopilot-policy-generation/src/lsp/test_utils.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/test_utils.rs
@@ -1,51 +1,5 @@
 //! Test utilities and fixtures for LSP client testing.
 
-/// Sample Python code fixtures for testing.
-pub mod fixtures {
-    /// Simple Python code with boto3 import and S3 client creation.
-    pub const SIMPLE_BOTO3: &str = r"import boto3
-
-s3_client = boto3.client('s3')
-response = s3_client.list_buckets()
-";
-
-    /// Python code with type annotations.
-    pub const WITH_TYPE_ANNOTATIONS: &str = r"import boto3
-from mypy_boto3_s3 import S3Client
-
-def get_s3_client() -> S3Client:
-    return boto3.client('s3')
-
-client: S3Client = get_s3_client()
-";
-
-    /// Python code with multiple AWS service clients.
-    pub const MULTIPLE_SERVICES: &str = r"import boto3
-
-s3 = boto3.client('s3')
-dynamodb = boto3.client('dynamodb')
-lambda_client = boto3.client('lambda')
-";
-
-    /// Python code with resource API usage.
-    pub const RESOURCE_API: &str = r"import boto3
-
-s3 = boto3.resource('s3')
-bucket = s3.Bucket('my-bucket')
-bucket.upload_file('local.txt', 'remote.txt')
-";
-
-    /// Empty Python file.
-    pub const EMPTY: &str = "";
-
-    /// Python code with syntax error (for error handling tests).
-    pub const SYNTAX_ERROR: &str = r"import boto3
-
-def broken_function(
-    # Missing closing parenthesis
-";
-}
-
 /// Find the (line, column) position of `needle` in `source`.
 ///
 /// Returns the zero-based line and column of the first occurrence.
@@ -61,26 +15,75 @@ pub fn find_position(source: &str, needle: &str) -> (u32, u32) {
     panic!("'{needle}' not found in fixture");
 }
 
-/// Check if ty is available in PATH.
-#[must_use]
-pub fn is_ty_available() -> bool {
-    which::which("ty").is_ok()
-}
+/// Language-specific readiness checks for LSP integration tests.
+pub mod python {
+    /// Check if ty is available in PATH.
+    #[must_use]
+    pub fn is_ty_available() -> bool {
+        which::which("ty").is_ok()
+    }
 
-/// Check if boto3-stubs are installed.
-#[must_use]
-pub fn is_boto3_stubs_available() -> bool {
-    std::process::Command::new("python3")
-        .args(["-c", "import mypy_boto3_s3"])
-        .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
-}
+    /// Check if boto3-stubs are installed.
+    #[must_use]
+    pub fn is_boto3_stubs_available() -> bool {
+        std::process::Command::new("python3")
+            .args(["-c", "import mypy_boto3_s3"])
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
 
-/// Check if both ty and boto3-stubs are available.
-#[must_use]
-pub fn is_lsp_ready() -> bool {
-    is_ty_available() && is_boto3_stubs_available()
+    /// Check if both ty and boto3-stubs are available.
+    #[must_use]
+    pub fn is_ready() -> bool {
+        is_ty_available() && is_boto3_stubs_available()
+    }
+
+    /// Sample Python code fixtures for testing.
+    pub mod fixtures {
+        /// Simple Python code with boto3 import and S3 client creation.
+        pub const SIMPLE_BOTO3: &str = r"import boto3
+
+s3_client = boto3.client('s3')
+response = s3_client.list_buckets()
+";
+
+        /// Python code with type annotations.
+        pub const WITH_TYPE_ANNOTATIONS: &str = r"import boto3
+from mypy_boto3_s3 import S3Client
+
+def get_s3_client() -> S3Client:
+    return boto3.client('s3')
+
+client: S3Client = get_s3_client()
+";
+
+        /// Python code with multiple AWS service clients.
+        pub const MULTIPLE_SERVICES: &str = r"import boto3
+
+s3 = boto3.client('s3')
+dynamodb = boto3.client('dynamodb')
+lambda_client = boto3.client('lambda')
+";
+
+        /// Python code with resource API usage.
+        pub const RESOURCE_API: &str = r"import boto3
+
+s3 = boto3.resource('s3')
+bucket = s3.Bucket('my-bucket')
+bucket.upload_file('local.txt', 'remote.txt')
+";
+
+        /// Empty Python file.
+        pub const EMPTY: &str = "";
+
+        /// Python code with syntax error (for error handling tests).
+        pub const SYNTAX_ERROR: &str = r"import boto3
+
+def broken_function(
+    # Missing closing parenthesis
+";
+    }
 }
 
 #[cfg(test)]
@@ -89,18 +92,24 @@ mod tests {
 
     #[test]
     fn test_find_position_first_line() {
-        assert_eq!(find_position(fixtures::SIMPLE_BOTO3, "import"), (0, 0));
+        assert_eq!(
+            find_position(python::fixtures::SIMPLE_BOTO3, "import"),
+            (0, 0)
+        );
     }
 
     #[test]
     fn test_find_position_nested() {
-        assert_eq!(find_position(fixtures::SIMPLE_BOTO3, "s3_client"), (2, 0));
+        assert_eq!(
+            find_position(python::fixtures::SIMPLE_BOTO3, "s3_client"),
+            (2, 0)
+        );
     }
 
     #[test]
     fn test_find_position_mid_line() {
         assert_eq!(
-            find_position(fixtures::SIMPLE_BOTO3, "list_buckets"),
+            find_position(python::fixtures::SIMPLE_BOTO3, "list_buckets"),
             (3, 21)
         );
     }
@@ -108,16 +117,16 @@ mod tests {
     #[test]
     #[should_panic(expected = "not found in fixture")]
     fn test_find_position_missing() {
-        let _ = find_position(fixtures::SIMPLE_BOTO3, "nonexistent_symbol");
+        let _ = find_position(python::fixtures::SIMPLE_BOTO3, "nonexistent_symbol");
     }
 
     #[test]
     fn test_fixtures_are_valid_strings() {
-        assert!(!fixtures::SIMPLE_BOTO3.is_empty());
-        assert!(!fixtures::WITH_TYPE_ANNOTATIONS.is_empty());
-        assert!(!fixtures::MULTIPLE_SERVICES.is_empty());
-        assert!(!fixtures::RESOURCE_API.is_empty());
-        assert!(fixtures::EMPTY.is_empty());
-        assert!(!fixtures::SYNTAX_ERROR.is_empty());
+        assert!(!python::fixtures::SIMPLE_BOTO3.is_empty());
+        assert!(!python::fixtures::WITH_TYPE_ANNOTATIONS.is_empty());
+        assert!(!python::fixtures::MULTIPLE_SERVICES.is_empty());
+        assert!(!python::fixtures::RESOURCE_API.is_empty());
+        assert!(python::fixtures::EMPTY.is_empty());
+        assert!(!python::fixtures::SYNTAX_ERROR.is_empty());
     }
 }

--- a/iam-policy-autopilot-policy-generation/src/lsp/test_utils.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/test_utils.rs
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "not found in fixture")]
     fn test_find_position_missing() {
-        find_position(fixtures::SIMPLE_BOTO3, "nonexistent_symbol");
+        let _ = find_position(fixtures::SIMPLE_BOTO3, "nonexistent_symbol");
     }
 
     #[test]

--- a/iam-policy-autopilot-policy-generation/src/lsp/test_utils.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/test_utils.rs
@@ -1,0 +1,123 @@
+//! Test utilities and fixtures for LSP client testing.
+
+/// Sample Python code fixtures for testing.
+pub mod fixtures {
+    /// Simple Python code with boto3 import and S3 client creation.
+    pub const SIMPLE_BOTO3: &str = r"import boto3
+
+s3_client = boto3.client('s3')
+response = s3_client.list_buckets()
+";
+
+    /// Python code with type annotations.
+    pub const WITH_TYPE_ANNOTATIONS: &str = r"import boto3
+from mypy_boto3_s3 import S3Client
+
+def get_s3_client() -> S3Client:
+    return boto3.client('s3')
+
+client: S3Client = get_s3_client()
+";
+
+    /// Python code with multiple AWS service clients.
+    pub const MULTIPLE_SERVICES: &str = r"import boto3
+
+s3 = boto3.client('s3')
+dynamodb = boto3.client('dynamodb')
+lambda_client = boto3.client('lambda')
+";
+
+    /// Python code with resource API usage.
+    pub const RESOURCE_API: &str = r"import boto3
+
+s3 = boto3.resource('s3')
+bucket = s3.Bucket('my-bucket')
+bucket.upload_file('local.txt', 'remote.txt')
+";
+
+    /// Empty Python file.
+    pub const EMPTY: &str = "";
+
+    /// Python code with syntax error (for error handling tests).
+    pub const SYNTAX_ERROR: &str = r"import boto3
+
+def broken_function(
+    # Missing closing parenthesis
+";
+}
+
+/// Find the (line, column) position of `needle` in `source`.
+///
+/// Returns the zero-based line and column of the first occurrence.
+/// Panics if `needle` is not found.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn find_position(source: &str, needle: &str) -> (u32, u32) {
+    for (line_idx, line) in source.lines().enumerate() {
+        if let Some(col) = line.find(needle) {
+            return (line_idx as u32, col as u32);
+        }
+    }
+    panic!("'{needle}' not found in fixture");
+}
+
+/// Check if ty is available in PATH.
+#[must_use]
+pub fn is_ty_available() -> bool {
+    which::which("ty").is_ok()
+}
+
+/// Check if boto3-stubs are installed.
+#[must_use]
+pub fn is_boto3_stubs_available() -> bool {
+    std::process::Command::new("python3")
+        .args(["-c", "import mypy_boto3_s3"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Check if both ty and boto3-stubs are available.
+#[must_use]
+pub fn is_lsp_ready() -> bool {
+    is_ty_available() && is_boto3_stubs_available()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_position_first_line() {
+        assert_eq!(find_position(fixtures::SIMPLE_BOTO3, "import"), (0, 0));
+    }
+
+    #[test]
+    fn test_find_position_nested() {
+        assert_eq!(find_position(fixtures::SIMPLE_BOTO3, "s3_client"), (2, 0));
+    }
+
+    #[test]
+    fn test_find_position_mid_line() {
+        assert_eq!(
+            find_position(fixtures::SIMPLE_BOTO3, "list_buckets"),
+            (3, 21)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "not found in fixture")]
+    fn test_find_position_missing() {
+        find_position(fixtures::SIMPLE_BOTO3, "nonexistent_symbol");
+    }
+
+    #[test]
+    fn test_fixtures_are_valid_strings() {
+        assert!(!fixtures::SIMPLE_BOTO3.is_empty());
+        assert!(!fixtures::WITH_TYPE_ANNOTATIONS.is_empty());
+        assert!(!fixtures::MULTIPLE_SERVICES.is_empty());
+        assert!(!fixtures::RESOURCE_API.is_empty());
+        assert!(fixtures::EMPTY.is_empty());
+        assert!(!fixtures::SYNTAX_ERROR.is_empty());
+    }
+}

--- a/iam-policy-autopilot-policy-generation/tests/lsp_integration_tests.rs
+++ b/iam-policy-autopilot-policy-generation/tests/lsp_integration_tests.rs
@@ -1,0 +1,370 @@
+//! Integration tests for the LSP client.
+//!
+//! These tests verify end-to-end behavior with a real ty server.
+//! Tests require ty and boto3-stubs to be installed.
+//! Tests run sequentially using #[serial] to avoid LSP server conflicts.
+
+use iam_policy_autopilot_policy_generation::lsp::{
+    test_utils::{fixtures, is_lsp_ready},
+    LspError, TyLspClient,
+};
+use serial_test::serial;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tokio::fs;
+
+/// Test fixture containing a temporary workspace with Python files.
+pub struct TestWorkspace {
+    /// Temporary directory that will be cleaned up when dropped
+    pub temp_dir: TempDir,
+    /// Path to the workspace root
+    pub root_path: PathBuf,
+}
+
+impl TestWorkspace {
+    /// Create a new test workspace with a temporary directory.
+    pub fn new() -> std::io::Result<Self> {
+        let temp_dir = TempDir::new()?;
+        let root_path = temp_dir.path().to_path_buf();
+        Ok(Self {
+            temp_dir,
+            root_path,
+        })
+    }
+
+    /// Create a Python file in the workspace with the given content.
+    ///
+    /// # Arguments
+    ///
+    /// * `relative_path` - Path relative to workspace root (e.g., "test.py" or "src/app.py")
+    /// * `content` - Python source code content
+    pub async fn create_file(
+        &self,
+        relative_path: &str,
+        content: &str,
+    ) -> std::io::Result<PathBuf> {
+        let file_path = self.root_path.join(relative_path);
+
+        // Create parent directories if needed
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+
+        // Write the file
+        fs::write(&file_path, content).await?;
+
+        Ok(file_path)
+    }
+
+    /// Get the absolute path for a file in the workspace.
+    pub fn file_path(&self, relative_path: &str) -> PathBuf {
+        self.root_path.join(relative_path)
+    }
+
+    /// Get the file:// URI for a file in the workspace.
+    pub fn file_uri(&self, relative_path: &str) -> String {
+        use lsp_types::Url;
+        let path = self.file_path(relative_path);
+        Url::from_file_path(&path)
+            .map(|url| url.to_string())
+            .unwrap_or_else(|_| format!("file://{}", path.display()))
+    }
+}
+
+/// Helper macro to skip tests if ty and boto3-stubs are not available
+macro_rules! skip_if_no_lsp {
+    () => {
+        if !is_lsp_ready() {
+            eprintln!("Skipping test: ty or boto3-stubs not available");
+            eprintln!("  Install ty: pip install ty");
+            eprintln!("  Install boto3-stubs: pip install 'boto3-stubs[essential|full|all]'");
+            return;
+        }
+    };
+}
+
+#[tokio::test]
+#[serial]
+async fn test_full_lifecycle() {
+    skip_if_no_lsp!();
+
+    // Create a test workspace
+    let workspace = TestWorkspace::new().expect("Failed to create workspace");
+
+    // Create a Python file
+    let file_path = workspace
+        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to create file");
+
+    eprintln!("Test file content:\n{}", fixtures::SIMPLE_BOTO3);
+
+    // Create and initialize LSP client
+    let mut client: TyLspClient = TyLspClient::new(&workspace.root_path)
+        .await
+        .expect("Failed to create LSP client");
+
+    // Open the document
+    let _: () = client
+        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to open document");
+
+    let file_uri = workspace.file_uri("test.py");
+
+    // Test 1: s3_client variable should return S3Client type
+    eprintln!("\nTest 1: s3_client variable at line 2, char 0");
+    let hover_s3_client: Option<String> = client
+        .hover(&file_uri, 2, 0)
+        .await
+        .expect("Failed to query hover");
+    eprintln!("Result: {:?}", hover_s3_client);
+
+    assert!(
+        hover_s3_client.is_some(),
+        "Expected type information for s3_client variable"
+    );
+    let s3_client_type = hover_s3_client.unwrap();
+    assert!(
+        s3_client_type.contains("S3Client"),
+        "Expected S3Client type, got: {}",
+        s3_client_type
+    );
+
+    // Test 2: response variable should return ListBucketsOutputTypeDef
+    eprintln!("\nTest 2: response variable at line 3, char 0");
+    let hover_response: Option<String> = client
+        .hover(&file_uri, 3, 0)
+        .await
+        .expect("Failed to query hover");
+    eprintln!("Result: {:?}", hover_response);
+
+    assert!(
+        hover_response.is_some(),
+        "Expected type information for response variable"
+    );
+    let response_type = hover_response.unwrap();
+    assert!(
+        response_type.contains("ListBucketsOutputTypeDef")
+            || response_type.contains("ListBucketsOutput"),
+        "Expected ListBucketsOutputTypeDef type, got: {}",
+        response_type
+    );
+
+    // Test 3: list_buckets method should return method signature
+    eprintln!("\nTest 3: list_buckets method at line 3, char 21");
+    let hover_method: Option<String> = client
+        .hover(&file_uri, 3, 21)
+        .await
+        .expect("Failed to query hover");
+    eprintln!("Result: {:?}", hover_method);
+
+    assert!(
+        hover_method.is_some(),
+        "Expected type information for list_buckets method"
+    );
+    let method_sig = hover_method.unwrap();
+    assert!(
+        method_sig.contains("list_buckets") && method_sig.contains("ListBucketsOutput"),
+        "Expected list_buckets method signature, got: {}",
+        method_sig
+    );
+
+    // Shutdown gracefully
+    let _: () = client.shutdown().await.expect("Failed to shutdown");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_multiple_documents() {
+    skip_if_no_lsp!();
+
+    let workspace = TestWorkspace::new().expect("Failed to create workspace");
+
+    // Create multiple Python files
+    let file1 = workspace
+        .create_file("file1.py", fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to create file1");
+
+    let file2 = workspace
+        .create_file("file2.py", fixtures::MULTIPLE_SERVICES)
+        .await
+        .expect("Failed to create file2");
+
+    // Create LSP client
+    let mut client: TyLspClient = TyLspClient::new(&workspace.root_path)
+        .await
+        .expect("Failed to create LSP client");
+
+    // Open both documents
+    let _: () = client
+        .open_document(&file1, fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to open file1");
+
+    let _: () = client
+        .open_document(&file2, fixtures::MULTIPLE_SERVICES)
+        .await
+        .expect("Failed to open file2");
+
+    // Query hover on both files at meaningful positions
+    let uri1 = workspace.file_uri("file1.py");
+    // Line 2, char 0: s3_client variable
+    let hover1: Option<String> = client
+        .hover(&uri1, 2, 0)
+        .await
+        .expect("Failed to hover file1");
+    eprintln!("File1 s3_client type: {:?}", hover1);
+
+    assert!(hover1.is_some(), "Expected type info for file1 s3_client");
+    assert!(
+        hover1.as_ref().unwrap().contains("S3Client"),
+        "Expected S3Client type in file1, got: {:?}",
+        hover1
+    );
+
+    let uri2 = workspace.file_uri("file2.py");
+    // Line 2, char 0: s3 variable
+    let hover2: Option<String> = client
+        .hover(&uri2, 2, 0)
+        .await
+        .expect("Failed to hover file2");
+    eprintln!("File2 s3 type: {:?}", hover2);
+
+    assert!(hover2.is_some(), "Expected type info for file2 s3");
+    assert!(
+        hover2.as_ref().unwrap().contains("S3Client"),
+        "Expected S3Client type in file2, got: {:?}",
+        hover2
+    );
+
+    // Shutdown
+    let _: () = client.shutdown().await.expect("Failed to shutdown");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_hover_on_empty_file() {
+    skip_if_no_lsp!();
+
+    let workspace = TestWorkspace::new().expect("Failed to create workspace");
+
+    let file_path = workspace
+        .create_file("empty.py", fixtures::EMPTY)
+        .await
+        .expect("Failed to create file");
+
+    let mut client: TyLspClient = TyLspClient::new(&workspace.root_path)
+        .await
+        .expect("Failed to create LSP client");
+
+    let _: () = client
+        .open_document(&file_path, fixtures::EMPTY)
+        .await
+        .expect("Failed to open document");
+
+    // Query hover on empty file should return None
+    let file_uri = workspace.file_uri("empty.py");
+    let hover_result: Option<String> = client
+        .hover(&file_uri, 0, 0)
+        .await
+        .expect("Failed to query hover");
+
+    assert!(
+        hover_result.is_none(),
+        "Expected None for hover on empty file"
+    );
+
+    let _: () = client.shutdown().await.expect("Failed to shutdown");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_hover_on_invalid_position() {
+    skip_if_no_lsp!();
+
+    let workspace = TestWorkspace::new().expect("Failed to create workspace");
+
+    let file_path = workspace
+        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to create file");
+
+    let mut client: TyLspClient = TyLspClient::new(&workspace.root_path)
+        .await
+        .expect("Failed to create LSP client");
+
+    let _: () = client
+        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to open document");
+
+    // Query hover at an invalid position (line 1000)
+    let file_uri = workspace.file_uri("test.py");
+    let hover_result: Option<String> = client
+        .hover(&file_uri, 1000, 0)
+        .await
+        .expect("Failed to query hover");
+
+    // Should return None for invalid position
+    assert!(
+        hover_result.is_none(),
+        "Expected None for hover on invalid position"
+    );
+
+    let _: () = client.shutdown().await.expect("Failed to shutdown");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_ty_not_found_error() {
+    // Temporarily modify PATH to exclude ty
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", "");
+
+    let workspace = TestWorkspace::new().expect("Failed to create workspace");
+    let result: Result<TyLspClient, LspError> = TyLspClient::new(&workspace.root_path).await;
+
+    // Restore original PATH
+    std::env::set_var("PATH", &original_path);
+
+    // Verify we get TyNotFound error
+    assert!(result.is_err());
+    match result {
+        Err(LspError::TyNotFound) => {
+            // Expected error
+        }
+        _ => panic!("Expected TyNotFound error, got: {:?}", result),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_open_same_document_twice() {
+    skip_if_no_lsp!();
+
+    let workspace = TestWorkspace::new().expect("Failed to create workspace");
+
+    let file_path = workspace
+        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to create file");
+
+    let mut client: TyLspClient = TyLspClient::new(&workspace.root_path)
+        .await
+        .expect("Failed to create LSP client");
+
+    // Open the document twice - should not error
+    let _: () = client
+        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to open document first time");
+
+    let _: () = client
+        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .await
+        .expect("Failed to open document second time");
+
+    let _: () = client.shutdown().await.expect("Failed to shutdown");
+}

--- a/iam-policy-autopilot-policy-generation/tests/lsp_integration_tests.rs
+++ b/iam-policy-autopilot-policy-generation/tests/lsp_integration_tests.rs
@@ -1,0 +1,236 @@
+//! Integration tests for the LSP client.
+//!
+//! These tests verify end-to-end behavior with a real ty server.
+//! Tests require ty and boto3-stubs to be installed.
+//! Tests run sequentially using #[serial] to avoid LSP server conflicts.
+//!
+//! Run with: `cargo test --features integ-test -- --ignored`
+
+use iam_policy_autopilot_policy_generation::lsp::{
+    test_utils::{find_position, fixtures, is_lsp_ready},
+    LspError, TyLspClient,
+};
+use rstest::rstest;
+use serial_test::serial;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tokio::fs;
+
+struct TestWorkspace {
+    _temp_dir: TempDir,
+    root_path: PathBuf,
+}
+
+impl TestWorkspace {
+    fn new() -> std::io::Result<Self> {
+        let temp_dir = TempDir::new()?;
+        let root_path = temp_dir.path().to_path_buf();
+        Ok(Self {
+            _temp_dir: temp_dir,
+            root_path,
+        })
+    }
+
+    async fn create_file(&self, relative_path: &str, content: &str) -> std::io::Result<PathBuf> {
+        let file_path = self.root_path.join(relative_path);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        fs::write(&file_path, content).await?;
+        Ok(file_path)
+    }
+
+    fn file_uri(&self, relative_path: &str) -> String {
+        let path = self.root_path.join(relative_path);
+        lsp_types::Url::from_file_path(&path)
+            .map(|url| url.to_string())
+            .unwrap_or_else(|_| format!("file://{}", path.display()))
+    }
+}
+
+#[rstest]
+#[case("s3_client", "S3Client")]
+#[case("response", "ListBuckets")]
+#[case("list_buckets", "list_buckets")]
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_hover_returns_expected_type(#[case] needle: &str, #[case] expected: &str) {
+    if !is_lsp_ready() {
+        panic!("LSP integration tests require ty + boto3-stubs");
+    }
+
+    let workspace = TestWorkspace::new().unwrap();
+    let file_path = workspace
+        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+
+    let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
+    client
+        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+
+    let (line, col) = find_position(fixtures::SIMPLE_BOTO3, needle);
+    let hover = client
+        .hover(&workspace.file_uri("test.py"), line, col)
+        .await
+        .unwrap();
+
+    assert!(
+        hover.as_ref().is_some_and(|h| h.contains(expected)),
+        "Expected hover at '{needle}' to contain '{expected}', got: {hover:?}"
+    );
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_multiple_documents() {
+    if !is_lsp_ready() {
+        panic!("LSP integration tests require ty + boto3-stubs");
+    }
+
+    let workspace = TestWorkspace::new().unwrap();
+    let file1 = workspace
+        .create_file("file1.py", fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+    let file2 = workspace
+        .create_file("file2.py", fixtures::MULTIPLE_SERVICES)
+        .await
+        .unwrap();
+
+    let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
+    client
+        .open_document(&file1, fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+    client
+        .open_document(&file2, fixtures::MULTIPLE_SERVICES)
+        .await
+        .unwrap();
+
+    let (line, col) = find_position(fixtures::SIMPLE_BOTO3, "s3_client");
+    let hover1 = client
+        .hover(&workspace.file_uri("file1.py"), line, col)
+        .await
+        .unwrap();
+    assert!(
+        hover1.as_ref().is_some_and(|h| h.contains("S3Client")),
+        "Expected S3Client in file1, got: {hover1:?}"
+    );
+
+    let (line, col) = find_position(fixtures::MULTIPLE_SERVICES, "s3 =");
+    let hover2 = client
+        .hover(&workspace.file_uri("file2.py"), line, col)
+        .await
+        .unwrap();
+    assert!(
+        hover2.as_ref().is_some_and(|h| h.contains("S3Client")),
+        "Expected S3Client in file2, got: {hover2:?}"
+    );
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_hover_on_empty_file() {
+    if !is_lsp_ready() {
+        panic!("LSP integration tests require ty + boto3-stubs");
+    }
+
+    let workspace = TestWorkspace::new().unwrap();
+    let file_path = workspace
+        .create_file("empty.py", fixtures::EMPTY)
+        .await
+        .unwrap();
+
+    let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
+    client
+        .open_document(&file_path, fixtures::EMPTY)
+        .await
+        .unwrap();
+
+    let hover = client
+        .hover(&workspace.file_uri("empty.py"), 0, 0)
+        .await
+        .unwrap();
+    assert!(hover.is_none(), "Expected None for hover on empty file");
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_hover_on_invalid_position() {
+    if !is_lsp_ready() {
+        panic!("LSP integration tests require ty + boto3-stubs");
+    }
+
+    let workspace = TestWorkspace::new().unwrap();
+    let file_path = workspace
+        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+
+    let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
+    client
+        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+
+    let hover = client
+        .hover(&workspace.file_uri("test.py"), 1000, 0)
+        .await
+        .unwrap();
+    assert!(hover.is_none(), "Expected None for invalid position");
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_server_not_found_error() {
+    let workspace = TestWorkspace::new().unwrap();
+
+    let result = temp_env::async_with_vars([("PATH", Some(""))], async {
+        TyLspClient::create(&workspace.root_path).await
+    })
+    .await;
+
+    assert!(matches!(result, Err(LspError::ServerNotFound(_))));
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_open_same_document_twice() {
+    if !is_lsp_ready() {
+        panic!("LSP integration tests require ty + boto3-stubs");
+    }
+
+    let workspace = TestWorkspace::new().unwrap();
+    let file_path = workspace
+        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+
+    let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
+    client
+        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+    client
+        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .await
+        .unwrap();
+
+    client.shutdown().await.unwrap();
+}

--- a/iam-policy-autopilot-policy-generation/tests/lsp_integration_tests.rs
+++ b/iam-policy-autopilot-policy-generation/tests/lsp_integration_tests.rs
@@ -7,7 +7,7 @@
 //! Run with: `cargo test --features integ-test -- --ignored`
 
 use iam_policy_autopilot_policy_generation::lsp::{
-    test_utils::{find_position, fixtures, is_lsp_ready},
+    test_utils::{find_position, python},
     LspError, TyLspClient,
 };
 use rstest::rstest;
@@ -73,23 +73,23 @@ impl TestWorkspace {
 #[serial]
 #[ignore]
 async fn test_hover_returns_expected_type(#[case] needle: &str, #[case] expected: &str) {
-    if !is_lsp_ready() {
+    if !python::is_ready() {
         panic!("LSP integration tests require ty + boto3-stubs");
     }
 
     let workspace = TestWorkspace::new().unwrap();
     let file_path = workspace
-        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .create_file("test.py", python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
 
     let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
     client
-        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .open_document(&file_path, python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
 
-    let (line, col) = find_position(fixtures::SIMPLE_BOTO3, needle);
+    let (line, col) = find_position(python::fixtures::SIMPLE_BOTO3, needle);
     let hover = client
         .hover(&workspace.file_uri("test.py"), line, col)
         .await
@@ -107,31 +107,31 @@ async fn test_hover_returns_expected_type(#[case] needle: &str, #[case] expected
 #[serial]
 #[ignore]
 async fn test_multiple_documents() {
-    if !is_lsp_ready() {
+    if !python::is_ready() {
         panic!("LSP integration tests require ty + boto3-stubs");
     }
 
     let workspace = TestWorkspace::new().unwrap();
     let file1 = workspace
-        .create_file("file1.py", fixtures::SIMPLE_BOTO3)
+        .create_file("file1.py", python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
     let file2 = workspace
-        .create_file("file2.py", fixtures::MULTIPLE_SERVICES)
+        .create_file("file2.py", python::fixtures::MULTIPLE_SERVICES)
         .await
         .unwrap();
 
     let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
     client
-        .open_document(&file1, fixtures::SIMPLE_BOTO3)
+        .open_document(&file1, python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
     client
-        .open_document(&file2, fixtures::MULTIPLE_SERVICES)
+        .open_document(&file2, python::fixtures::MULTIPLE_SERVICES)
         .await
         .unwrap();
 
-    let (line, col) = find_position(fixtures::SIMPLE_BOTO3, "s3_client");
+    let (line, col) = find_position(python::fixtures::SIMPLE_BOTO3, "s3_client");
     let hover1 = client
         .hover(&workspace.file_uri("file1.py"), line, col)
         .await
@@ -141,7 +141,7 @@ async fn test_multiple_documents() {
         "Expected S3Client in file1, got: {hover1:?}"
     );
 
-    let (line, col) = find_position(fixtures::MULTIPLE_SERVICES, "s3 =");
+    let (line, col) = find_position(python::fixtures::MULTIPLE_SERVICES, "s3 =");
     let hover2 = client
         .hover(&workspace.file_uri("file2.py"), line, col)
         .await
@@ -158,19 +158,19 @@ async fn test_multiple_documents() {
 #[serial]
 #[ignore]
 async fn test_hover_on_empty_file() {
-    if !is_lsp_ready() {
+    if !python::is_ready() {
         panic!("LSP integration tests require ty + boto3-stubs");
     }
 
     let workspace = TestWorkspace::new().unwrap();
     let file_path = workspace
-        .create_file("empty.py", fixtures::EMPTY)
+        .create_file("empty.py", python::fixtures::EMPTY)
         .await
         .unwrap();
 
     let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
     client
-        .open_document(&file_path, fixtures::EMPTY)
+        .open_document(&file_path, python::fixtures::EMPTY)
         .await
         .unwrap();
 
@@ -187,19 +187,19 @@ async fn test_hover_on_empty_file() {
 #[serial]
 #[ignore]
 async fn test_hover_on_invalid_position() {
-    if !is_lsp_ready() {
+    if !python::is_ready() {
         panic!("LSP integration tests require ty + boto3-stubs");
     }
 
     let workspace = TestWorkspace::new().unwrap();
     let file_path = workspace
-        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .create_file("test.py", python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
 
     let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
     client
-        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .open_document(&file_path, python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
 
@@ -229,23 +229,23 @@ async fn test_server_not_found_error() {
 #[serial]
 #[ignore]
 async fn test_open_same_document_twice() {
-    if !is_lsp_ready() {
+    if !python::is_ready() {
         panic!("LSP integration tests require ty + boto3-stubs");
     }
 
     let workspace = TestWorkspace::new().unwrap();
     let file_path = workspace
-        .create_file("test.py", fixtures::SIMPLE_BOTO3)
+        .create_file("test.py", python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
 
     let mut client = TyLspClient::create(&workspace.root_path).await.unwrap();
     client
-        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .open_document(&file_path, python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
     client
-        .open_document(&file_path, fixtures::SIMPLE_BOTO3)
+        .open_document(&file_path, python::fixtures::SIMPLE_BOTO3)
         .await
         .unwrap();
 

--- a/iam-policy-autopilot-policy-generation/tests/lsp_integration_tests.rs
+++ b/iam-policy-autopilot-policy-generation/tests/lsp_integration_tests.rs
@@ -25,6 +25,23 @@ impl TestWorkspace {
     fn new() -> std::io::Result<Self> {
         let temp_dir = TempDir::new()?;
         let root_path = temp_dir.path().to_path_buf();
+
+        // ty resolves third-party imports by looking for a .venv in the project root.
+        // Since test workspaces are temp directories, we write a pyproject.toml pointing
+        // ty to the active Python environment so it can find boto3-stubs.
+        let python_prefix = std::process::Command::new("python3")
+            .args(["-c", "import sys; print(sys.prefix)"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .unwrap_or_default();
+        let python_prefix = python_prefix.trim();
+
+        std::fs::write(
+            root_path.join("pyproject.toml"),
+            format!("[tool.ty.environment]\npython = \"{python_prefix}\"\n"),
+        )?;
+
         Ok(Self {
             _temp_dir: temp_dir,
             root_path,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Implements a generic async LSP client built on [`async-lsp`](https://crates.io/crates/async-lsp) for type information extraction from Python code. The client communicates with [the ty Python type checker](https://docs.astral.sh/ty/) and is designed to support additional language servers (e.g., gopls for Go) via the `LspServerConfig` trait.

### Changes
- Add generic `LspClient<C: LspServerConfig>` with `TyConfig` implementation for ty
- Use `async-lsp` for LSP protocol handling (replacing hand-rolled JSON-RPC framing from the initial PR)
- Add per-URI diagnostics tracking (`publishDiagnostics`) so `open_document` returns as soon as the server is ready, with configurable timeout fallback
- Add `LspClientOptions` for tuning timeouts (10s initialize, 5s hover, 2s shutdown, 1s open-document)
- Add `extract_type_from_hover` as a standalone public function with rstest-parameterized unit tests
- Add 7 integration tests with `#[ignore]` + `#[serial]`, covering hover, multi-document, empty file, invalid position, idempotent open, and server-not-found
- Add dedicated CI job that installs ty + boto3-stubs and runs the ignored tests

### Notes
- LSP client is standalone and not yet integrated with the extraction pipeline
- Integration tests require ty and boto3-stubs. They run in CI automatically, or locally with:
```
pip install 'ty>=0.0.39,<0.1' 'boto3-stubs[essential]'
cargo test -p iam-policy-autopilot-policy-generation --features integ-test -- --ignored
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
