### PR TITLE
refactor: SdkMethodCallMetadata easier to extend

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
@@ -835,16 +835,16 @@ mod location_tests {
     }
 
     fn mock_sdk_method_call() -> SdkMethodCall {
+        let metadata = SdkMethodCallMetadata::new(
+            "s3.get_object(Bucket='my-bucket')".to_string(),
+            Location::new(PathBuf::from("test.py"), (10, 5), (10, 79)),
+        )
+        .with_receiver("s3".to_string());
+
         SdkMethodCall {
             name: "get_object".to_string(),
             possible_services: vec!["s3".to_string()],
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: vec![],
-                return_type: None,
-                expr: "s3.get_object(Bucket='my-bucket')".to_string(),
-                location: Location::new(PathBuf::from("test.py"), (10, 5), (10, 79)),
-                receiver: Some("s3".to_string()),
-            }),
+            metadata: Some(metadata),
         }
     }
 
@@ -884,13 +884,11 @@ mod location_tests {
 
     #[test]
     fn test_operation_source_extracted_serialization() {
-        let metadata = SdkMethodCallMetadata {
-            parameters: vec![],
-            return_type: None,
-            expr: "dynamodb.get_item(\n        TableName='my-table',\n        Key={'id': {'S': '123'}}\n    )".to_string(),
-            location: Location::new(PathBuf::from("iam-policy-autopilot-cli/tests/resources/test_example.py"), (19, 5), (22, 5)),
-            receiver: Some("dynamodb".to_string()),
-        };
+        let metadata = SdkMethodCallMetadata::new(
+            "dynamodb.get_item(\n        TableName='my-table',\n        Key={'id': {'S': '123'}}\n    )".to_string(),
+            Location::new(PathBuf::from("iam-policy-autopilot-cli/tests/resources/test_example.py"), (19, 5), (22, 5)),
+        )
+        .with_receiver("dynamodb".to_string());
 
         let source = OperationSource::Extracted(metadata);
         let json = serde_json::to_string(&source).unwrap();
@@ -955,13 +953,11 @@ mod location_tests {
 
         {
             let expr = "kms.decrypt(...)".to_string();
-            let metadata = SdkMethodCallMetadata {
-                parameters: vec![],
-                return_type: None,
-                expr: expr.clone(),
-                location: Location::new(PathBuf::new(), (1, 1), (1, expr.len() + 1)),
-                receiver: Some("kms".to_string()),
-            };
+            let metadata = SdkMethodCallMetadata::new(
+                expr.clone(),
+                Location::new(PathBuf::new(), (1, 1), (1, expr.len() + 1)),
+            )
+            .with_receiver("kms".to_string());
             let call = SdkMethodCall {
                 name: "decrypt".to_string(),
                 possible_services: vec!["kms".to_string()],

--- a/iam-policy-autopilot-policy-generation/src/extraction/go/disambiguation.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/go/disambiguation.rs
@@ -582,32 +582,32 @@ mod tests {
         let service_index = create_test_service_index();
         let disambiguator = GoMethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "ListObjectsV2".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved(
+                    "&s3.ListObjectsV2Input{ Bucket: aws.String(\"my-bucket\") }".to_string(),
+                ),
+                position: 1,
+                type_annotation: Some("s3.ListObjectsV2Input".to_string()),
+                struct_fields: Some(vec!["Bucket".to_string()]),
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "ListObjectsV2".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "ListObjectsV2".to_string(),
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                        struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved(
-                            "&s3.ListObjectsV2Input{ Bucket: aws.String(\"my-bucket\") }"
-                                .to_string(),
-                        ),
-                        position: 1,
-                        type_annotation: Some("s3.ListObjectsV2Input".to_string()),
-                        struct_fields: Some(vec!["Bucket".to_string()]),
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], None);
@@ -643,21 +643,22 @@ mod tests {
         let service_index = create_test_service_index();
         let disambiguator = GoMethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "NonAwsMethod".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 30)),
+        )
+        .with_parameters(vec![Parameter::Positional {
+            value: ParameterValue::Unresolved("someParam".to_string()),
+            position: 0,
+            type_annotation: None,
+            struct_fields: None,
+        }])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "NonAwsMethod".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "NonAwsMethod".to_string(),
-                parameters: vec![Parameter::Positional {
-                    value: ParameterValue::Unresolved("someParam".to_string()),
-                    position: 0,
-                    type_annotation: None,
-                    struct_fields: None,
-                }],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 30)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], None);
@@ -680,32 +681,32 @@ mod tests {
         ));
 
         // Create a method call that could match multiple services but we only have S3 imported
+        let metadata = SdkMethodCallMetadata::new(
+            "ListObjectsV2".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved(
+                    "&s3.ListObjectsV2Input{ Bucket: aws.String(\"my-bucket\") }".to_string(),
+                ),
+                position: 1,
+                type_annotation: Some("s3.ListObjectsV2Input".to_string()),
+                struct_fields: Some(vec!["Bucket".to_string()]),
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "ListObjectsV2".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "ListObjectsV2".to_string(),
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                        struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved(
-                            "&s3.ListObjectsV2Input{ Bucket: aws.String(\"my-bucket\") }"
-                                .to_string(),
-                        ),
-                        position: 1,
-                        type_annotation: Some("s3.ListObjectsV2Input".to_string()),
-                        struct_fields: Some(vec!["Bucket".to_string()]),
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], Some(&import_info));
@@ -723,32 +724,32 @@ mod tests {
         // Create empty import info (no AWS services imported)
         let import_info = GoImportInfo::new();
 
+        let metadata = SdkMethodCallMetadata::new(
+            "ListObjectsV2".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved(
+                    "&s3.ListObjectsV2Input{ Bucket: aws.String(\"my-bucket\") }".to_string(),
+                ),
+                position: 1,
+                type_annotation: Some("s3.ListObjectsV2Input".to_string()),
+                struct_fields: Some(vec!["Bucket".to_string()]),
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "ListObjectsV2".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "ListObjectsV2".to_string(),
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                        struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved(
-                            "&s3.ListObjectsV2Input{ Bucket: aws.String(\"my-bucket\") }"
-                                .to_string(),
-                        ),
-                        position: 1,
-                        type_annotation: Some("s3.ListObjectsV2Input".to_string()),
-                        struct_fields: Some(vec!["Bucket".to_string()]),
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], Some(&import_info));
@@ -772,32 +773,32 @@ mod tests {
             5,
         ));
 
+        let metadata = SdkMethodCallMetadata::new(
+            "ListObjectsV2".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved(
+                    "&myS3.ListObjectsV2Input{ Bucket: aws.String(\"my-bucket\") }".to_string(),
+                ),
+                position: 1,
+                type_annotation: Some("myS3.ListObjectsV2Input".to_string()),
+                struct_fields: Some(vec!["Bucket".to_string()]),
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "ListObjectsV2".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "ListObjectsV2".to_string(),
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                        struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved(
-                            "&myS3.ListObjectsV2Input{ Bucket: aws.String(\"my-bucket\") }"
-                                .to_string(),
-                        ),
-                        position: 1,
-                        type_annotation: Some("myS3.ListObjectsV2Input".to_string()),
-                        struct_fields: Some(vec!["Bucket".to_string()]),
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], Some(&import_info));
@@ -811,31 +812,32 @@ mod tests {
         let disambiguator = GoMethodDisambiguator::new(&service_index);
 
         // GetObject requires both Bucket and Key, but we only provide Bucket
+        let metadata = SdkMethodCallMetadata::new(
+            "GetObject".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved(
+                    "&s3.GetObjectInput{ Bucket: aws.String(\"my-bucket\") }".to_string(),
+                ),
+                position: 1,
+                type_annotation: Some("s3.GetObjectInput".to_string()),
+                struct_fields: Some(vec!["Bucket".to_string()]),
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "GetObject".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                        struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved(
-                            "&s3.GetObjectInput{ Bucket: aws.String(\"my-bucket\") }".to_string(),
-                        ),
-                        position: 1,
-                        type_annotation: Some("s3.GetObjectInput".to_string()),
-                        struct_fields: Some(vec!["Bucket".to_string()]),
-                    },
-                ],
-                expr: "GetObject".to_string(),
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                return_type: None,
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], None);
@@ -849,31 +851,32 @@ mod tests {
         let disambiguator = GoMethodDisambiguator::new(&service_index);
 
         // GetObject requires both Bucket and Key, and we provide both
+        let metadata = SdkMethodCallMetadata::new(
+            "GetObject".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved(
+                    "&s3.GetObjectInput{ Bucket: aws.String(\"my-bucket\"), Key: aws.String(\"my-key\") }".to_string(),
+                ),
+                position: 1,
+                type_annotation: Some("s3.GetObjectInput".to_string()),
+                struct_fields: Some(vec!["Bucket".to_string(), "Key".to_string()]),
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "GetObject".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                    struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved(
-                            "&s3.GetObjectInput{ Bucket: aws.String(\"my-bucket\"), Key: aws.String(\"my-key\") }".to_string(),
-                        ),
-                        position: 1,
-                        type_annotation: Some("s3.GetObjectInput".to_string()),
-                        struct_fields: Some(vec!["Bucket".to_string(), "Key".to_string()]),
-                    },
-                ],
-                expr: "GetObject".to_string(),
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                return_type: None,
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], None);
@@ -888,29 +891,30 @@ mod tests {
         let disambiguator = GoMethodDisambiguator::new(&service_index);
 
         // Using a variable for input - can't extract fields, so should be accepted
+        let metadata = SdkMethodCallMetadata::new(
+            "GetObject".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("getObjectInput".to_string()),
+                position: 1,
+                type_annotation: Some("s3.GetObjectInput".to_string()),
+                struct_fields: Some(vec!["Bucket".to_string(), "Key".to_string()]),
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "GetObject".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                        struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("getObjectInput".to_string()),
-                        position: 1,
-                        type_annotation: Some("s3.GetObjectInput".to_string()),
-                        struct_fields: Some(vec!["Bucket".to_string(), "Key".to_string()]),
-                    },
-                ],
-                expr: "GetObject".to_string(),
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                return_type: None,
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], None);
@@ -928,31 +932,32 @@ mod tests {
         // s3 requires: Bucket, Key
         // s3control requires: AccountId, Bucket, Key
         // If we only provide Bucket and Key, it should match s3 but not s3control
+        let metadata = SdkMethodCallMetadata::new(
+            "GetObject".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved(
+                    "&s3.GetObjectInput{ Bucket: aws.String(\"my-bucket\"), Key: aws.String(\"my-key\") }".to_string(),
+                ),
+                position: 1,
+                type_annotation: Some("s3.GetObjectInput".to_string()),
+                struct_fields: Some(vec!["Bucket".to_string(), "Key".to_string()]),
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "GetObject".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                    struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved(
-                            "&s3.GetObjectInput{ Bucket: aws.String(\"my-bucket\"), Key: aws.String(\"my-key\") }".to_string(),
-                        ),
-                        position: 1,
-                        type_annotation: Some("s3.GetObjectInput".to_string()),
-                        struct_fields: Some(vec!["Bucket".to_string(), "Key".to_string()]),
-                    },
-                ],
-                expr: "GetObject".to_string(),
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                return_type: None,
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], None);
@@ -984,32 +989,33 @@ mod tests {
         // - QueueName (required) is present
         // - Attributes (optional) is present and valid
 
+        let metadata = SdkMethodCallMetadata::new(
+            "CreateQueue".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Positional {
+                value: ParameterValue::Unresolved("context.TODO()".to_string()),
+                position: 0,
+                type_annotation: Some("context.Context".to_string()),
+                struct_fields: None,
+            },
+            Parameter::Positional {
+                value: ParameterValue::Unresolved(
+                    "&sqs.CreateQueueInput{ QueueName: aws.String(queueName), Attributes: map[string]string{\"VisibilityTimeout\": \"60\", \"MessageRetentionPeriod\": \"345600\"} }".to_string(),
+                ),
+                position: 1,
+                type_annotation: Some("sqs.CreateQueueInput".to_string()),
+                // AST-extracted fields: only top-level fields, NOT nested map keys
+                struct_fields: Some(vec!["QueueName".to_string(), "Attributes".to_string()]),
+            },
+        ])
+        .with_receiver("sqsClient".to_string());
+
         let method_call = SdkMethodCall {
             name: "CreateQueue".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: vec![
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved("context.TODO()".to_string()),
-                        position: 0,
-                        type_annotation: Some("context.Context".to_string()),
-                        struct_fields: None,
-                    },
-                    Parameter::Positional {
-                        value: ParameterValue::Unresolved(
-                            "&sqs.CreateQueueInput{ QueueName: aws.String(queueName), Attributes: map[string]string{\"VisibilityTimeout\": \"60\", \"MessageRetentionPeriod\": \"345600\"} }".to_string(),
-                        ),
-                        position: 1,
-                        type_annotation: Some("sqs.CreateQueueInput".to_string()),
-                        // AST-extracted fields: only top-level fields, NOT nested map keys
-                        struct_fields: Some(vec!["QueueName".to_string(), "Attributes".to_string()]),
-                    },
-                ],
-                expr: "CreateQueue".to_string(),
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                return_type: None,
-                receiver: Some("sqsClient".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call], None);

--- a/iam-policy-autopilot-policy-generation/src/extraction/go/extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/go/extractor.rs
@@ -189,16 +189,21 @@ rule:
             vec![]
         };
 
+        let metadata = SdkMethodCallMetadata::new(
+            node_match.text().to_string(),
+            Location::from_node(source_file.path.clone(), node_match.get_node()),
+        )
+        .with_parameters(arguments);
+        let metadata = if let Some(r) = receiver {
+            metadata.with_receiver(r)
+        } else {
+            metadata
+        };
+
         let method_call = SdkMethodCall {
             name: method_name.to_string(),
             possible_services: Vec::new(), // Will be determined later during service validation
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: arguments,
-                return_type: None, // We don't know the return type from the call site
-                expr: node_match.text().to_string(),
-                location: Location::from_node(source_file.path.clone(), node_match.get_node()),
-                receiver,
-            }),
+            metadata: Some(metadata),
         };
 
         Some(method_call)

--- a/iam-policy-autopilot-policy-generation/src/extraction/go/features_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/go/features_extractor.rs
@@ -214,16 +214,19 @@ rule:
                     operation
                 );
 
+                let metadata =
+                    SdkMethodCallMetadata::new(call_info.expr.clone(), call_info.location.clone())
+                        .with_parameters(parameters.clone());
+                let metadata = if let Some(r) = call_info.receiver.clone() {
+                    metadata.with_receiver(r)
+                } else {
+                    metadata
+                };
+
                 SdkMethodCall {
                     name: operation_name,
                     possible_services: vec![service_name.to_string()],
-                    metadata: Some(SdkMethodCallMetadata {
-                        parameters: parameters.clone(),
-                        return_type: None,
-                        expr: call_info.expr.clone(),
-                        location: call_info.location.clone(),
-                        receiver: call_info.receiver.clone(),
-                    }),
+                    metadata: Some(metadata),
                 }
             })
             .collect()

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/shared.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/shared.rs
@@ -197,16 +197,16 @@ impl ExtractionUtils {
                             if let Some(operation_name) = command_name.strip_suffix("Command") {
                                 // Keep PascalCase operation name to match service index
                                 // e.g., "PutItem" from "PutItemCommand"
+                                let metadata = SdkMethodCallMetadata::new(
+                                    result.text.to_string(),
+                                    result.location.clone(),
+                                )
+                                .with_parameters(result.parameters.clone());
+
                                 let method_call = SdkMethodCall {
                                     name: operation_name.to_string(),
                                     possible_services: vec![service.clone()],
-                                    metadata: Some(SdkMethodCallMetadata {
-                                        parameters: result.parameters.clone(),
-                                        return_type: None,
-                                        expr: result.text.to_string(),
-                                        location: result.location.clone(),
-                                        receiver: None, // Commands are typically standalone
-                                    }),
+                                    metadata: Some(metadata),
                                 };
                                 operations.push(method_call);
                             }
@@ -286,16 +286,16 @@ impl ExtractionUtils {
                             };
 
                             // Keep PascalCase operation name to match service index
+                            let metadata = SdkMethodCallMetadata::new(
+                                result.text.to_string(),
+                                result.location.clone(),
+                            )
+                            .with_parameters(result.parameters.clone());
+
                             let method_call = SdkMethodCall {
                                 name: operation_name,
                                 possible_services: vec![service.clone()],
-                                metadata: Some(SdkMethodCallMetadata {
-                                    parameters: result.parameters.clone(), // extracted from 2nd argument!
-                                    return_type: None,
-                                    expr: result.text.to_string(),
-                                    location: result.location.clone(),
-                                    receiver: None,
-                                }),
+                                metadata: Some(metadata),
                             };
                             operations.push(method_call);
                         }
@@ -345,16 +345,16 @@ impl ExtractionUtils {
                             // Keep PascalCase waiter name
                             // e.g., "BucketExists" from "waitUntilBucketExists"
                             // This will be resolved to the actual operation (e.g., "HeadBucket") in filter_map
+                            let metadata = SdkMethodCallMetadata::new(
+                                result.text.to_string(),
+                                result.location.clone(),
+                            )
+                            .with_parameters(result.parameters);
+
                             let method_call = SdkMethodCall {
                                 name: waiter_name.to_string(),
                                 possible_services: vec![service.clone()],
-                                metadata: Some(SdkMethodCallMetadata {
-                                    parameters: result.parameters, // Extracted from 2nd argument (operation params)
-                                    return_type: None,
-                                    expr: result.text.to_string(),
-                                    location: result.location.clone(),
-                                    receiver: None, // Waiter functions are standalone
-                                }),
+                                metadata: Some(metadata),
                             };
                             operations.push(method_call);
                         }
@@ -404,16 +404,15 @@ impl ExtractionUtils {
 
                         // Keep PascalCase operation name to match service index
                         // e.g., "Query" stays "Query"
+                        let metadata = SdkMethodCallMetadata::new(
+                            result.text.to_string(),
+                            result.location.clone(),
+                        );
+
                         let method_call = SdkMethodCall {
                             name: operation_name.to_string(),
                             possible_services: vec![service.clone()],
-                            metadata: Some(SdkMethodCallMetadata {
-                                parameters: Vec::new(),
-                                return_type: None,
-                                expr: result.text.to_string(),
-                                location: result.location.clone(),
-                                receiver: None,
-                            }),
+                            metadata: Some(metadata),
                         };
                         operations.push(method_call);
                     }
@@ -476,16 +475,16 @@ impl ExtractionUtils {
                         for command_name in expanded_commands {
                             // Extract operation name by removing "Command" suffix
                             if let Some(operation_name) = command_name.strip_suffix("Command") {
+                                let metadata = SdkMethodCallMetadata::new(
+                                    result.text.to_string(),
+                                    result.location.clone(),
+                                )
+                                .with_parameters(result.parameters.clone());
+
                                 let method_call = SdkMethodCall {
                                     name: operation_name.to_string(),
                                     possible_services: vec![service.clone()],
-                                    metadata: Some(SdkMethodCallMetadata {
-                                        parameters: result.parameters.clone(),
-                                        return_type: None,
-                                        expr: result.text.to_string(),
-                                        location: result.location.clone(),
-                                        receiver: None,
-                                    }),
+                                    metadata: Some(metadata),
                                 };
                                 operations.push(method_call);
                             }
@@ -525,16 +524,15 @@ impl ExtractionUtils {
             // Convert method arguments to parameters
             let parameters = Self::convert_arguments_to_parameters(&method_call.arguments);
 
+            let metadata =
+                SdkMethodCallMetadata::new(method_call.expr.clone(), method_call.location.clone())
+                    .with_parameters(parameters)
+                    .with_receiver(method_call.client_variable.clone());
+
             let sdk_method_call = SdkMethodCall {
                 name: operation_name,
                 possible_services: vec![service],
-                metadata: Some(SdkMethodCallMetadata {
-                    parameters,
-                    return_type: None,
-                    expr: method_call.expr.clone(),
-                    location: method_call.location.clone(),
-                    receiver: Some(method_call.client_variable.clone()),
-                }),
+                metadata: Some(metadata),
             };
 
             operations.push(sdk_method_call);

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/disambiguation.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/disambiguation.rs
@@ -300,35 +300,36 @@ mod tests {
         let service_index = create_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "DomainName".to_string(),
+                value: ParameterValue::Resolved("example.com".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "Stage".to_string(),
+                value: ParameterValue::Resolved("prod".to_string()),
+                position: 1,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "ApiId".to_string(),
+                value: ParameterValue::Resolved("abc123".to_string()),
+                position: 2,
+                type_annotation: None,
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![
-                    Parameter::Keyword {
-                        name: "DomainName".to_string(),
-                        value: ParameterValue::Resolved("example.com".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "Stage".to_string(),
-                        value: ParameterValue::Resolved("prod".to_string()),
-                        position: 1,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "ApiId".to_string(),
-                        value: ParameterValue::Resolved("abc123".to_string()),
-                        position: 2,
-                        type_annotation: None,
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -341,24 +342,25 @@ mod tests {
         let service_index = create_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 30)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "DomainName".to_string(),
+                value: ParameterValue::Resolved("example.com".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            // Missing required Stage and ApiId parameters
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![
-                    Parameter::Keyword {
-                        name: "DomainName".to_string(),
-                        value: ParameterValue::Resolved("example.com".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    // Missing required Stage and ApiId parameters
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 30)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -370,19 +372,20 @@ mod tests {
         let service_index = create_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 30)),
+        )
+        .with_parameters(vec![Parameter::DictionarySplat {
+            expression: "**params".to_string(),
+            position: 0,
+        }])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![Parameter::DictionarySplat {
-                    expression: "**params".to_string(),
-                    position: 0,
-                }],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 30)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -395,21 +398,22 @@ mod tests {
         let service_index = create_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "non_aws_method".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 30)),
+        )
+        .with_parameters(vec![Parameter::Keyword {
+            name: "custom_param".to_string(),
+            value: ParameterValue::Resolved("value".to_string()),
+            position: 0,
+            type_annotation: None,
+        }])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "non_aws_method".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "non_aws_method".to_string(),
-                parameters: vec![Parameter::Keyword {
-                    name: "custom_param".to_string(),
-                    value: ParameterValue::Resolved("value".to_string()),
-                    position: 0,
-                    type_annotation: None,
-                }],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 30)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -424,33 +428,34 @@ mod tests {
         // Test case: explicit DomainName + dictionary unpacking for other params
         // This should be valid even though Stage and ApiId are missing explicitly
         // (they could be provided via **params)
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "DomainName".to_string(),
+                value: ParameterValue::Resolved("example.com".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "ApiMappingKey".to_string(), // Optional parameter
+                value: ParameterValue::Resolved("v1".to_string()),
+                position: 1,
+                type_annotation: None,
+            },
+            Parameter::DictionarySplat {
+                expression: "**params".to_string(),
+                position: 2,
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![
-                    Parameter::Keyword {
-                        name: "DomainName".to_string(),
-                        value: ParameterValue::Resolved("example.com".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "ApiMappingKey".to_string(), // Optional parameter
-                        value: ParameterValue::Resolved("v1".to_string()),
-                        position: 1,
-                        type_annotation: None,
-                    },
-                    Parameter::DictionarySplat {
-                        expression: "**params".to_string(),
-                        position: 2,
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -465,29 +470,30 @@ mod tests {
 
         // Test case: invalid explicit parameter + dictionary unpacking
         // This should be filtered out because the explicit parameter is invalid
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "DomainName".to_string(),
+                value: ParameterValue::Resolved("example.com".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "InvalidParam".to_string(), // This parameter doesn't exist in AWS API
+                value: ParameterValue::Resolved("invalid".to_string()),
+                position: 1,
+                type_annotation: None,
+            },
+        ])
+        .with_receiver("client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![
-                    Parameter::Keyword {
-                        name: "DomainName".to_string(),
-                        value: ParameterValue::Resolved("example.com".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "InvalidParam".to_string(), // This parameter doesn't exist in AWS API
-                        value: ParameterValue::Resolved("invalid".to_string()),
-                        position: 1,
-                        type_annotation: None,
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                receiver: Some("client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/disambiguation_tests.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/disambiguation_tests.rs
@@ -177,35 +177,36 @@ mod tests {
         let service_index = create_comprehensive_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 80)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "DomainName".to_string(),
+                value: ParameterValue::Resolved("example.com".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "Stage".to_string(),
+                value: ParameterValue::Resolved("prod".to_string()),
+                position: 1,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "ApiId".to_string(),
+                value: ParameterValue::Resolved("abc123".to_string()),
+                position: 2,
+                type_annotation: None,
+            },
+        ])
+        .with_receiver("apigateway_client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![
-                    Parameter::Keyword {
-                        name: "DomainName".to_string(),
-                        value: ParameterValue::Resolved("example.com".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "Stage".to_string(),
-                        value: ParameterValue::Resolved("prod".to_string()),
-                        position: 1,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "ApiId".to_string(),
-                        value: ParameterValue::Resolved("abc123".to_string()),
-                        position: 2,
-                        type_annotation: None,
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 80)),
-                receiver: Some("apigateway_client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -219,24 +220,25 @@ mod tests {
         let service_index = create_comprehensive_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 40)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "DomainName".to_string(),
+                value: ParameterValue::Resolved("example.com".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            // Missing required Stage and ApiId parameters
+        ])
+        .with_receiver("apigateway_client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![
-                    Parameter::Keyword {
-                        name: "DomainName".to_string(),
-                        value: ParameterValue::Resolved("example.com".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    // Missing required Stage and ApiId parameters
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 40)),
-                receiver: Some("apigateway_client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -248,41 +250,42 @@ mod tests {
         let service_index = create_comprehensive_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 100)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "DomainName".to_string(),
+                value: ParameterValue::Resolved("example.com".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "Stage".to_string(),
+                value: ParameterValue::Resolved("prod".to_string()),
+                position: 1,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "ApiId".to_string(),
+                value: ParameterValue::Resolved("abc123".to_string()),
+                position: 2,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "InvalidParam".to_string(), // This parameter doesn't exist in the AWS API
+                value: ParameterValue::Resolved("invalid".to_string()),
+                position: 3,
+                type_annotation: None,
+            },
+        ])
+        .with_receiver("apigateway_client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![
-                    Parameter::Keyword {
-                        name: "DomainName".to_string(),
-                        value: ParameterValue::Resolved("example.com".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "Stage".to_string(),
-                        value: ParameterValue::Resolved("prod".to_string()),
-                        position: 1,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "ApiId".to_string(),
-                        value: ParameterValue::Resolved("abc123".to_string()),
-                        position: 2,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "InvalidParam".to_string(), // This parameter doesn't exist in the AWS API
-                        value: ParameterValue::Resolved("invalid".to_string()),
-                        position: 3,
-                        type_annotation: None,
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 100)),
-                receiver: Some("apigateway_client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -294,19 +297,20 @@ mod tests {
         let service_index = create_comprehensive_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "create_api_mapping".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![Parameter::DictionarySplat {
+            expression: "**params".to_string(),
+            position: 0,
+        }])
+        .with_receiver("apigateway_client".to_string());
+
         let method_call = SdkMethodCall {
             name: "create_api_mapping".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "create_api_mapping".to_string(),
-                parameters: vec![Parameter::DictionarySplat {
-                    expression: "**params".to_string(),
-                    position: 0,
-                }],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                receiver: Some("apigateway_client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -325,21 +329,22 @@ mod tests {
         let service_index = create_comprehensive_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "custom_method".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 30)),
+        )
+        .with_parameters(vec![Parameter::Keyword {
+            name: "custom_param".to_string(),
+            value: ParameterValue::Resolved("value".to_string()),
+            position: 0,
+            type_annotation: None,
+        }])
+        .with_receiver("custom_client".to_string());
+
         let method_call = SdkMethodCall {
             name: "custom_method".to_string(), // Not an AWS SDK method
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "custom_method".to_string(),
-                parameters: vec![Parameter::Keyword {
-                    name: "custom_param".to_string(),
-                    value: ParameterValue::Resolved("value".to_string()),
-                    position: 0,
-                    type_annotation: None,
-                }],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 30)),
-                receiver: Some("custom_client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -351,65 +356,68 @@ mod tests {
         let service_index = create_comprehensive_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata1 = SdkMethodCallMetadata::new(
+            "get_object".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 50)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "Bucket".to_string(),
+                value: ParameterValue::Resolved("my-bucket".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "Key".to_string(),
+                value: ParameterValue::Resolved("my-key".to_string()),
+                position: 1,
+                type_annotation: None,
+            },
+        ])
+        .with_receiver("s3_client".to_string());
+
+        let metadata2 = SdkMethodCallMetadata::new(
+            "get_object".to_string(),
+            Location::new(PathBuf::new(), (2, 1), (2, 30)),
+        )
+        .with_parameters(vec![Parameter::Keyword {
+            name: "custom_param".to_string(), // Invalid parameter for AWS S3
+            value: ParameterValue::Resolved("value".to_string()),
+            position: 0,
+            type_annotation: None,
+        }])
+        .with_receiver("custom_client".to_string());
+
+        let metadata3 = SdkMethodCallMetadata::new(
+            "custom_method".to_string(),
+            Location::new(PathBuf::new(), (3, 1), (3, 25)),
+        )
+        .with_parameters(vec![Parameter::Keyword {
+            name: "param".to_string(),
+            value: ParameterValue::Resolved("value".to_string()),
+            position: 0,
+            type_annotation: None,
+        }])
+        .with_receiver("custom_client".to_string());
+
         let method_calls = vec![
             // Valid AWS SDK call
             SdkMethodCall {
                 name: "get_object".to_string(),
                 possible_services: Vec::new(),
-                metadata: Some(SdkMethodCallMetadata {
-                    expr: "get_object".to_string(),
-                    parameters: vec![
-                        Parameter::Keyword {
-                            name: "Bucket".to_string(),
-                            value: ParameterValue::Resolved("my-bucket".to_string()),
-                            position: 0,
-                            type_annotation: None,
-                        },
-                        Parameter::Keyword {
-                            name: "Key".to_string(),
-                            value: ParameterValue::Resolved("my-key".to_string()),
-                            position: 1,
-                            type_annotation: None,
-                        },
-                    ],
-                    return_type: None,
-                    location: Location::new(PathBuf::new(), (1, 1), (1, 50)),
-                    receiver: Some("s3_client".to_string()),
-                }),
+                metadata: Some(metadata1),
             },
             // Non-AWS method call with same name as AWS method but different parameters
             SdkMethodCall {
                 name: "get_object".to_string(),
                 possible_services: Vec::new(),
-                metadata: Some(SdkMethodCallMetadata {
-                    expr: "get_object".to_string(),
-                    parameters: vec![Parameter::Keyword {
-                        name: "custom_param".to_string(), // Invalid parameter for AWS S3
-                        value: ParameterValue::Resolved("value".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    }],
-                    return_type: None,
-                    location: Location::new(PathBuf::new(), (2, 1), (2, 30)),
-                    receiver: Some("custom_client".to_string()),
-                }),
+                metadata: Some(metadata2),
             },
             // Completely non-AWS method
             SdkMethodCall {
                 name: "custom_method".to_string(),
                 possible_services: Vec::new(),
-                metadata: Some(SdkMethodCallMetadata {
-                    expr: "custom_method".to_string(),
-                    parameters: vec![Parameter::Keyword {
-                        name: "param".to_string(),
-                        value: ParameterValue::Resolved("value".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    }],
-                    return_type: None,
-                    location: Location::new(PathBuf::new(), (3, 1), (3, 25)),
-                    receiver: Some("custom_client".to_string()),
-                }),
+                metadata: Some(metadata3),
             },
         ];
 
@@ -507,44 +515,45 @@ def example():
         let service_index = create_comprehensive_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "get_object".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 80)),
+        )
+        .with_parameters(vec![
+            Parameter::Keyword {
+                name: "Bucket".to_string(),
+                value: ParameterValue::Resolved("my-bucket".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "Key".to_string(),
+                value: ParameterValue::Resolved("my-key".to_string()),
+                position: 1,
+                type_annotation: None,
+            },
+            // This keyword argument starts with "arg_" but should NOT be filtered out
+            // because it's a legitimate keyword parameter, not a positional placeholder
+            Parameter::Keyword {
+                name: "arg_custom_param".to_string(), // This would have been incorrectly filtered before the fix
+                value: ParameterValue::Resolved("custom_value".to_string()),
+                position: 2,
+                type_annotation: None,
+            },
+            // Also include a positional argument to show the difference
+            Parameter::Positional {
+                value: ParameterValue::Resolved("positional_value".to_string()),
+                position: 3,
+                type_annotation: None,
+                struct_fields: None,
+            },
+        ])
+        .with_receiver("s3_client".to_string());
+
         let method_call = SdkMethodCall {
             name: "get_object".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "get_object".to_string(),
-                parameters: vec![
-                    Parameter::Keyword {
-                        name: "Bucket".to_string(),
-                        value: ParameterValue::Resolved("my-bucket".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "Key".to_string(),
-                        value: ParameterValue::Resolved("my-key".to_string()),
-                        position: 1,
-                        type_annotation: None,
-                    },
-                    // This keyword argument starts with "arg_" but should NOT be filtered out
-                    // because it's a legitimate keyword parameter, not a positional placeholder
-                    Parameter::Keyword {
-                        name: "arg_custom_param".to_string(), // This would have been incorrectly filtered before the fix
-                        value: ParameterValue::Resolved("custom_value".to_string()),
-                        position: 2,
-                        type_annotation: None,
-                    },
-                    // Also include a positional argument to show the difference
-                    Parameter::Positional {
-                        value: ParameterValue::Resolved("positional_value".to_string()),
-                        position: 3,
-                        type_annotation: None,
-                        struct_fields: None,
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 80)),
-                receiver: Some("s3_client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);
@@ -565,37 +574,38 @@ def example():
         let service_index = create_comprehensive_test_service_index();
         let disambiguator = MethodDisambiguator::new(&service_index);
 
+        let metadata = SdkMethodCallMetadata::new(
+            "get_object".to_string(),
+            Location::new(PathBuf::new(), (1, 1), (1, 60)),
+        )
+        .with_parameters(vec![
+            // Valid required parameters
+            Parameter::Keyword {
+                name: "Bucket".to_string(),
+                value: ParameterValue::Resolved("my-bucket".to_string()),
+                position: 0,
+                type_annotation: None,
+            },
+            Parameter::Keyword {
+                name: "Key".to_string(),
+                value: ParameterValue::Resolved("my-key".to_string()),
+                position: 1,
+                type_annotation: None,
+            },
+            // Positional argument with arg_ prefix - should be ignored in validation
+            Parameter::Positional {
+                value: ParameterValue::Resolved("positional_value".to_string()),
+                position: 2,
+                type_annotation: None,
+                struct_fields: None,
+            },
+        ])
+        .with_receiver("s3_client".to_string());
+
         let method_call = SdkMethodCall {
             name: "get_object".to_string(),
             possible_services: Vec::new(),
-            metadata: Some(SdkMethodCallMetadata {
-                expr: "get_object".to_string(),
-                parameters: vec![
-                    // Valid required parameters
-                    Parameter::Keyword {
-                        name: "Bucket".to_string(),
-                        value: ParameterValue::Resolved("my-bucket".to_string()),
-                        position: 0,
-                        type_annotation: None,
-                    },
-                    Parameter::Keyword {
-                        name: "Key".to_string(),
-                        value: ParameterValue::Resolved("my-key".to_string()),
-                        position: 1,
-                        type_annotation: None,
-                    },
-                    // Positional argument with arg_ prefix - should be ignored in validation
-                    Parameter::Positional {
-                        value: ParameterValue::Resolved("positional_value".to_string()),
-                        position: 2,
-                        type_annotation: None,
-                        struct_fields: None,
-                    },
-                ],
-                return_type: None,
-                location: Location::new(PathBuf::new(), (1, 1), (1, 60)),
-                receiver: Some("s3_client".to_string()),
-            }),
+            metadata: Some(metadata),
         };
 
         let result = disambiguator.disambiguate_method_calls(vec![method_call]);

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/extractor.rs
@@ -44,16 +44,21 @@ impl PythonExtractor {
         let args_nodes = env.get_multiple_matches("ARGS");
         let arguments = ArgumentExtractor::extract_arguments(&args_nodes);
 
+        let metadata = SdkMethodCallMetadata::new(
+            node_match.text().to_string(),
+            Location::from_node(source_file.path.clone(), node_match.get_node()),
+        )
+        .with_parameters(arguments);
+        let metadata = if let Some(r) = receiver {
+            metadata.with_receiver(r)
+        } else {
+            metadata
+        };
+
         let method_call = SdkMethodCall {
             name: method_name.to_string(),
             possible_services: Vec::new(), // Will be determined later during service validation
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: arguments,
-                return_type: None, // We don't know the return type from the call site
-                expr: node_match.text().to_string(),
-                location: Location::from_node(source_file.path.clone(), node_match.get_node()),
-                receiver,
-            }),
+            metadata: Some(metadata),
         };
         log::debug!("Found method call: {method_call:?}");
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/shared/extraction_utils.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/shared/extraction_utils.rs
@@ -215,16 +215,14 @@ impl<'a> PaginatorCallPattern<'a> {
                 Vec::new() // No services found for this method
             };
 
+        let metadata = SdkMethodCallMetadata::new(self.expr().to_string(), self.location().clone())
+            .with_parameters(self.arguments().to_vec())
+            .with_receiver(self.client_receiver().to_string());
+
         crate::extraction::SdkMethodCall {
             name: method_name,
             possible_services,
-            metadata: Some(SdkMethodCallMetadata {
-                parameters: self.arguments().to_vec(),
-                return_type: None,
-                expr: self.expr().to_string(),
-                location: self.location().clone(),
-                receiver: Some(self.client_receiver().to_string()),
-            }),
+            metadata: Some(metadata),
         }
     }
 }
@@ -363,16 +361,15 @@ impl<'a> WaiterCallPattern<'a> {
                 let method_name =
                     ServiceDiscovery::operation_to_method_name(operation_name, language);
 
+                let metadata =
+                    SdkMethodCallMetadata::new(self.expr().to_string(), self.location().clone())
+                        .with_parameters(parameters)
+                        .with_receiver(self.client_receiver().to_string());
+
                 synthetic_calls.push(crate::extraction::SdkMethodCall {
                     name: method_name,
                     possible_services: vec![service_name.clone()],
-                    metadata: Some(SdkMethodCallMetadata {
-                        parameters,
-                        return_type: None,
-                        expr: self.expr().to_string(),
-                        location: self.location().clone(),
-                        receiver: Some(self.client_receiver().to_string()),
-                    }),
+                    metadata: Some(metadata),
                 });
             }
         }


### PR DESCRIPTION
*Issue #, if available:* related: https://github.com/awslabs/iam-policy-autopilot/issues/61

*Description of changes:* Refactor `SdkMethodCallMetadata` to make it easier to extend. Currently adding a new field requires changing ~50 struct initialization sites (mostly in tests). Adding the `with_...` setters makes it easier to add a new field, which adds functionality, without having to immediately refactor the extractors for all languages.

Prepares for using return type information in Java, if present. Adds, the currently unused `result_usage: Option<MethodCallResultUsage>`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
