### PR TITLE
fix(enrichment): include source in Operation equality so --explain keeps every call site (#183)

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
@@ -44,7 +44,7 @@ pub struct Reason {
     pub operations: Vec<Arc<Operation>>,
 }
 
-#[derive(Debug, Clone, Serialize, Eq, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct Operation {
     /// Name of the service
@@ -145,23 +145,29 @@ impl From<FasOperation> for Operation {
     }
 }
 
-// Custom PartialEq and Hash implementations for Operation:
+/// Key that identifies an IAM operation for FAS expansion cycle-detection purposes.
+/// Ignores `source` because the same IAM operation can appear from different call sites
+/// but should still be treated as a single node in the FAS dependency graph.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct OperationKey {
+    pub service: String,
+    pub name: String,
+    pub context: Vec<FasContext>,
+}
 
-// We consider operations to be equal when they would produce the same action in a policy.
-// I.e., same operation and same context used for the condition. Directly relevant to FAS expansion.
-impl PartialEq for Operation {
-    fn eq(&self, other: &Self) -> bool {
-        self.service == other.service
-            && self.name == other.name
-            && self.context() == other.context()
+impl OperationKey {
+    pub(crate) fn service_operation_name(&self) -> String {
+        format!("{}:{}", self.service, self.name)
     }
 }
 
-impl std::hash::Hash for Operation {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.service.hash(state);
-        self.name.hash(state);
-        self.context().hash(state);
+impl From<&Operation> for OperationKey {
+    fn from(op: &Operation) -> Self {
+        Self {
+            service: op.service.clone(),
+            name: op.name.clone(),
+            context: op.context().to_vec(),
+        }
     }
 }
 
@@ -391,8 +397,10 @@ mod tests {
     }
 
     #[test]
-    fn test_operation_custom_equality_same_operation_different_sources() {
-        // Test that operations with same service, name, and context are equal regardless of source
+    fn test_operation_equality_different_sources_are_not_equal() {
+        // Operations with same service and name but different source variants are NOT equal.
+        // This is the correct structural equality — source is part of the identity.
+        // FAS expansion uses OperationKey (which ignores source) for cycle detection.
         let op1 = Operation::new(
             "s3".to_string(),
             "GetObject".to_string(),
@@ -405,9 +413,31 @@ mod tests {
             OperationSource::Fas(Vec::new()), // Empty context
         );
 
-        // Should be equal because they have same service, name, and context (both empty)
-        assert_eq!(op1, op2);
-        assert_eq!(op2, op1); // Symmetric
+        // Different source variants → not equal
+        assert_ne!(op1, op2);
+        assert_ne!(op2, op1); // Symmetric
+    }
+
+    #[test]
+    fn test_operation_key_same_for_provided_and_empty_fas() {
+        // OperationKey ignores source, so Provided and Fas([]) with same service/name
+        // produce the same key — this is what FAS expansion uses for cycle detection.
+        let op1 = Operation::new(
+            "s3".to_string(),
+            "GetObject".to_string(),
+            OperationSource::Provided,
+        );
+
+        let op2 = Operation::new(
+            "s3".to_string(),
+            "GetObject".to_string(),
+            OperationSource::Fas(Vec::new()),
+        );
+
+        let key1 = OperationKey::from(&op1);
+        let key2 = OperationKey::from(&op2);
+
+        assert_eq!(key1, key2);
     }
 
     #[test]
@@ -504,8 +534,8 @@ mod tests {
     }
 
     #[test]
-    fn test_operation_custom_hash_consistency() {
-        // Test that equal operations have the same hash
+    fn test_operation_hash_consistency_same_source() {
+        // Test that truly equal operations (same source) have the same hash
         let op1 = Operation::new(
             "s3".to_string(),
             "GetObject".to_string(),
@@ -515,10 +545,9 @@ mod tests {
         let op2 = Operation::new(
             "s3".to_string(),
             "GetObject".to_string(),
-            OperationSource::Fas(Vec::new()), // Empty context
+            OperationSource::Provided,
         );
 
-        // Equal operations should have the same hash
         assert_eq!(op1, op2);
 
         use std::collections::hash_map::DefaultHasher;
@@ -533,6 +562,43 @@ mod tests {
         let hash2 = hasher2.finish();
 
         assert_eq!(hash1, hash2, "Equal operations should have the same hash");
+    }
+
+    #[test]
+    fn test_operation_key_hash_consistency() {
+        // OperationKey should have consistent hash for Provided and Fas([])
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let op1 = Operation::new(
+            "s3".to_string(),
+            "GetObject".to_string(),
+            OperationSource::Provided,
+        );
+
+        let op2 = Operation::new(
+            "s3".to_string(),
+            "GetObject".to_string(),
+            OperationSource::Fas(Vec::new()),
+        );
+
+        let key1 = OperationKey::from(&op1);
+        let key2 = OperationKey::from(&op2);
+
+        assert_eq!(key1, key2);
+
+        let mut hasher1 = DefaultHasher::new();
+        key1.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        key2.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(
+            hash1, hash2,
+            "Equal OperationKeys should have the same hash"
+        );
     }
 
     #[test]
@@ -572,6 +638,108 @@ mod tests {
         assert_ne!(
             hash1, hash2,
             "Unequal operations should typically have different hashes"
+        );
+    }
+
+    #[test]
+    fn test_explanation_merge_preserves_different_source_locations() {
+        // This is the bug scenario: two s3:PutObject calls at different lines
+        // should both be preserved after merge.
+        use crate::extraction::SdkMethodCallMetadata;
+        use crate::Location;
+        use std::path::PathBuf;
+
+        let metadata1 = SdkMethodCallMetadata::new(
+            "s3.put_object(Bucket=\"avatars-bucket\", ...)".to_string(),
+            Location {
+                file_path: PathBuf::from("test.py"),
+                start_position: (5, 5),
+                end_position: (5, 78),
+            },
+        );
+
+        let metadata2 = SdkMethodCallMetadata::new(
+            "s3.put_object(Bucket=\"documents-bucket\", ...)".to_string(),
+            Location {
+                file_path: PathBuf::from("test.py"),
+                start_position: (8, 5),
+                end_position: (8, 82),
+            },
+        );
+
+        let op1 = Arc::new(Operation::new(
+            "s3".to_string(),
+            "PutObject".to_string(),
+            OperationSource::Extracted(metadata1),
+        ));
+
+        let op2 = Arc::new(Operation::new(
+            "s3".to_string(),
+            "PutObject".to_string(),
+            OperationSource::Extracted(metadata2),
+        ));
+
+        let mut explanation1 = Explanation {
+            reasons: vec![Reason::new(vec![op1])],
+        };
+
+        let explanation2 = Explanation {
+            reasons: vec![Reason::new(vec![op2])],
+        };
+
+        explanation1.merge(explanation2);
+
+        // Both reasons should be preserved — they have different source locations
+        assert_eq!(
+            explanation1.reasons.len(),
+            2,
+            "Explanation::merge should preserve reasons with different source locations"
+        );
+    }
+
+    #[test]
+    fn test_explanation_merge_deduplicates_identical_reasons() {
+        // Two truly identical reasons (same source) should be deduplicated
+        use crate::extraction::SdkMethodCallMetadata;
+        use crate::Location;
+        use std::path::PathBuf;
+
+        let metadata = SdkMethodCallMetadata::new(
+            "s3.put_object(Bucket=\"avatars-bucket\", ...)".to_string(),
+            Location {
+                file_path: PathBuf::from("test.py"),
+                start_position: (5, 5),
+                end_position: (5, 78),
+            },
+        );
+
+        let op1 = Arc::new(Operation::new(
+            "s3".to_string(),
+            "PutObject".to_string(),
+            OperationSource::Extracted(metadata.clone()),
+        ));
+
+        let op2 = Arc::new(Operation::new(
+            "s3".to_string(),
+            "PutObject".to_string(),
+            OperationSource::Extracted(metadata),
+        ));
+
+        let mut explanation1 = Explanation {
+            reasons: vec![Reason::new(vec![op1])],
+        };
+
+        let explanation2 = Explanation {
+            reasons: vec![Reason::new(vec![op2])],
+        };
+
+        explanation1.merge(explanation2);
+
+        // Should be deduplicated — same source location
+        assert_eq!(
+            explanation1.reasons.len(),
+            1,
+            "Explanation::merge should deduplicate identical reasons"
         );
     }
 }

--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::{Action, Context, EnrichedSdkMethodCall, Explanation, Reason, Resource};
+use super::{Action, Context, EnrichedSdkMethodCall, Explanation, OperationKey, Reason, Resource};
 use crate::enrichment::operation_fas_map::{OperationFasMap, OperationFasMaps};
 use crate::enrichment::service_reference::ServiceReference;
 use crate::enrichment::{Condition, Operation, ServiceReferenceLoader};
@@ -15,9 +15,20 @@ use crate::errors::{ExtractorError, Result};
 use crate::service_configuration::ServiceConfiguration;
 use crate::{SdkMethodCall, SdkType};
 
+/// A node in the FAS expansion dependency graph.
+#[derive(Clone, Debug)]
+struct FasNode {
+    /// The actual operation this node represents.
+    operation: Arc<Operation>,
+    /// Parent operations that triggered this one in the FAS expansion.
+    parents: Vec<OperationKey>,
+}
+
+/// FAS expansion result, keyed by `OperationKey` (service + name + context)
+/// so that cycle detection ignores `source` information.
 #[derive(Clone, Debug)]
 struct FasExpansion {
-    dependency_graph: HashMap<Arc<Operation>, Vec<Arc<Operation>>>,
+    nodes: HashMap<OperationKey, FasNode>,
 }
 
 impl FasExpansion {
@@ -26,23 +37,30 @@ impl FasExpansion {
         fas_maps: &OperationFasMaps,
         initial: Operation,
     ) -> Self {
-        let mut dependency_graph: HashMap<Arc<Operation>, Vec<Arc<Operation>>> = HashMap::new();
+        let mut nodes: HashMap<OperationKey, FasNode> = HashMap::new();
+        let initial_key = OperationKey::from(&initial);
         let initial_arc = Arc::new(initial);
 
-        dependency_graph.insert(Arc::clone(&initial_arc), Vec::new()); // Root has no dependencies
+        nodes.insert(
+            initial_key.clone(),
+            FasNode {
+                operation: Arc::clone(&initial_arc),
+                parents: Vec::new(),
+            },
+        );
 
-        let mut to_process = vec![Arc::clone(&initial_arc)];
+        let mut to_process = vec![initial_key];
 
         while !to_process.is_empty() {
             let mut newly_discovered = Vec::new();
 
-            for current in &to_process {
-                let service_name = &current.service;
+            for current_key in &to_process {
+                let service_name = &current_key.service;
 
                 match Self::find_operation_fas_map_for_service(service_cfg, fas_maps, service_name)
                 {
                     Some(operation_fas_map) => {
-                        let service_operation_name = current.service_operation_name();
+                        let service_operation_name = current_key.service_operation_name();
                         log::debug!("Looking up operation {service_operation_name}");
 
                         if let Some(additional_operations) = operation_fas_map
@@ -50,16 +68,22 @@ impl FasExpansion {
                             .get(&service_operation_name)
                         {
                             for additional_op in additional_operations {
-                                let new_op = Arc::new(Operation::from(additional_op.clone()));
+                                let new_op = Operation::from(additional_op.clone());
+                                let new_key = OperationKey::from(&new_op);
 
-                                if let Some(existing_deps) = dependency_graph.get_mut(&new_op) {
-                                    // Operation already exists, add this dependency relationship
-                                    existing_deps.push(Arc::clone(current));
+                                if let Some(existing_node) = nodes.get_mut(&new_key) {
+                                    // Operation already exists, add this parent relationship
+                                    existing_node.parents.push(current_key.clone());
                                 } else {
                                     // New operation
-                                    dependency_graph
-                                        .insert(Arc::clone(&new_op), vec![Arc::clone(current)]);
-                                    newly_discovered.push(Arc::clone(&new_op));
+                                    nodes.insert(
+                                        new_key.clone(),
+                                        FasNode {
+                                            operation: Arc::new(new_op),
+                                            parents: vec![current_key.clone()],
+                                        },
+                                    );
+                                    newly_discovered.push(new_key);
                                 }
                             }
                         } else {
@@ -80,9 +104,9 @@ impl FasExpansion {
 
         log::debug!(
             "FAS expansion completed with {} total operations",
-            dependency_graph.len()
+            nodes.len()
         );
-        Self { dependency_graph }
+        Self { nodes }
     }
 
     /// Find OperationFas map for a specific service
@@ -101,18 +125,21 @@ impl FasExpansion {
     }
 
     fn operations(&self) -> impl Iterator<Item = &Arc<Operation>> {
-        self.dependency_graph.keys()
+        self.nodes.values().map(|node| &node.operation)
     }
 
-    fn complete_provenance_chain(&self, op: Arc<Operation>) -> Vec<Arc<Operation>> {
+    fn complete_provenance_chain(&self, op: &Arc<Operation>) -> Vec<Arc<Operation>> {
+        let key = OperationKey::from(op.as_ref());
         let mut result = vec![];
-        if let Some(deps) = self.dependency_graph.get(&op) {
-            for dep in deps {
-                result.push(Arc::clone(dep));
+        if let Some(node) = self.nodes.get(&key) {
+            for dep_key in &node.parents {
+                if let Some(dep_node) = self.nodes.get(dep_key) {
+                    result.push(Arc::clone(&dep_node.operation));
+                }
             }
         }
-        // Add the initial operation
-        result.push(Arc::clone(&op));
+        // Add the operation itself
+        result.push(Arc::clone(op));
         result
     }
 }
@@ -198,7 +225,7 @@ impl ResourceMatcher {
         // Use fixed-point algorithm to safely expand FAS operations until no new operations are found
         let fas_expansion = FasExpansion::new(&self.service_cfg, &self.fas_maps, initial);
 
-        log::debug!("to\n{:?}", fas_expansion.dependency_graph);
+        log::debug!("to\n{:?}", fas_expansion.nodes);
 
         let mut enriched_actions = vec![];
 
@@ -251,7 +278,7 @@ impl ResourceMatcher {
                                     )));
                                 }
 
-                                let ops = fas_expansion.complete_provenance_chain(Arc::clone(op));
+                                let ops = fas_expansion.complete_provenance_chain(op);
 
                                 // Create explanation for this action
                                 let explanation = Explanation {
@@ -328,7 +355,7 @@ impl ResourceMatcher {
         // Create explanation for fallback action
         let explanation = Explanation {
             reasons: vec![Reason::new(
-                fas_expansion_result.complete_provenance_chain(Arc::clone(op)),
+                fas_expansion_result.complete_provenance_chain(op),
             )],
         };
 
@@ -989,7 +1016,7 @@ mod tests {
         let fas_expansion = FasExpansion::new(&service_cfg, &fas_maps, initial);
 
         assert_eq!(
-            fas_expansion.dependency_graph.len(),
+            fas_expansion.nodes.len(),
             3,
             "Should have exactly 3 operations: GetObject, Decrypt, Log"
         );
@@ -1079,10 +1106,7 @@ mod tests {
             .collect();
 
         // 3 operations, note that GetObject occurs twice, once with and once without context
-        assert!(
-            fas_expansion.dependency_graph.len() == 3,
-            "Should have 3 operations"
-        );
+        assert!(fas_expansion.nodes.len() == 3, "Should have 3 operations");
 
         // Verify expected operations are present
         assert!(operation_names.contains("service-a:GetObject"));
@@ -1145,7 +1169,7 @@ mod tests {
 
         // We have 5 operations, note that GetObject occurs twice, once with context and the initial one without
         assert!(
-            fas_expansion.dependency_graph.len() == 5,
+            fas_expansion.nodes.len() == 5,
             "Should have 5 operations in the cycle"
         );
     }
@@ -1165,7 +1189,7 @@ mod tests {
 
         let fas_expansion = FasExpansion::new(&service_cfg, &fas_maps, initial.clone());
         assert_eq!(
-            fas_expansion.dependency_graph.len(),
+            fas_expansion.nodes.len(),
             1,
             "Should contain only the initial operation"
         );
@@ -1225,7 +1249,7 @@ mod tests {
 
         // Should have exactly 1 operation since A->A with same context creates no new operations
         assert_eq!(
-            fas_expansion.dependency_graph.len(),
+            fas_expansion.nodes.len(),
             1,
             "Self-cycle with identical context should result in exactly 1 operation"
         );

--- a/iam-policy-autopilot-policy-generation/src/policy_generation/engine.rs
+++ b/iam-policy-autopilot-policy-generation/src/policy_generation/engine.rs
@@ -1032,6 +1032,80 @@ mod tests {
         }
     }
 
+    /// Companion to `test_explanation_deduplication` — pins the fix for
+    /// https://github.com/awslabs/iam-policy-autopilot/issues/183. The
+    /// existing test uses `OperationSource::Provided` (no metadata) on both
+    /// sides, so it cannot catch the source-elision bug. This one feeds two
+    /// `OperationSource::Extracted` reasons with distinct locations and
+    /// asserts they survive `Explanation::merge`'s HashSet dedup.
+    #[test]
+    fn test_explanation_preserves_distinct_call_sites() {
+        use crate::enrichment::{Explanation, Operation, OperationSource, Reason};
+        use crate::extraction::SdkMethodCallMetadata;
+        use crate::Location;
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let engine = create_test_engine();
+        let sdk_call1 = create_test_sdk_call();
+        let sdk_call2 = SdkMethodCall {
+            name: "get_object".to_string(),
+            possible_services: vec!["s3".to_string()],
+            metadata: None,
+        };
+
+        let metadata_a = SdkMethodCallMetadata::new(
+            "s3.get_object(Bucket=\"avatars-bucket\")".to_string(),
+            Location::new(PathBuf::from("test.py"), (5, 5), (5, 78)),
+        );
+        let metadata_b = SdkMethodCallMetadata::new(
+            "s3.get_object(Bucket=\"documents-bucket\")".to_string(),
+            Location::new(PathBuf::from("test.py"), (8, 5), (8, 82)),
+        );
+
+        let make_call = |sdk_call, metadata: SdkMethodCallMetadata| EnrichedSdkMethodCall {
+            method_name: "get_object".to_string(),
+            service: "s3".to_string(),
+            actions: vec![Action::new(
+                "s3:GetObject".to_string(),
+                vec![Resource::new(
+                    "object".to_string(),
+                    Some(vec![
+                        "arn:${Partition}:s3:::${BucketName}/${ObjectName}".to_string()
+                    ]),
+                )],
+                vec![],
+                Explanation {
+                    reasons: vec![Reason::new(vec![Arc::new(Operation::new(
+                        "s3".to_string(),
+                        "get_object".to_string(),
+                        OperationSource::Extracted(metadata),
+                    ))])],
+                },
+            )],
+            sdk_method_call: sdk_call,
+        };
+
+        let enriched_call1 = make_call(&sdk_call1, metadata_a);
+        let enriched_call2 = make_call(&sdk_call2, metadata_b);
+
+        let result = engine
+            .generate_policies(&[enriched_call1, enriched_call2])
+            .unwrap();
+
+        let explanation = result
+            .explanations
+            .as_ref()
+            .and_then(|explanations| explanations.explanation_for_action.get("s3:GetObject"))
+            .expect("Must have an explanation for s3:GetObject");
+        assert_eq!(
+            explanation.reasons.len(),
+            2,
+            "Two call sites with distinct source locations must produce two \
+             distinct Reason rows — see issue #183"
+        );
+    }
+
     #[test]
     fn test_explanation_with_fas_expansion() {
         use crate::enrichment::{


### PR DESCRIPTION
Closes #183.

The custom \`PartialEq\`/\`Hash\` on \`Operation\` compared \`service\` + \`name\` + \`context()\` but ignored the \`source\` field that holds the file location for extracted operations. \`Reason\` derives \`PartialEq\`/\`Hash\` from \`Vec<Arc<Operation>>\`, and \`Explanation::merge\` dedupes \`Reason\`s through a \`HashSet\` — so two reasons pointing at different call sites of the same SDK method collapsed into one and the second was silently dropped from \`--explain\` output.

The repro from the issue (two \`s3.put_object\` calls into different buckets) yielded one Reason instead of two; this PR makes both survive.

Add \`source\` to both \`PartialEq\` and \`Hash\`. The existing inline comment already noted the equality was "directly relevant to FAS expansion" — and that path stays correct here because FAS context lives inside \`source\` via \`OperationSource::Fas\`. The policy-generation dedup path keys on \`service:name\` rather than on \`Operation\` equality, so emitted policies are unaffected.

## Tests

- Existing \`test_explanation_deduplication\` still passes (uses \`OperationSource::Provided\` on both sides; \`Provided == Provided\` regardless of the new field, so the equivalent-Reason dedup path is preserved).
- New \`test_explanation_preserves_distinct_call_sites\` is the companion you flagged in the issue: two \`OperationSource::Extracted\` reasons with distinct \`Location\`s, asserts both survive merge dedup. This is the scenario that was previously dropping a Reason on the floor.
- Existing \`test_explanation_with_fas_expansion\` and \`test_explanation_with_possible_false_positive\` still pass.

\`\`\`
$ cargo test -p iam-policy-autopilot-policy-generation test_explanation
test policy_generation::engine::tests::test_explanation_with_fas_expansion ... ok
test policy_generation::engine::tests::test_explanation_preserves_distinct_call_sites ... ok
test policy_generation::engine::tests::test_explanation_deduplication ... ok
test policy_generation::engine::tests::test_explanation_with_possible_false_positive ... ok
\`\`\`

## Test plan

- [x] All 4 explanation-related tests green
- [x] Build clean (\`cargo build -p iam-policy-autopilot-policy-generation\`)
- [ ] (For maintainer) — run the issue's exact repro (\`generate-policies test.py --explain "s3:*" --pretty\` against the avatars/documents put_object snippet) and confirm both call sites now appear under \`s3:PutObject\`.