### PR TITLE
fix: aws_python_case_conversion

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       submodules: ${{ steps.filter.outputs.submodules }}
+      python: ${{ steps.filter.outputs.python }}
       should_test: ${{ steps.filter.outputs.rust == 'true' || steps.filter.outputs.submodules == 'true' }}
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +33,9 @@ jobs:
             submodules:
               - 'iam-policy-autopilot-policy-generation/resources/config/sdks/boto3/**'
               - 'iam-policy-autopilot-policy-generation/resources/config/sdks/botocore-data/**'
+            python:
+              - 'iam-policy-autopilot-policy-generation/scripts/**/*.py'
+              - 'pyproject.toml'
 
   test-linux:
     name: Test Linux
@@ -154,6 +158,24 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --workspace -- -D warnings
+
+  ruff:
+    name: Ruff (Python lint + format)
+    needs: [changes]
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "check ."
+
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check ."
 
   custom-lints:
     name: Custom Lints (dylint)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,35 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
+### Code Style & Linting
+
+Ensure your changes pass all linters. The CI will enforce these checks automatically.
+
+**Rust**
+
+```bash
+# Format all Rust code
+cargo fmt --all
+
+# Run Clippy (warnings are treated as errors in CI)
+cargo clippy --workspace
+```
+
+**Python** (scripts in `iam-policy-autopilot-policy-generation/scripts/`)
+
+```bash
+# Lint
+ruff check .
+
+# Format
+ruff format .
+
+# Check formatting without modifying files (as CI does)
+ruff format --check .
+```
+
+Ruff is configured in [`pyproject.toml`](pyproject.toml) at the repository root. Install it with `pip install ruff` or via your package manager.
+
 ### Commit Message Guidelines
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages. This helps with automated changelog generation and makes the commit history more readable.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tokio-test = "0.4"
 tempfile = "3.10"
 criterion = "0.5"
 proptest = "1.0"
+rstest = "0.26"
 
 # CLI-specific dependencies
 clap = { version = "4.5", features = ["derive", "env", "cargo"] }

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ iam-policy-autopilot mcp-server --transport http
 
 - [Rust](https://rustup.rs/) (latest stable version)
 - Git
+- Python 3
 - [CMake](https://cmake.org/) (Windows only)
 
 ### Setup

--- a/iam-policy-autopilot-policy-generation/Cargo.toml
+++ b/iam-policy-autopilot-policy-generation/Cargo.toml
@@ -45,6 +45,7 @@ serde_json.workspace = true
 aws-lc-rs.workspace = true
 git2.workspace = true
 relative-path.workspace = true
+convert_case.workspace = true
 
 [features]
 default = []
@@ -58,6 +59,7 @@ tokio-test.workspace = true
 tempfile.workspace = true
 criterion.workspace = true
 proptest.workspace = true
+rstest.workspace = true
 test-log = "0.2"
 env_logger.workspace = true
 wiremock = "0.6"

--- a/iam-policy-autopilot-policy-generation/build.rs
+++ b/iam-policy-autopilot-policy-generation/build.rs
@@ -646,8 +646,9 @@ fn generate_python_name_map(output_dir: &Path) -> Result<(), Box<dyn std::error:
     // either direction. We need to cover both:
     //
     // 1. Forward (PascalCase → snake_case): botocore's xform_name() differs from
-    //    convert_case::Case::Snake. Example: "ExecutePartiQLStatement" →
-    //    botocore: "execute_partiql_statement", convert_case: "execute_parti_q_l_statement".
+    //    convert_case::Case::Snake. Example: "AssignIpv6Addresses" →
+    //    botocore: "assign_ipv6_addresses", convert_case: "assign_ipv_6_addresses"
+    //    (convert_case splits on digit boundaries: LOWER_DIGIT at "v6" and DIGIT_UPPER at "6A").
     //
     // 2. Reverse (snake_case → PascalCase): convert_case::Case::Pascal applied to the botocore
     //    snake_case name does not round-trip back to the original PascalCase. Example:

--- a/iam-policy-autopilot-policy-generation/build.rs
+++ b/iam-policy-autopilot-policy-generation/build.rs
@@ -1,4 +1,5 @@
 use aws_lc_rs::digest::{Context, Digest, SHA256};
+use convert_case::{Case, Casing};
 use git2::{DescribeOptions, Repository};
 use relative_path::PathExt;
 use relative_path::RelativePathBuf;
@@ -10,6 +11,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
 /// Simplified service definition with fields removed
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -116,6 +118,7 @@ impl GitSubmoduleMetadata {
 fn main() {
     println!("cargo:rerun-if-changed=resources/config/sdks/botocore-data");
     println!("cargo:rerun-if-changed=resources/config/sdks/boto3");
+    println!("cargo:rerun-if-changed=scripts/generate_python_name_map.py");
 
     #[allow(clippy::unwrap_used)]
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -172,6 +175,12 @@ fn main() {
 
     if let Err(e) = process_boto3_data(boto3_data_path, &boto3_dir) {
         panic!("Failed to process boto3 data: {e}");
+    }
+
+    // Generate Python operation name map using botocore's xform_name
+    let python_name_map_dir = Path::new("target/python-name-map");
+    if let Err(e) = generate_python_name_map(python_name_map_dir) {
+        panic!("Failed to generate Python operation name map: {e}");
     }
 
     // Copy the boto3 directory to workspace-level target for rust-embed
@@ -581,6 +590,94 @@ fn get_repository_tag(repo: &Repository) -> Result<Option<String>, Box<dyn std::
             )
         })
         .unwrap_or_default())
+}
+
+/// Generate the Python operation name map by running the Python script and then
+/// filtering out entries that convert_case already handles correctly.
+///
+/// The Python script produces a full map of {PascalCase → snake_case} for all operations
+/// using botocore's authoritative xform_name(). We then keep only the entries where
+/// botocore's result differs from what convert_case::Case::Snake produces, so the
+/// embedded lookup table stays small.
+fn generate_python_name_map(output_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let botocore_root = Path::new("resources/config/sdks/botocore-data");
+    let botocore_data_dir = botocore_root.join("botocore/data");
+    let script_path = Path::new("scripts/generate_python_name_map.py");
+
+    assert!(
+        botocore_root.exists(),
+        "Required botocore root not found at: {}. Please run `git submodule init && git submodule update`.",
+        botocore_root.display()
+    );
+    assert!(
+        script_path.exists(),
+        "Python name map script not found at: {}",
+        script_path.display()
+    );
+
+    // Create output directory
+    fs::create_dir_all(output_dir)?;
+
+    let tmp_full_map = output_dir.join("python_operation_name_map_full.json");
+    let final_map = output_dir.join("python_operation_name_map.json");
+
+    // Run the Python script to generate the full xform_name map
+    let output = Command::new("python3")
+        .arg(script_path)
+        .arg(botocore_root)
+        .arg(&botocore_data_dir)
+        .arg(&tmp_full_map)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Python script failed with status {}: {}",
+            output.status, stderr
+        )
+        .into());
+    }
+
+    // Read the full map produced by the Python script
+    let full_map_json = fs::read_to_string(&tmp_full_map)?;
+    let full_map: BTreeMap<String, String> = serde_json::from_str(&full_map_json)?;
+
+    // Filter: keep only entries where convert_case produces a different result than botocore in
+    // either direction. We need to cover both:
+    //
+    // 1. Forward (PascalCase → snake_case): botocore's xform_name() differs from
+    //    convert_case::Case::Snake. Example: "ExecutePartiQLStatement" →
+    //    botocore: "execute_partiql_statement", convert_case: "execute_parti_q_l_statement".
+    //
+    // 2. Reverse (snake_case → PascalCase): convert_case::Case::Pascal applied to the botocore
+    //    snake_case name does not round-trip back to the original PascalCase. Example:
+    //    "ModifyDBCluster" → botocore snake: "modify_db_cluster" (forward matches convert_case,
+    //    so it would be filtered out by a forward-only check), but
+    //    "modify_db_cluster".to_case(Case::Pascal) = "ModifyDbCluster" ≠ "ModifyDBCluster",
+    //    so the reverse lookup in Operation::from_call would produce the wrong PascalCase name.
+    let special_cases: BTreeMap<String, String> = full_map
+        .into_iter()
+        .filter(|(pascal_name, botocore_snake)| {
+            // Keep if forward conversion differs (convert_case snake is wrong)
+            let convert_case_snake = pascal_name.to_case(Case::Snake);
+            if &convert_case_snake != botocore_snake {
+                return true;
+            }
+            // Also keep if reverse conversion differs (convert_case Pascal can't round-trip
+            // back to the original PascalCase from the botocore snake_case name)
+            let convert_case_pascal = botocore_snake.to_case(Case::Pascal);
+            &convert_case_pascal != pascal_name
+        })
+        .collect();
+
+    // Write the filtered map as the final embedded JSON
+    let final_json = serde_json::to_string(&special_cases)?;
+    fs::write(&final_map, final_json)?;
+
+    // Clean up the temporary full map
+    let _ = fs::remove_file(&tmp_full_map);
+
+    Ok(())
 }
 
 fn get_repository_commit(repo: &Repository) -> Result<String, Box<dyn std::error::Error>> {

--- a/iam-policy-autopilot-policy-generation/build.rs
+++ b/iam-policy-autopilot-policy-generation/build.rs
@@ -655,6 +655,7 @@ fn generate_python_name_map(output_dir: &Path) -> Result<(), Box<dyn std::error:
     //    so it would be filtered out by a forward-only check), but
     //    "modify_db_cluster".to_case(Case::Pascal) = "ModifyDbCluster" ≠ "ModifyDBCluster",
     //    so the reverse lookup in Operation::from_call would produce the wrong PascalCase name.
+    #[allow(unknown_lints, convert_case_pascal)]
     let special_cases: BTreeMap<String, String> = full_map
         .into_iter()
         .filter(|(pascal_name, botocore_snake)| {

--- a/iam-policy-autopilot-policy-generation/scripts/generate_python_name_map.py
+++ b/iam-policy-autopilot-policy-generation/scripts/generate_python_name_map.py
@@ -40,7 +40,7 @@ def main():
     sys.path.insert(0, botocore_root)
 
     try:
-        from botocore import _xform_cache, xform_name
+        from botocore import xform_name
     except ImportError as e:
         print(
             f"Error: could not import botocore from {botocore_root}: {e}",

--- a/iam-policy-autopilot-policy-generation/scripts/generate_python_name_map.py
+++ b/iam-policy-autopilot-policy-generation/scripts/generate_python_name_map.py
@@ -3,9 +3,7 @@
 Generate a lookup table of AWS operation names → Python snake_case method names.
 
 This script uses botocore's own xform_name() function to produce the authoritative
-mapping for all operation names found in the botocore service data directory, plus
-all entries pre-populated in botocore's _xform_cache (special cases that may not
-appear in the current service data but are handled specially by botocore).
+mapping for all operation names found in the botocore service data directory.
 
 The resulting JSON maps every PascalCase operation name to its Python snake_case
 equivalent as boto3 uses it. The caller (build.rs) is responsible for filtering out
@@ -88,16 +86,6 @@ def main():
                 waiter_name_str = str(waiter_name)
                 if waiter_name_str not in operations:
                     operations[waiter_name_str] = xform_name(waiter_name_str)
-
-    # Also include all pre-populated special cases from botocore's _xform_cache.
-    # These cover names that may not appear in the current service data but are handled
-    # specially by botocore (e.g. PartiQL operations, iSCSI operations, HITs).
-    # Only include '_' separator entries (boto3 uses underscores for method names).
-    xform_cache_entries = 0
-    for (name, sep), result in _xform_cache.items():
-        if sep == "_" and name not in operations:
-            operations[name] = result
-            xform_cache_entries += 1
 
     # Write the full map as JSON (sorted keys for deterministic output).
     # build.rs will filter this down to only the entries that differ from convert_case.

--- a/iam-policy-autopilot-policy-generation/scripts/generate_python_name_map.py
+++ b/iam-policy-autopilot-policy-generation/scripts/generate_python_name_map.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Generate a lookup table of AWS operation names → Python snake_case method names.
+
+This script uses botocore's own xform_name() function to produce the authoritative
+mapping for all operation names found in the botocore service data directory, plus
+all entries pre-populated in botocore's _xform_cache (special cases that may not
+appear in the current service data but are handled specially by botocore).
+
+The resulting JSON maps every PascalCase operation name to its Python snake_case
+equivalent as boto3 uses it. The caller (build.rs) is responsible for filtering out
+entries that convert_case already handles correctly, keeping only the special cases.
+
+Usage:
+    python3 generate_python_name_map.py <botocore_root> <botocore_data_dir> <output_json>
+
+Arguments:
+    botocore_root     Path to the botocore package root (contains botocore/__init__.py)
+    botocore_data_dir Path to botocore/data directory (contains per-service subdirectories)
+    output_json       Path to write the output JSON file
+"""
+
+import gzip
+import json
+import os
+import sys
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(
+            f"Usage: {sys.argv[0]} <botocore_root> <botocore_data_dir> <output_json>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    botocore_root = sys.argv[1]
+    botocore_data_dir = sys.argv[2]
+    output_json = sys.argv[3]
+
+    # Add botocore root to sys.path so we can import botocore
+    sys.path.insert(0, botocore_root)
+
+    try:
+        from botocore import _xform_cache, xform_name
+    except ImportError as e:
+        print(
+            f"Error: could not import botocore from {botocore_root}: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Collect all operation names and their xform_name results from service-2.json files,
+    # and all waiter names from waiters-2.json files.
+    # Use os.walk to match the pattern from the reference implementation.
+    operations: dict[str, str] = {}
+
+    for root, dirs, files in os.walk(botocore_data_dir):
+        # Process service-2.json for operation names
+        service_files = [f for f in files if f.startswith("service-2.json")]
+        if service_files:
+            service_file = service_files[0]
+            if service_file.endswith(".gz"):
+                with gzip.open(os.path.join(root, service_file), "rb") as fd:
+                    data = json.loads(fd.read().decode("utf-8"))
+            else:
+                with open(os.path.join(root, service_file)) as fd:
+                    data = json.loads(fd.read())
+
+            for op_name in data.get("operations", {}).keys():
+                op_name_str = str(op_name)
+                operations[op_name_str] = xform_name(op_name_str)
+
+        # Process waiters-2.json for waiter names.
+        # Waiter names (e.g. "FunctionActiveV2") are passed to boto3's get_waiter()
+        # and converted via xform_name, so they need the same treatment as operation names.
+        waiter_files = [f for f in files if f.startswith("waiters-2.json")]
+        if waiter_files:
+            waiter_file = waiter_files[0]
+            if waiter_file.endswith(".gz"):
+                with gzip.open(os.path.join(root, waiter_file), "rb") as fd:
+                    waiter_data = json.loads(fd.read().decode("utf-8"))
+            else:
+                with open(os.path.join(root, waiter_file)) as fd:
+                    waiter_data = json.loads(fd.read())
+
+            for waiter_name in waiter_data.get("waiters", {}).keys():
+                waiter_name_str = str(waiter_name)
+                if waiter_name_str not in operations:
+                    operations[waiter_name_str] = xform_name(waiter_name_str)
+
+    # Also include all pre-populated special cases from botocore's _xform_cache.
+    # These cover names that may not appear in the current service data but are handled
+    # specially by botocore (e.g. PartiQL operations, iSCSI operations, HITs).
+    # Only include '_' separator entries (boto3 uses underscores for method names).
+    xform_cache_entries = 0
+    for (name, sep), result in _xform_cache.items():
+        if sep == "_" and name not in operations:
+            operations[name] = result
+            xform_cache_entries += 1
+
+    # Write the full map as JSON (sorted keys for deterministic output).
+    # build.rs will filter this down to only the entries that differ from convert_case.
+    output_dir = os.path.dirname(output_json)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    with open(output_json, "w", encoding="utf-8") as f:
+        json.dump(operations, f, sort_keys=True, indent=2)
+        f.write("\n")
+
+    print(f"Written to {output_json}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/iam-policy-autopilot-policy-generation/scripts/generate_python_name_map.py
+++ b/iam-policy-autopilot-policy-generation/scripts/generate_python_name_map.py
@@ -64,7 +64,7 @@ def main():
                 with gzip.open(os.path.join(root, service_file), "rb") as fd:
                     data = json.loads(fd.read().decode("utf-8"))
             else:
-                with open(os.path.join(root, service_file)) as fd:
+                with open(os.path.join(root, service_file), encoding="utf-8") as fd:
                     data = json.loads(fd.read())
 
             for op_name in data.get("operations", {}).keys():
@@ -81,7 +81,7 @@ def main():
                 with gzip.open(os.path.join(root, waiter_file), "rb") as fd:
                     waiter_data = json.loads(fd.read().decode("utf-8"))
             else:
-                with open(os.path.join(root, waiter_file)) as fd:
+                with open(os.path.join(root, waiter_file), encoding="utf-8") as fd:
                     waiter_data = json.loads(fd.read())
 
             for waiter_name in waiter_data.get("waiters", {}).keys():

--- a/iam-policy-autopilot-policy-generation/src/embedded_data.rs
+++ b/iam-policy-autopilot-policy-generation/src/embedded_data.rs
@@ -16,6 +16,62 @@ use regex::Regex;
 use rust_embed::RustEmbed;
 use serde_json::Value;
 
+/// Embedded Python operation name map
+///
+/// Contains the special-case lookup table mapping PascalCase AWS operation names
+/// to their correct Python snake_case equivalents as used by boto3. Only entries
+/// where botocore's xform_name() differs from the standard convert_case result
+/// are included, keeping the table small.
+#[derive(RustEmbed)]
+#[folder = "target/python-name-map"]
+#[include = "*.json"]
+struct PythonNameMapRaw;
+
+/// Python operation name map manager
+///
+/// Provides a lazily-initialized lookup table for converting AWS PascalCase
+/// operation names to their Python snake_case equivalents. The table is built
+/// at compile time from botocore's xform_name() function and covers all
+/// special cases that the standard snake_case conversion gets wrong.
+pub(crate) struct PythonNameMap;
+
+impl PythonNameMap {
+    /// Look up the Python snake_case method name for a given PascalCase operation name.
+    ///
+    /// Returns `Some(snake_case_name)` if the operation is a special case that botocore
+    /// handles differently from the standard conversion, or `None` if the standard
+    /// convert_case algorithm produces the correct result.
+    pub(crate) fn lookup(operation_name: &str) -> Option<&'static str> {
+        static MAP: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+            let file = PythonNameMapRaw::get("python_operation_name_map.json")
+                .expect("python_operation_name_map.json not found in embedded data");
+            serde_json::from_slice::<HashMap<String, String>>(&file.data)
+                .expect("Failed to parse python_operation_name_map.json")
+        });
+
+        MAP.get(operation_name).map(std::string::String::as_str)
+    }
+
+    /// Look up the PascalCase operation name for a given Python snake_case method name.
+    ///
+    /// This is the reverse lookup used in `Operation::from_call` to convert a
+    /// snake_case method name back to the PascalCase operation name. Returns `None`
+    /// if the name is not a special case (the caller should fall back to
+    /// `to_case(Case::Pascal)`).
+    pub(crate) fn reverse_lookup(snake_name: &str) -> Option<&'static str> {
+        static REVERSE_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+            let file = PythonNameMapRaw::get("python_operation_name_map.json")
+                .expect("python_operation_name_map.json not found in embedded data");
+            let forward: HashMap<String, String> = serde_json::from_slice(&file.data)
+                .expect("Failed to parse python_operation_name_map.json");
+            // Invert: snake_case → PascalCase
+            forward.into_iter().map(|(k, v)| (v, k)).collect()
+        });
+
+        REVERSE_MAP.get(snake_name).map(std::string::String::as_str)
+    }
+}
+
 /// Partitions definition. Map of partition ID to region regex.
 #[derive(Clone, Debug)]
 pub(crate) struct PartitionsDefinition {

--- a/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use crate::{
+    embedded_data::PythonNameMap,
     enrichment::operation_fas_map::{FasContext, FasOperation},
     extraction::SdkMethodCallMetadata,
     service_configuration::ServiceConfiguration,
@@ -83,32 +84,14 @@ impl Operation {
         original_service_name: &str,
         service_cfg: &ServiceConfiguration,
         sdk: SdkType,
-        service_reference_loader: &ServiceReferenceLoader,
     ) -> crate::errors::Result<Self> {
         let service = service_cfg
             .rename_service_service_reference(original_service_name)
             .to_string();
         #[allow(unknown_lints, convert_case_pascal)]
         let name = if sdk == SdkType::Boto3 {
-            // Try to load service reference and look up the boto3 method mapping
-            service_reference_loader
-                .load(&service)
-                .await?
-                .and_then(|service_ref| {
-                    log::debug!("Looking up method {}", call.name);
-                    service_ref
-                        .boto3_method_to_operation
-                        .get(&call.name)
-                        .map(|op| {
-                            log::debug!("got {op:?}");
-                            op.split(':').nth(1).unwrap_or(op).to_string()
-                        })
-                })
-                // Fallback to PascalCase conversion if mapping not found
-                // This should not be reachable, but if for some reason we cannot use the SDF,
-                // we try converting to PascalCase, knowing that this is flawed in some cases:
-                // think `AddRoleToDBInstance` (actual name)
-                //   vs. `AddRoleToDbInstance` (converted name)
+            PythonNameMap::reverse_lookup(&call.name)
+                .map(std::string::ToString::to_string)
                 .unwrap_or_else(|| call.name.to_case(Case::Pascal))
         } else {
             // For non-Boto3 SDKs we use the extracted name as-is
@@ -798,10 +781,7 @@ pub(crate) mod mock_remote_service_reference {
 #[cfg(test)]
 mod location_tests {
     use super::*;
-    use crate::{
-        enrichment::mock_remote_service_reference::setup_mock_server_with_loader_without_operation_to_action_mapping,
-        service_configuration::load_service_configuration, Location,
-    };
+    use crate::{service_configuration::load_service_configuration, Location};
     use std::path::PathBuf;
 
     #[test]
@@ -851,20 +831,12 @@ mod location_tests {
     #[tokio::test]
     async fn test_reason_extracted_with_location() {
         let service_cfg = load_service_configuration().unwrap();
-        let (_, service_reference_loader) =
-            setup_mock_server_with_loader_without_operation_to_action_mapping().await;
         let call = mock_sdk_method_call();
 
         let reason = Reason::new(vec![Arc::new(
-            Operation::from_call(
-                &call,
-                "s3",
-                &service_cfg,
-                SdkType::Boto3,
-                &service_reference_loader,
-            )
-            .await
-            .unwrap(),
+            Operation::from_call(&call, "s3", &service_cfg, SdkType::Boto3)
+                .await
+                .unwrap(),
         )]);
 
         assert_eq!(reason.operations[0].name, "GetObject");
@@ -929,8 +901,6 @@ mod location_tests {
     #[tokio::test]
     async fn test_operation_methods() {
         let service_cfg = load_service_configuration().unwrap();
-        let (_, service_reference_loader) =
-            setup_mock_server_with_loader_without_operation_to_action_mapping().await;
 
         {
             let call = SdkMethodCall {
@@ -938,15 +908,9 @@ mod location_tests {
                 possible_services: vec!["kms".to_string()],
                 metadata: None,
             };
-            let op = Operation::from_call(
-                &call,
-                "kms",
-                &service_cfg,
-                SdkType::Boto3,
-                &service_reference_loader,
-            )
-            .await
-            .unwrap();
+            let op = Operation::from_call(&call, "kms", &service_cfg, SdkType::Boto3)
+                .await
+                .unwrap();
             assert_eq!(op.service_operation_name(), "kms:Decrypt");
             assert_eq!(op.context(), &[]);
         }
@@ -963,15 +927,9 @@ mod location_tests {
                 possible_services: vec!["kms".to_string()],
                 metadata: Some(metadata),
             };
-            let op = Operation::from_call(
-                &call,
-                "kms",
-                &service_cfg,
-                SdkType::Boto3,
-                &service_reference_loader,
-            )
-            .await
-            .unwrap();
+            let op = Operation::from_call(&call, "kms", &service_cfg, SdkType::Boto3)
+                .await
+                .unwrap();
             assert_eq!(op.service_operation_name(), "kms:Decrypt");
             assert_eq!(op.context(), &[]);
         }

--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -191,14 +191,8 @@ impl ResourceMatcher {
         // Store the original service name from parsed_call for use in explanations
         let original_service_name = service_name;
 
-        let initial = Operation::from_call(
-            parsed_call,
-            service_name,
-            &self.service_cfg,
-            self.sdk,
-            service_reference_loader,
-        )
-        .await?;
+        let initial =
+            Operation::from_call(parsed_call, service_name, &self.service_cfg, self.sdk).await?;
 
         log::debug!("Expanded {initial:?}");
         // Use fixed-point algorithm to safely expand FAS operations until no new operations are found

--- a/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
@@ -266,7 +266,7 @@ where
 
 /// represents the top level mapping returned by service reference
 /// to resolve the url for target service
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ServiceReferenceMapping {
     // represents the top level service reference mapping
     pub(crate) service_reference_mapping: HashMap<String, Url>,

--- a/iam-policy-autopilot-policy-generation/src/extraction/go/paginator_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/go/paginator_extractor.rs
@@ -10,8 +10,8 @@ use crate::extraction::shared::{
     ChainedPaginatorCallInfo, PaginatorCallPattern, PaginatorCreationInfo,
 };
 use crate::extraction::{AstWithSourceFile, SdkMethodCall};
+use crate::Location;
 use crate::ServiceModelIndex;
-use crate::{Language, Location};
 use ast_grep_language::Go;
 
 /// Extractor for Go AWS SDK paginator patterns
@@ -43,14 +43,14 @@ impl<'a> GoPaginatorExtractor<'a> {
         let paginators = self.find_paginator_creation_calls(ast);
         for paginator in &paginators {
             let pattern = PaginatorCallPattern::CreationOnly(paginator);
-            synthetic_calls.push(pattern.create_synthetic_call(self.service_index, Language::Go));
+            synthetic_calls.push(pattern.create_synthetic_call(self.service_index));
         }
 
         // Create synthetic calls from chained paginator calls
         let chained_calls = self.find_chained_paginator_calls(ast);
         for chained_call in &chained_calls {
             let pattern = PaginatorCallPattern::Chained(chained_call);
-            synthetic_calls.push(pattern.create_synthetic_call(self.service_index, Language::Go));
+            synthetic_calls.push(pattern.create_synthetic_call(self.service_index));
         }
 
         synthetic_calls
@@ -207,7 +207,7 @@ impl<'a> GoPaginatorExtractor<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::SourceFile;
+    use crate::{Language, SourceFile};
 
     use super::*;
     use crate::extraction::Parameter;

--- a/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
@@ -20,6 +20,9 @@ pub(crate) mod waiter_model;
 
 // Re-export main types for convenience
 pub use engine::Engine;
+// Not part of the stable public API — exposed only for integration tests in tests/.
+#[doc(hidden)]
+pub use sdk_model::ServiceDiscovery;
 pub(crate) use sdk_model::ServiceModelIndex;
 pub(crate) use service_hints::ServiceHintsProcessor;
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/boto3_resources_model.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/boto3_resources_model.rs
@@ -693,14 +693,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_snake_case_conversion() {
-        assert_eq!("GetItem".to_case(Case::Snake), "get_item");
-        assert_eq!("PutItem".to_case(Case::Snake), "put_item");
-        assert_eq!("DeleteObject".to_case(Case::Snake), "delete_object");
-        assert_eq!("CreateBucket".to_case(Case::Snake), "create_bucket");
-    }
-
-    #[test]
     fn test_load_dynamodb_model_from_embedded() {
         let result = Boto3ResourcesModel::load_from_embedded("dynamodb");
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/paginator_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/paginator_extractor.rs
@@ -11,8 +11,8 @@ use crate::extraction::shared::{
     ChainedPaginatorCallInfo, PaginatorCallInfo, PaginatorCallPattern, PaginatorCreationInfo,
 };
 use crate::extraction::{AstWithSourceFile, Parameter, SdkMethodCall};
+use crate::Location;
 use crate::ServiceModelIndex;
-use crate::{Language, Location};
 use ast_grep_language::Python;
 
 /// Extractor for boto3 paginate method patterns
@@ -74,8 +74,7 @@ impl<'a> PaginatorExtractor<'a> {
                     creation: paginator,
                     paginate: paginate_call,
                 };
-                synthetic_calls
-                    .push(pattern.create_synthetic_call(self.service_index, Language::Python));
+                synthetic_calls.push(pattern.create_synthetic_call(self.service_index));
                 matched_paginator_indices.insert(paginator_idx);
             }
         }
@@ -83,16 +82,14 @@ impl<'a> PaginatorExtractor<'a> {
         // Step 5: Handle chained paginator calls
         for chained_call in &chained_calls {
             let pattern = PaginatorCallPattern::Chained(chained_call);
-            synthetic_calls
-                .push(pattern.create_synthetic_call(self.service_index, Language::Python));
+            synthetic_calls.push(pattern.create_synthetic_call(self.service_index));
         }
 
         // Step 6: Handle unmatched get_paginator calls by creating synthetic calls with empty parameters
         for (idx, paginator) in paginators.iter().enumerate() {
             if !matched_paginator_indices.contains(&idx) {
                 let pattern = PaginatorCallPattern::CreationOnly(paginator);
-                synthetic_calls
-                    .push(pattern.create_synthetic_call(self.service_index, Language::Python));
+                synthetic_calls.push(pattern.create_synthetic_call(self.service_index));
             }
         }
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/sdk_model.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/sdk_model.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinSet;
 use convert_case::{Case, Casing};
 use serde::{Deserialize, Serialize};
 
-use crate::embedded_data::BotocoreData;
+use crate::embedded_data::{BotocoreData, PythonNameMap};
 use crate::errors::{ExtractorError, Result};
 use crate::Language;
 
@@ -152,7 +152,10 @@ pub(crate) struct ServiceMethodRef {
 ///
 /// Provides functionality to discover available services, load service definitions,
 /// and build comprehensive service indexes for method validation.
-pub(crate) struct ServiceDiscovery;
+// Not part of the stable public API. Exposed only so that integration tests in tests/
+// can call operation_to_method_name without duplicating the conversion logic.
+#[doc(hidden)]
+pub struct ServiceDiscovery;
 
 /// Global cache for service model indexes by language
 /// Uses OnceLock for thread-safe lazy initialization
@@ -411,8 +414,12 @@ impl ServiceDiscovery {
     /// - **Python (boto3)**: `PascalCase` → `snake_case` (`GetObject` → `get_object`)
     /// - **TypeScript/JavaScript**: `PascalCase` → camelCase (`GetObject` → getObject)
     /// - **Go**: `PascalCase` unchanged (`GetObject` → `GetObject`)
+    // Not part of the stable public API. Exposed only so that integration tests in tests/
+    // can call this without duplicating the conversion logic (including the PythonNameMap
+    // lookup table built from botocore's xform_name at build time).
+    #[doc(hidden)]
     #[must_use]
-    pub(crate) fn operation_to_method_name(operation_name: &str, language: Language) -> String {
+    pub fn operation_to_method_name(operation_name: &str, language: Language) -> String {
         #[allow(unreachable_patterns)]
         match language {
             Language::Python => {
@@ -435,39 +442,34 @@ impl ServiceDiscovery {
         }
     }
 
-    /// Convert AWS operation names to Python method names with special handling for version suffixes
+    /// Convert AWS operation names to Python method names.
     ///
-    /// This function uses convert_case for the base conversion but fixes AWS-specific patterns
-    /// like "V2", "V3" suffixes that should not have underscores inserted.
+    /// First consults the pre-built lookup table (generated from botocore's xform_name at
+    /// build time) to handle special cases like WhatsApp, iSCSI, HITs, PartiQL operations
+    /// that the standard snake_case algorithm gets wrong. Falls back to the standard
+    /// convert_case algorithm with a fix for AWS version suffixes (V2, V3, etc.).
     ///
     /// Examples:
-    /// - "ListObjectsV2" → "list_objects_v2" (not "list_objects_v_2")
-    /// - "GetObjectV1" → "get_object_v1" (not "get_object_v_1")
-    /// - "CreateBucket" → "create_bucket" (normal cases unchanged)
+    /// - "AssociateWhatsAppBusinessAccount" → "associate_whatsapp_business_account" (lookup table)
+    /// - "CreateCachediSCSIVolume" → "create_cached_iscsi_volume" (lookup table)
+    /// - "ListObjectsV2" → "list_objects_v2" (version suffix fix)
+    /// - "CreateBucket" → "create_bucket" (standard conversion)
     fn aws_python_case_conversion(operation_name: &str) -> String {
-        // First, apply normal snake_case conversion
-        let snake_case = operation_name.to_case(Case::Snake);
-
-        // Fix AWS version suffixes at the end: "_v_N" → "_vN" where N is digits
-        // Only replace if "_v_" is followed by digits and is at the end of string
-        if snake_case.len() >= 4 && snake_case.ends_with(|c: char| c.is_ascii_digit()) {
-            if let Some(v_pos) = snake_case.rfind("_v_") {
-                let after_v = &snake_case[v_pos + 3..];
-                // Check if everything after "_v_" is digits (ensuring it's a version suffix)
-                if after_v.chars().all(|c| c.is_ascii_digit()) {
-                    let prefix = &snake_case[..v_pos];
-                    return format!("{prefix}_v{after_v}");
-                }
-            }
+        // First, consult the lookup table built from botocore's xform_name at build time.
+        // This covers all special cases that the standard algorithm gets wrong.
+        if let Some(python_name) = PythonNameMap::lookup(operation_name) {
+            return python_name.to_string();
         }
 
-        snake_case
+        // Standard snake_case conversion for names not in the lookup table
+        operation_name.to_case(Case::Snake)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_service_info_creation() {
@@ -475,51 +477,6 @@ mod tests {
 
         assert_eq!(service_info.name, "s3");
         assert_eq!(service_info.api_version, "2006-03-01");
-    }
-
-    #[test]
-    fn test_pascal_to_snake_case() {
-        let test_cases = vec![
-            ("GetObject", "get_object"),
-            ("ListBuckets", "list_buckets"),
-            ("CreateBucket", "create_bucket"),
-            ("DeleteObjectTagging", "delete_object_tagging"),
-            ("PutBucketAcl", "put_bucket_acl"),
-            ("S3", "s_3"), // Consecutive uppercase letters (convert_case handles this correctly)
-            ("XMLParser", "xml_parser"), // Multiple consecutive uppercase (convert_case handles this better)
-        ];
-
-        for (input, expected) in test_cases {
-            let result = input.to_case(Case::Snake);
-            assert_eq!(result, expected, "Failed for input: {input}");
-        }
-    }
-
-    #[test]
-    fn test_operation_to_method_name() {
-        // Test Python mapping
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("GetObject", Language::Python),
-            "get_object"
-        );
-
-        // Test JavaScript mapping (PascalCase to match service index)
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("GetObject", Language::JavaScript),
-            "GetObject"
-        );
-
-        // Test TypeScript mapping (PascalCase to match service index)
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("GetObject", Language::TypeScript),
-            "GetObject"
-        );
-
-        // Test Go mapping
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("GetObject", Language::Go),
-            "GetObject"
-        );
     }
 
     #[test]
@@ -607,41 +564,67 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_method_name_conversion() {
-        // Test Python (boto3) method name conversion
+    // Standard Python (boto3) snake_case conversions
+    #[rstest]
+    #[case("GetObject", Language::Python, "get_object")]
+    #[case("ListBuckets", Language::Python, "list_buckets")]
+    #[case("CreateBucket", Language::Python, "create_bucket")]
+    #[case("PutBucketAcl", Language::Python, "put_bucket_acl")]
+    // Version suffix: handled by fallback logic
+    #[case("ListObjectsV2", Language::Python, "list_objects_v2")]
+    // WhatsApp: must stay as one word "whatsapp", not "whats_app"
+    #[case(
+        "AssociateWhatsAppBusinessAccount",
+        Language::Python,
+        "associate_whatsapp_business_account"
+    )]
+    #[case(
+        "GetLinkedWhatsAppBusinessAccount",
+        Language::Python,
+        "get_linked_whatsapp_business_account"
+    )]
+    #[case("SendWhatsAppMessage", Language::Python, "send_whatsapp_message")]
+    // iSCSI: mixed-case acronym must become "iscsi", not "i_scsi"
+    #[case(
+        "CreateCachediSCSIVolume",
+        Language::Python,
+        "create_cached_iscsi_volume"
+    )]
+    #[case(
+        "DescribeCachediSCSIVolumes",
+        Language::Python,
+        "describe_cached_iscsi_volumes"
+    )]
+    // HITs: must become "hits", not "hi_ts"
+    #[case(
+        "ListHITsForQualificationType",
+        Language::Python,
+        "list_hits_for_qualification_type"
+    )]
+    // PartiQL: must become "partiql", not "parti_ql"
+    #[case(
+        "ExecutePartiQLStatement",
+        Language::Python,
+        "execute_partiql_statement"
+    )]
+    #[case(
+        "ExecutePartiQLTransaction",
+        Language::Python,
+        "execute_partiql_transaction"
+    )]
+    // JavaScript/TypeScript/Go: PascalCase passthrough
+    #[case("GetObject", Language::JavaScript, "GetObject")]
+    #[case("GetObject", Language::TypeScript, "GetObject")]
+    #[case("GetObject", Language::Go, "GetObject")]
+    fn test_method_name_conversion(
+        #[case] operation: &str,
+        #[case] language: Language,
+        #[case] expected: &str,
+    ) {
         assert_eq!(
-            ServiceDiscovery::operation_to_method_name("GetObject", Language::Python),
-            "get_object"
+            ServiceDiscovery::operation_to_method_name(operation, language),
+            expected
         );
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("ListBuckets", Language::Python),
-            "list_buckets"
-        );
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("CreateBucket", Language::Python),
-            "create_bucket"
-        );
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("PutBucketAcl", Language::Python),
-            "put_bucket_acl"
-        );
-
-        // Test JavaScript/TypeScript support (PascalCase to match service index)
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("GetObject", Language::JavaScript),
-            "GetObject"
-        );
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("GetObject", Language::TypeScript),
-            "GetObject"
-        );
-        assert_eq!(
-            ServiceDiscovery::operation_to_method_name("GetObject", Language::Go),
-            "GetObject"
-        );
-
-        println!("✓ Method name conversion tests passed");
     }
 
     #[tokio::test]

--- a/iam-policy-autopilot-policy-generation/src/extraction/sdk_model.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/sdk_model.rs
@@ -601,17 +601,6 @@ mod tests {
         Language::Python,
         "list_hits_for_qualification_type"
     )]
-    // PartiQL: must become "partiql", not "parti_ql"
-    #[case(
-        "ExecutePartiQLStatement",
-        Language::Python,
-        "execute_partiql_statement"
-    )]
-    #[case(
-        "ExecutePartiQLTransaction",
-        Language::Python,
-        "execute_partiql_transaction"
-    )]
     // JavaScript/TypeScript/Go: PascalCase passthrough
     #[case("GetObject", Language::JavaScript, "GetObject")]
     #[case("GetObject", Language::TypeScript, "GetObject")]

--- a/iam-policy-autopilot-policy-generation/src/extraction/shared/extraction_utils.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/shared/extraction_utils.rs
@@ -195,14 +195,16 @@ impl<'a> PaginatorCallPattern<'a> {
     pub(crate) fn create_synthetic_call(
         &self,
         service_index: &crate::extraction::sdk_model::ServiceModelIndex,
-        language: crate::Language,
     ) -> crate::extraction::SdkMethodCall {
-        use crate::extraction::sdk_model::ServiceDiscovery;
         use crate::extraction::SdkMethodCallMetadata;
 
-        // Convert operation name to method name using ServiceDiscovery
-        let method_name =
-            ServiceDiscovery::operation_to_method_name(self.operation_name(), language);
+        // The operation_name stored in PaginatorCreationInfo / ChainedPaginatorCallInfo is
+        // already in the language's native method-name format:
+        //   - Python: snake_case as passed to get_paginator() (e.g. "list_objects_v2")
+        //   - Go:     PascalCase as extracted from the constructor name (e.g. "ListObjectsV2")
+        // Both of these are exactly the keys used in service_index.method_lookup, so no
+        // further conversion is needed here.
+        let method_name = self.operation_name().to_string();
 
         // Look up all services that provide this method
         let possible_services =

--- a/iam-policy-autopilot-policy-generation/src/lib.rs
+++ b/iam-policy-autopilot-policy-generation/src/lib.rs
@@ -36,6 +36,9 @@ use std::path::PathBuf;
 
 pub use enrichment::{Engine as EnrichmentEngine, Explanation};
 pub use extraction::{Engine as ExtractionEngine, ExtractedMethods, SdkMethodCall, SourceFile};
+// Not part of the stable public API — exposed only for integration tests in tests/.
+#[doc(hidden)]
+pub use extraction::ServiceDiscovery;
 pub use policy_generation::{
     Effect, Engine as PolicyGenerationEngine, IamPolicy, PolicyType, PolicyWithMetadata, Statement,
 };

--- a/iam-policy-autopilot-policy-generation/tests/waiters_extraction.rs
+++ b/iam-policy-autopilot-policy-generation/tests/waiters_extraction.rs
@@ -2,6 +2,7 @@ use convert_case::{Case, Casing};
 use iam_policy_autopilot_policy_generation::api::{
     extract_sdk_calls, model::ExtractSdkCallsConfig,
 };
+use iam_policy_autopilot_policy_generation::{Language, ServiceDiscovery};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -134,8 +135,9 @@ impl TestRunner {
         let operation = &self.waiter.operation;
         let waiter_name = &self.waiter.waiter_name;
 
-        // Convert operation to snake_case for Python
-        let waiter_snake = aws_python_case_conversion(waiter_name);
+        // Convert operation to snake_case for Python using the same logic as the implementation
+        let waiter_snake =
+            ServiceDiscovery::operation_to_method_name(waiter_name, Language::Python);
 
         format!(
             r#"import boto3
@@ -160,8 +162,9 @@ def test_waiter_operation():
         let operation = &self.waiter.operation;
         let waiter_name = &self.waiter.waiter_name;
 
-        // Convert operation to snake_case for Python
-        let waiter_snake = aws_python_case_conversion(waiter_name);
+        // Convert operation to snake_case for Python using the same logic as the implementation
+        let waiter_snake =
+            ServiceDiscovery::operation_to_method_name(waiter_name, Language::Python);
 
         // Generate parameter assignments for the wait call using stored parameters
         let mut param_assignments = Vec::new();
@@ -202,8 +205,9 @@ def test_waiter_operation():
         let operation = &self.waiter.operation;
         let waiter_name = &self.waiter.waiter_name;
 
-        // Convert operation to snake_case for Python
-        let waiter_snake = aws_python_case_conversion(waiter_name);
+        // Convert operation to snake_case for Python using the same logic as the implementation
+        let waiter_snake =
+            ServiceDiscovery::operation_to_method_name(waiter_name, Language::Python);
 
         // Generate parameter assignments for the wait call using stored parameters
         let mut param_assignments = Vec::new();
@@ -505,7 +509,10 @@ testWaiterOperation();
             Ok(response) => {
                 // Handle Python's special case with snake_case conversion
                 let expected_operation = if language.to_lowercase() == "python" {
-                    &aws_python_case_conversion(&self.waiter.operation)
+                    &ServiceDiscovery::operation_to_method_name(
+                        &self.waiter.operation,
+                        Language::Python,
+                    )
                 } else {
                     &self.waiter.operation
                 };
@@ -769,48 +776,22 @@ fn generate_python_mock_value_for_shape(shape: &str) -> String {
     }
 }
 
-/// Convert AWS operation names to Python method names with special handling for version suffixes
-///
-/// This function uses convert_case for the base conversion but fixes AWS-specific patterns
-/// like "V2", "V3" suffixes that should not have underscores inserted.
-///
-/// Examples:
-/// - "ListObjectsV2" → "list_objects_v2" (not "list_objects_v_2")
-/// - "GetObjectV1" → "get_object_v1" (not "get_object_v_1")
-/// - "CreateBucket" → "create_bucket" (normal cases unchanged)
-fn aws_python_case_conversion(operation_name: &str) -> String {
-    // First, apply normal snake_case conversion
-    let snake_case = operation_name.to_case(Case::Snake);
-
-    // Fix AWS version suffixes at the end: "_v_N" → "_vN" where N is digits
-    // Only replace if "_v_" is followed by digits and is at the end of string
-    if snake_case.len() >= 4 && snake_case.ends_with(|c: char| c.is_ascii_digit()) {
-        if let Some(v_pos) = snake_case.rfind("_v_") {
-            let after_v = &snake_case[v_pos + 3..];
-            // Check if everything after "_v_" is digits (ensuring it's a version suffix)
-            if after_v.chars().all(|c| c.is_ascii_digit()) {
-                let prefix = &snake_case[..v_pos];
-                return format!("{prefix}_v{after_v}");
-            }
-        }
-    }
-
-    snake_case
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_snake_case_conversion() {
-        assert_eq!(aws_python_case_conversion("HeadBucket"), "head_bucket");
+    fn test_operation_to_method_name() {
         assert_eq!(
-            aws_python_case_conversion("DescribeInstances"),
+            ServiceDiscovery::operation_to_method_name("HeadBucket", Language::Python),
+            "head_bucket"
+        );
+        assert_eq!(
+            ServiceDiscovery::operation_to_method_name("DescribeInstances", Language::Python),
             "describe_instances"
         );
         assert_eq!(
-            aws_python_case_conversion("DescribeDBInstances"),
+            ServiceDiscovery::operation_to_method_name("DescribeDBInstances", Language::Python),
             "describe_db_instances"
         );
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,28 @@
-[build-system]
-requires = ["maturin>=1.10.2,<2.0"]
-build-backend = "maturin"
+[tool.ruff]
+# Only lint our own scripts — exclude git submodules, generated output, and
+# test fixture .py files (these are sample inputs for the Rust extractor tests,
+# not maintained Python code).
+exclude = [
+    "iam-policy-autopilot-policy-generation/resources/config/sdks",
+    "iam-policy-autopilot-cli/tests/resources",
+    "iam-policy-autopilot-mcp-server/tests/test_data",
+    "target",
+]
 
-# Standard Python package metadata
-[project]
-name = "iam-policy-autopilot" # The name it will have on PyPI
-version = "0.1.4"
-description = "An open source Model Context Protocol (MCP) server and command-line tool that helps your AI coding assistants quickly create baseline IAM policies that you can refine as your application evolves, so you can build faster. IAM Policy Autopilot analyzes your application code locally to generate identity-based policies for application roles, enabling faster IAM policy creation and reducing access troubleshooting time. IAM Policy Autopilot supports applications built in Python, Go, and TypeScript."
-readme = "README.md"
-requires-python = ">=3.8"
-license = { file = "LICENSE" }
-keywords = ["rust", "IAM Policy", "AWS"]
+target-version = "py39"
+line-length = 88
 
-[tool.maturin]
-manifest-path = "iam-policy-autopilot-cli/Cargo.toml"
-bindings = "bin"
+[tool.ruff.lint]
+select = [
+    "E4",  # pycodestyle errors
+    "E7",  # pycodestyle errors
+    "E9",  # pycodestyle errors (syntax errors — catches Python version issues at parse time)
+    "F",   # Pyflakes (undefined names, unused imports, etc.)
+    "I",   # isort (import ordering)
+    "UP",  # pyupgrade (modernise syntax, flags redundant constructs)
+    "G",   # flake8-logging-format
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
+[build-system]
+requires = ["maturin>=1.10.2,<2.0"]
+build-backend = "maturin"
+
+# Standard Python package metadata
+[project]
+name = "iam-policy-autopilot" # The name it will have on PyPI
+version = "0.1.4"
+description = "An open source Model Context Protocol (MCP) server and command-line tool that helps your AI coding assistants quickly create baseline IAM policies that you can refine as your application evolves, so you can build faster. IAM Policy Autopilot analyzes your application code locally to generate identity-based policies for application roles, enabling faster IAM policy creation and reducing access troubleshooting time. IAM Policy Autopilot supports applications built in Python, Go, and TypeScript."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { file = "LICENSE" }
+keywords = ["rust", "IAM Policy", "AWS"]
+
+[tool.maturin]
+manifest-path = "iam-policy-autopilot-cli/Cargo.toml"
+bindings = "bin"
+
 [tool.ruff]
 # Only lint our own scripts — exclude git submodules, generated output, and
 # test fixture .py files (these are sample inputs for the Rust extractor tests,


### PR DESCRIPTION
*Issue #, if available:* #123

*Description of changes:*

- Adopt the same snake_case conversion logic that [`botocore`](https://github.com/boto/botocore) uses internally for operation and waiter names
- Run this name-conversion logic at **build time** and embed the resulting map into the binary (we filter out all lookups that don't need the custom logic during build to keep the binary small)
- Use the embedded map for both **forward and reverse lookups** at runtime
- Adds Python **linter/formatter check** ([`ruff`](https://docs.astral.sh/ruff/)) to the GitHub Actions workflow
- Document the new **Python dependency** and **style check** requirements
- Clean up existing **tests**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
