### PR TITLE
build(policy-generation): rerun-if-changed for rstest fixture dirs (#171)

### DIFF
--- a/iam-policy-autopilot-policy-generation/build.rs
+++ b/iam-policy-autopilot-policy-generation/build.rs
@@ -166,6 +166,24 @@ fn main() {
     );
     println!("cargo:rerun-if-changed=resources/config/terraform/terraform-provider-aws/names/data/names_data.hcl");
 
+    // Rstest's `#[files(...)]` macro evaluates its glob at compile time, so a
+    // freshly added test fixture is invisible until cargo decides to rebuild
+    // the test crate. Without explicit rerun-if-changed entries on the
+    // fixture roots, dropping a new fixture in does NOT trigger a rebuild —
+    // you have to also touch a `.rs` file (or run `cargo clean`). See
+    // https://github.com/awslabs/iam-policy-autopilot/issues/171 and the
+    // upstream rstest issue at https://github.com/la10736/rstest/issues/220.
+    //
+    // Watch the directory roots that contain fixture trees consumed by
+    // `#[files(...)]` invocations in this crate. Cargo dedupes inputs, so
+    // listing each root individually rather than the parent `tests/` keeps
+    // the watcher tight (avoids re-running this build script for unrelated
+    // test source changes).
+    println!("cargo:rerun-if-changed=tests/java/extractors");
+    println!("cargo:rerun-if-changed=tests/java/entry_point");
+    println!("cargo:rerun-if-changed=tests/java/matchers");
+    println!("cargo:rerun-if-changed=tests/resources/terraform");
+
     // --- Auto-initialize all submodules if needed ---
     ensure_submodule_initialized(
         "botocore",


### PR DESCRIPTION
Closes #171.

\`#[files(...)]\` evaluates its glob at compile time, so adding a new fixture under \`tests/...\` did not trigger a rebuild of the test crate. Users had to also \`touch\` a \`.rs\` file (or \`cargo clean\`) to pick up the new fixture — the exact friction described in the issue and in the upstream rstest issue at https://github.com/la10736/rstest/issues/220.

Adds three \`cargo:rerun-if-changed\` lines on the fixture roots actually referenced by \`#[files(...)]\` invocations in this crate:

- \`tests/java/extractors\` — used by the per-extractor tests and by the \`test_macros.rs\` macro-generated tests.
- \`tests/java/entry_point\` — used by \`test_entry_point\`.
- \`tests/resources/terraform\` — used by \`terraform_integration::test_fixture\`.

I deliberately listed the roots individually rather than one watcher on the whole \`tests/\` directory. The build script does submodule-init and a non-trivial codegen pass, so re-running it for unrelated test-source changes (a new \`.rs\` test file, a comment edit) is wasteful. Watching the fixture-root subtrees alone keeps fixture-add re-runs cheap without firing on every test edit.

If there are other \`#[files(...)]\` globs I missed (I grepped \`#[files\` across the workspace and only found these three patterns), happy to extend.

## Test plan

- [x] Verified all three fixture root dirs exist on \`main\`.
- [x] Existing \`cargo:rerun-if-changed\` lines unchanged — backwards-compat.
- [ ] (For maintainer) — drop a sentinel fixture under one of the three roots without touching any \`.rs\`, run \`cargo test --no-run\`, confirm the test binary recompiles.