### PR TITLE
chore: reduce cache duration to 5 minutes

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
@@ -20,9 +20,9 @@ use tokio::sync::{OnceCell, RwLock};
 
 type OperationName = String;
 const IAM_POLICY_AUTOPILOT: &str = "IAMPolicyAutopilot";
-// Cache files for 6 hours.
+// Cache files for 5 minutes.
 // We can allow cache duration override in future.
-const DEFAULT_CACHE_DURATION_IN_SECONDS: u64 = 21600;
+const DEFAULT_CACHE_DURATION_IN_SECONDS: u64 = 300;
 /// Service Reference data structure
 ///
 /// Represents the complete service reference loaded from service reference endpoint.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change reduces the cache duration to 5 minutes, which's sufficient for current rate limit enforced by service reference and ensures clients get latest updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
