### PR TITLE
feat: support namespace imports in TypeScript/JavaScript

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/extractor.rs
@@ -524,4 +524,212 @@ const command = new GetObjectCommand({ Bucket: 'test', Key: 'test.txt' });
             _ => panic!("Should return JavaScript result"),
         }
     }
+
+    #[tokio::test]
+    async fn test_wildcard_import_command_extraction() {
+        let extractor = JavaScriptExtractor::new();
+        let source_code = r#"
+import * as S3 from "@aws-sdk/client-s3";
+
+const client = new S3.S3Client({ region: "us-east-1" });
+
+async function createBucket() {
+    const command = new S3.CreateBucketCommand({ Bucket: "my-bucket" });
+    await client.send(command);
+}
+        "#;
+
+        let result = extractor.parse(&create_source_file(source_code)).await;
+        let method_calls = result.method_calls_ref();
+
+        // Should find CreateBucket operation from namespace-prefixed command
+        assert!(
+            !method_calls.is_empty(),
+            "Should find operations from wildcard import"
+        );
+
+        let create_bucket_op = method_calls
+            .iter()
+            .find(|call| call.name == "CreateBucket")
+            .expect("Should find CreateBucket operation from S3.CreateBucketCommand");
+
+        // Should be associated with s3 service
+        assert_eq!(
+            create_bucket_op.possible_services,
+            vec!["s3"],
+            "Should associate with s3 service"
+        );
+
+        println!("✅ Wildcard import command extraction works!");
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_import_waiter_extraction() {
+        let extractor = JavaScriptExtractor::new();
+        let source_code = r#"
+import * as S3 from "@aws-sdk/client-s3";
+
+const client = new S3.S3Client({ region: "us-east-1" });
+
+async function waitForBucket() {
+    await S3.waitUntilBucketExists(
+        { client, maxWaitTime: 300 },
+        { Bucket: "my-bucket" }
+    );
+}
+        "#;
+
+        let result = extractor.parse(&create_source_file(source_code)).await;
+        let method_calls = result.method_calls_ref();
+
+        // Should find waiter operation from namespace-prefixed waiter
+        assert!(
+            !method_calls.is_empty(),
+            "Should find waiter from wildcard import"
+        );
+
+        // The waiter name "BucketExists" will be resolved to actual operation in filter_map
+        let waiter_call = method_calls
+            .iter()
+            .find(|call| call.name == "BucketExists")
+            .expect("Should find BucketExists waiter from S3.waitUntilBucketExists");
+
+        // Should be associated with s3 service
+        assert_eq!(
+            waiter_call.possible_services,
+            vec!["s3"],
+            "Should associate with s3 service"
+        );
+
+        println!("✅ Wildcard import waiter extraction works!");
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_import_paginator_extraction() {
+        let extractor = JavaScriptExtractor::new();
+        let source_code = r#"
+import * as S3 from "@aws-sdk/client-s3";
+
+const client = new S3.S3Client({ region: "us-east-1" });
+
+async function listAllObjects() {
+    const paginator = S3.paginateListObjectsV2(
+        { client },
+        { Bucket: "my-bucket" }
+    );
+    
+    for await (const page of paginator) {
+        console.log(page.Contents);
+    }
+}
+        "#;
+
+        let result = extractor.parse(&create_source_file(source_code)).await;
+        let method_calls = result.method_calls_ref();
+
+        // Should find paginator operation from namespace-prefixed paginator
+        assert!(
+            !method_calls.is_empty(),
+            "Should find paginator from wildcard import"
+        );
+
+        let list_op = method_calls
+            .iter()
+            .find(|call| call.name == "ListObjectsV2")
+            .expect("Should find ListObjectsV2 operation from S3.paginateListObjectsV2");
+
+        // Should be associated with s3 service
+        assert_eq!(
+            list_op.possible_services,
+            vec!["s3"],
+            "Should associate with s3 service"
+        );
+
+        println!("✅ Wildcard import paginator extraction works!");
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_import_multiple_services() {
+        let extractor = JavaScriptExtractor::new();
+        let source_code = r#"
+import * as S3 from "@aws-sdk/client-s3";
+import * as DynamoDB from "@aws-sdk/client-dynamodb";
+
+async function multiServiceOperations() {
+    const s3Client = new S3.S3Client({ region: "us-east-1" });
+    const dynamoClient = new DynamoDB.DynamoDBClient({ region: "us-east-1" });
+    
+    const getCommand = new S3.GetObjectCommand({
+        Bucket: "my-bucket",
+        Key: "my-key"
+    });
+    await s3Client.send(getCommand);
+    
+    const queryCommand = new DynamoDB.QueryCommand({
+        TableName: "my-table"
+    });
+    await dynamoClient.send(queryCommand);
+}
+        "#;
+
+        let result = extractor.parse(&create_source_file(source_code)).await;
+        let method_calls = result.method_calls_ref();
+
+        // Should find operations from both services
+        assert!(
+            method_calls.len() >= 2,
+            "Should find operations from multiple wildcard imports"
+        );
+
+        // Check S3 operation
+        let get_object_op = method_calls
+            .iter()
+            .find(|call| call.name == "GetObject")
+            .expect("Should find GetObject from S3");
+        assert_eq!(get_object_op.possible_services, vec!["s3"]);
+
+        // Check DynamoDB operation
+        let query_op = method_calls
+            .iter()
+            .find(|call| call.name == "Query")
+            .expect("Should find Query from DynamoDB");
+        assert_eq!(query_op.possible_services, vec!["dynamodb"]);
+
+        println!("✅ Multiple wildcard imports work correctly!");
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_import_lib_dynamodb_expansion() {
+        let extractor = JavaScriptExtractor::new();
+        // Wildcard import of a lib-* package should expand commands through the mapping
+        let source_code = r#"
+import * as dynamoLib from "@aws-sdk/lib-dynamodb";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+async function putItem() {
+    const command = new dynamoLib.PutCommand({ TableName: "my-table", Item: { id: "1" } });
+    await client.send(command);
+}
+        "#;
+
+        let result = extractor.parse(&create_source_file(source_code)).await;
+        let method_calls = result.method_calls_ref();
+
+        // PutCommand from lib-dynamodb should expand to PutItemCommand -> PutItem
+        let put_item_op = method_calls
+            .iter()
+            .find(|call| call.name == "PutItem")
+            .expect("PutCommand from lib-dynamodb should expand to PutItem operation");
+
+        assert_eq!(put_item_op.possible_services, vec!["dynamodb"]);
+
+        // Verify no double-extraction: should appear exactly once
+        let put_item_count = method_calls
+            .iter()
+            .filter(|call| call.name == "PutItem")
+            .count();
+        assert_eq!(put_item_count, 1, "PutItem should not be double-extracted");
+    }
 }

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/extractor.rs
@@ -598,6 +598,11 @@ async function putItem() {
         #[case] source_code: &str,
         #[case] expected_operations: &[(&str, &str)],
     ) {
+        assert!(
+            !expected_operations.is_empty(),
+            "each test case must assert at least one (service, operation) pair"
+        );
+
         let extractor = JavaScriptExtractor::new();
         let result = extractor.parse(&create_source_file(source_code)).await;
         let method_calls = result.method_calls_ref();

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/extractor.rs
@@ -525,211 +525,100 @@ const command = new GetObjectCommand({ Bucket: 'test', Key: 'test.txt' });
         }
     }
 
-    #[tokio::test]
-    async fn test_wildcard_import_command_extraction() {
-        let extractor = JavaScriptExtractor::new();
-        let source_code = r#"
+    #[rstest::rstest]
+    #[case::namespace_command(
+        r#"
 import * as S3 from "@aws-sdk/client-s3";
-
 const client = new S3.S3Client({ region: "us-east-1" });
-
 async function createBucket() {
     const command = new S3.CreateBucketCommand({ Bucket: "my-bucket" });
     await client.send(command);
 }
-        "#;
-
-        let result = extractor.parse(&create_source_file(source_code)).await;
-        let method_calls = result.method_calls_ref();
-
-        // Should find CreateBucket operation from namespace-prefixed command
-        assert!(
-            !method_calls.is_empty(),
-            "Should find operations from wildcard import"
-        );
-
-        let create_bucket_op = method_calls
-            .iter()
-            .find(|call| call.name == "CreateBucket")
-            .expect("Should find CreateBucket operation from S3.CreateBucketCommand");
-
-        // Should be associated with s3 service
-        assert_eq!(
-            create_bucket_op.possible_services,
-            vec!["s3"],
-            "Should associate with s3 service"
-        );
-
-        println!("✅ Wildcard import command extraction works!");
-    }
-
-    #[tokio::test]
-    async fn test_wildcard_import_waiter_extraction() {
-        let extractor = JavaScriptExtractor::new();
-        let source_code = r#"
+        "#,
+        &[("s3", "CreateBucket")],
+    )]
+    #[case::namespace_waiter(
+        r#"
 import * as S3 from "@aws-sdk/client-s3";
-
 const client = new S3.S3Client({ region: "us-east-1" });
-
 async function waitForBucket() {
     await S3.waitUntilBucketExists(
         { client, maxWaitTime: 300 },
         { Bucket: "my-bucket" }
     );
 }
-        "#;
-
-        let result = extractor.parse(&create_source_file(source_code)).await;
-        let method_calls = result.method_calls_ref();
-
-        // Should find waiter operation from namespace-prefixed waiter
-        assert!(
-            !method_calls.is_empty(),
-            "Should find waiter from wildcard import"
-        );
-
-        // The waiter name "BucketExists" will be resolved to actual operation in filter_map
-        let waiter_call = method_calls
-            .iter()
-            .find(|call| call.name == "BucketExists")
-            .expect("Should find BucketExists waiter from S3.waitUntilBucketExists");
-
-        // Should be associated with s3 service
-        assert_eq!(
-            waiter_call.possible_services,
-            vec!["s3"],
-            "Should associate with s3 service"
-        );
-
-        println!("✅ Wildcard import waiter extraction works!");
-    }
-
-    #[tokio::test]
-    async fn test_wildcard_import_paginator_extraction() {
-        let extractor = JavaScriptExtractor::new();
-        let source_code = r#"
+        "#,
+        &[("s3", "BucketExists")],
+    )]
+    #[case::namespace_paginator(
+        r#"
 import * as S3 from "@aws-sdk/client-s3";
-
 const client = new S3.S3Client({ region: "us-east-1" });
-
 async function listAllObjects() {
     const paginator = S3.paginateListObjectsV2(
         { client },
         { Bucket: "my-bucket" }
     );
-    
     for await (const page of paginator) {
         console.log(page.Contents);
     }
 }
-        "#;
-
-        let result = extractor.parse(&create_source_file(source_code)).await;
-        let method_calls = result.method_calls_ref();
-
-        // Should find paginator operation from namespace-prefixed paginator
-        assert!(
-            !method_calls.is_empty(),
-            "Should find paginator from wildcard import"
-        );
-
-        let list_op = method_calls
-            .iter()
-            .find(|call| call.name == "ListObjectsV2")
-            .expect("Should find ListObjectsV2 operation from S3.paginateListObjectsV2");
-
-        // Should be associated with s3 service
-        assert_eq!(
-            list_op.possible_services,
-            vec!["s3"],
-            "Should associate with s3 service"
-        );
-
-        println!("✅ Wildcard import paginator extraction works!");
-    }
-
-    #[tokio::test]
-    async fn test_wildcard_import_multiple_services() {
-        let extractor = JavaScriptExtractor::new();
-        let source_code = r#"
+        "#,
+        &[("s3", "ListObjectsV2")],
+    )]
+    #[case::multiple_services(
+        r#"
 import * as S3 from "@aws-sdk/client-s3";
 import * as DynamoDB from "@aws-sdk/client-dynamodb";
-
 async function multiServiceOperations() {
     const s3Client = new S3.S3Client({ region: "us-east-1" });
     const dynamoClient = new DynamoDB.DynamoDBClient({ region: "us-east-1" });
-    
-    const getCommand = new S3.GetObjectCommand({
-        Bucket: "my-bucket",
-        Key: "my-key"
-    });
+    const getCommand = new S3.GetObjectCommand({ Bucket: "my-bucket", Key: "my-key" });
     await s3Client.send(getCommand);
-    
-    const queryCommand = new DynamoDB.QueryCommand({
-        TableName: "my-table"
-    });
+    const queryCommand = new DynamoDB.QueryCommand({ TableName: "my-table" });
     await dynamoClient.send(queryCommand);
 }
-        "#;
-
-        let result = extractor.parse(&create_source_file(source_code)).await;
-        let method_calls = result.method_calls_ref();
-
-        // Should find operations from both services
-        assert!(
-            method_calls.len() >= 2,
-            "Should find operations from multiple wildcard imports"
-        );
-
-        // Check S3 operation
-        let get_object_op = method_calls
-            .iter()
-            .find(|call| call.name == "GetObject")
-            .expect("Should find GetObject from S3");
-        assert_eq!(get_object_op.possible_services, vec!["s3"]);
-
-        // Check DynamoDB operation
-        let query_op = method_calls
-            .iter()
-            .find(|call| call.name == "Query")
-            .expect("Should find Query from DynamoDB");
-        assert_eq!(query_op.possible_services, vec!["dynamodb"]);
-
-        println!("✅ Multiple wildcard imports work correctly!");
-    }
-
-    #[tokio::test]
-    async fn test_wildcard_import_lib_dynamodb_expansion() {
-        let extractor = JavaScriptExtractor::new();
-        // Wildcard import of a lib-* package should expand commands through the mapping
-        let source_code = r#"
+        "#,
+        &[("s3", "GetObject"), ("dynamodb", "Query")],
+    )]
+    #[case::lib_dynamodb_expansion(
+        r#"
 import * as dynamoLib from "@aws-sdk/lib-dynamodb";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-
-const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
-
+const client = dynamoLib.DynamoDBDocumentClient.from(new DynamoDBClient({}));
 async function putItem() {
     const command = new dynamoLib.PutCommand({ TableName: "my-table", Item: { id: "1" } });
     await client.send(command);
 }
-        "#;
-
+        "#,
+        &[("dynamodb", "PutItem")],
+    )]
+    #[tokio::test]
+    async fn test_wildcard_import_extraction(
+        #[case] source_code: &str,
+        #[case] expected_operations: &[(&str, &str)],
+    ) {
+        let extractor = JavaScriptExtractor::new();
         let result = extractor.parse(&create_source_file(source_code)).await;
         let method_calls = result.method_calls_ref();
 
-        // PutCommand from lib-dynamodb should expand to PutItemCommand -> PutItem
-        let put_item_op = method_calls
-            .iter()
-            .find(|call| call.name == "PutItem")
-            .expect("PutCommand from lib-dynamodb should expand to PutItem operation");
-
-        assert_eq!(put_item_op.possible_services, vec!["dynamodb"]);
-
-        // Verify no double-extraction: should appear exactly once
-        let put_item_count = method_calls
-            .iter()
-            .filter(|call| call.name == "PutItem")
-            .count();
-        assert_eq!(put_item_count, 1, "PutItem should not be double-extracted");
+        for &(expected_service, expected_op) in expected_operations {
+            let call = method_calls
+                .iter()
+                .find(|c| c.name == expected_op)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "expected operation '{}' not found; got: {:?}",
+                        expected_op,
+                        method_calls.iter().map(|c| &c.name).collect::<Vec<_>>()
+                    )
+                });
+            assert_eq!(
+                call.possible_services,
+                vec![expected_service],
+                "service mismatch for '{}'",
+                expected_op
+            );
+        }
     }
 }

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/scanner.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/scanner.rs
@@ -304,6 +304,105 @@ where
         None
     }
 
+    /// Find namespace-prefixed function/constructor calls matching a pattern.
+    ///
+    /// Returns `(matched_name, CommandUsage)` pairs for each match where the name
+    /// passes the `name_filter`. Parameters are extracted from the argument at
+    /// `param_arg_index` (0-based), or from all arguments if `None`.
+    pub(crate) fn find_namespace_calls(
+        &self,
+        patterns: &[String],
+        name_var: &str,
+        name_filter: &dyn Fn(&str) -> bool,
+        param_arg_index: Option<usize>,
+    ) -> Vec<(String, CommandUsage<'_>)> {
+        use crate::extraction::javascript::argument_extractor::ArgumentExtractor;
+
+        let mut results = Vec::new();
+
+        for pattern in patterns {
+            if let Ok(matches) = self.find_all_matches(pattern) {
+                for node_match in matches {
+                    let location =
+                        Location::from_node(self.ast_grep.source_file.path.clone(), &node_match);
+                    let env = node_match.get_env();
+
+                    if let Some(name_node) = env.get_match(name_var) {
+                        let name = name_node.text().to_string();
+
+                        if name_filter(&name) {
+                            let parameters = match param_arg_index {
+                                Some(idx) => {
+                                    let child = env
+                                        .get_match("ARGS")
+                                        .and_then(|args| args.children().nth(idx));
+                                    ArgumentExtractor::extract_object_parameters(child.as_ref())
+                                }
+                                None => ArgumentExtractor::extract_object_parameters(
+                                    env.get_match("ARGS"),
+                                ),
+                            };
+
+                            results.push((
+                                name,
+                                CommandUsage::new(node_match.text(), location, parameters),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        results
+    }
+
+    /// Find namespace-prefixed Command instantiation (e.g., `new S3.CreateBucketCommand(...)`)
+    pub(crate) fn find_namespace_command_with_args(
+        &self,
+        namespace: &str,
+        command_suffix: &str,
+    ) -> Vec<(String, CommandUsage<'_>)> {
+        let pattern = format!("new {namespace}.$NAME($$$ARGS)");
+        let suffix = command_suffix.to_string();
+        self.find_namespace_calls(
+            &[pattern],
+            "NAME",
+            &|name: &str| name.ends_with(&suffix),
+            None,
+        )
+    }
+
+    /// Find namespace-prefixed paginate function calls (e.g., `S3.paginateListObjectsV2(...)`)
+    pub(crate) fn find_namespace_paginate_with_args(
+        &self,
+        namespace: &str,
+    ) -> Vec<(String, CommandUsage<'_>)> {
+        let pattern = format!("{namespace}.$NAME($$$ARGS)");
+        self.find_namespace_calls(
+            &[pattern],
+            "NAME",
+            &|name: &str| name.starts_with("paginate"),
+            Some(1),
+        )
+    }
+
+    /// Find namespace-prefixed waiter function calls (e.g., `S3.waitUntilBucketExists(...)`)
+    pub(crate) fn find_namespace_waiter_with_args(
+        &self,
+        namespace: &str,
+    ) -> Vec<(String, CommandUsage<'_>)> {
+        let patterns = [
+            format!("await {namespace}.$NAME($$$ARGS)"),
+            format!("{namespace}.$NAME($$$ARGS)"),
+        ];
+        self.find_namespace_calls(
+            &patterns,
+            "NAME",
+            &|name: &str| name.starts_with("waitUntil"),
+            Some(1),
+        )
+    }
+
     /// Scan AWS import/require statements generically
     fn scan_aws_statements(&self, pattern: &str) -> Result<Vec<SublibraryInfo>, String> {
         let mut sublibrary_data: HashMap<String, SublibraryInfo> = HashMap::new();
@@ -354,7 +453,48 @@ where
 
     /// Scan for AWS SDK ES6 imports
     pub(crate) fn scan_aws_imports(&mut self) -> Result<Vec<SublibraryInfo>, String> {
-        self.scan_aws_statements("import $IMPORTS from $MODULE")
+        let mut sublibrary_data: HashMap<String, SublibraryInfo> = HashMap::new();
+
+        // Named imports: import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+        let named_matches = self.find_all_matches("import $IMPORTS from $MODULE")?;
+        self.process_import_matches(named_matches, &mut sublibrary_data)?;
+
+        // Wildcard imports: import * as S3 from '@aws-sdk/client-s3'
+        let wildcard_matches = self.find_all_matches("import * as $NAMESPACE from $MODULE")?;
+        self.process_wildcard_import_matches(wildcard_matches, &mut sublibrary_data);
+
+        Ok(sublibrary_data.into_values().collect())
+    }
+
+    /// Process wildcard import matches and set the namespace on the corresponding SublibraryInfo
+    fn process_wildcard_import_matches(
+        &self,
+        matches: Vec<ast_grep_core::NodeMatch<ast_grep_core::tree_sitter::StrDoc<T>>>,
+        sublibrary_data: &mut HashMap<String, SublibraryInfo>,
+    ) {
+        for node_match in matches {
+            let env = node_match.get_env();
+
+            let module_node = env.get_match("MODULE");
+            let namespace_node = env.get_match("NAMESPACE");
+
+            if let (Some(module_node), Some(namespace_node)) = (module_node, namespace_node) {
+                let module_text_cow = module_node.text();
+                let module_text = module_text_cow.trim_matches('"').trim_matches('\'');
+
+                // Check if it's an AWS SDK statement
+                if let Some(sublibrary) = module_text.strip_prefix("@aws-sdk/") {
+                    let sublibrary = sublibrary.to_string();
+                    let namespace = namespace_node.text().to_string();
+
+                    let sublibrary_info = sublibrary_data
+                        .entry(sublibrary.clone())
+                        .or_insert_with(|| SublibraryInfo::new(sublibrary));
+
+                    sublibrary_info.set_wildcard_namespace(namespace);
+                }
+            }
+        }
     }
 
     /// Scan for AWS SDK CommonJS requires

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/shared.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/shared.rs
@@ -160,6 +160,9 @@ impl ExtractionUtils {
                     continue;
                 };
 
+                let is_lib = sublibrary_info.sublibrary.starts_with("lib-");
+
+                // Named imports (e.g., import { CreateBucketCommand } from '@aws-sdk/client-s3')
                 for import_info in &sublibrary_info.imports {
                     // Check if this is a Command type (ends with "Command")
                     if import_info.original_name.ends_with("Command") {
@@ -170,45 +173,37 @@ impl ExtractionUtils {
                             .unwrap_or_else(|| import_info.into()); // Fallback to import position with no params
 
                         // Check if this needs library expansion (lib-* sublibraries)
-                        let expanded_command_names =
-                            if sublibrary_info.sublibrary.starts_with("lib-") {
-                                // lib-* sublibrary - try to expand using mappings
-                                lib_mappings
-                                    .and_then(|m| m.library_operation_expansions.get(&service))
-                                    .and_then(|lib| lib.get(&import_info.original_name))
-                                    .cloned()
-                                    .unwrap_or_else(|| {
-                                        // No mapping found - use original name as fallback
-                                        log::debug!(
-                                            "No mapping found for {}/{}, using original name",
-                                            service,
-                                            import_info.original_name
-                                        );
-                                        vec![import_info.original_name.clone()]
-                                    })
-                            } else {
-                                // client-* sublibrary - no expansion needed
-                                vec![import_info.original_name.clone()]
-                            };
+                        let expanded = Self::expand_lib_names(
+                            is_lib,
+                            &service,
+                            &import_info.original_name,
+                            lib_mappings,
+                        );
 
                         // Create operations for each expanded command name
-                        for command_name in expanded_command_names {
+                        for command_name in expanded {
                             // Extract operation name by removing "Command" suffix
                             if let Some(operation_name) = command_name.strip_suffix("Command") {
-                                // Keep PascalCase operation name to match service index
-                                // e.g., "PutItem" from "PutItemCommand"
-                                let metadata = SdkMethodCallMetadata::new(
-                                    result.text.to_string(),
-                                    result.location.clone(),
-                                )
-                                .with_parameters(result.parameters.clone());
+                                operations.push(Self::build_sdk_method_call(
+                                    operation_name,
+                                    &service,
+                                    &result,
+                                ));
+                            }
+                        }
+                    }
+                }
 
-                                let method_call = SdkMethodCall {
-                                    name: operation_name.to_string(),
-                                    possible_services: vec![service.clone()],
-                                    metadata: Some(metadata),
-                                };
-                                operations.push(method_call);
+                // Wildcard imports (e.g., import * as S3 from '@aws-sdk/client-s3')
+                if let Some(namespace) = &sublibrary_info.wildcard_namespace {
+                    for (command_name, usage) in
+                        scanner.find_namespace_command_with_args(namespace, "Command")
+                    {
+                        let expanded =
+                            Self::expand_lib_names(is_lib, &service, &command_name, lib_mappings);
+                        for name in expanded {
+                            if let Some(op) = name.strip_suffix("Command") {
+                                operations.push(Self::build_sdk_method_call(op, &service, &usage));
                             }
                         }
                     }
@@ -240,6 +235,9 @@ impl ExtractionUtils {
                     continue;
                 };
 
+                let is_lib = sublibrary_info.sublibrary.starts_with("lib-");
+
+                // Named imports (e.g., import { paginateListObjectsV2 } from '@aws-sdk/client-s3')
                 for import_info in &sublibrary_info.imports {
                     // Check if this is a paginate function (starts with "paginate")
                     if import_info.original_name.starts_with("paginate") {
@@ -250,54 +248,35 @@ impl ExtractionUtils {
                             .unwrap_or_else(|| import_info.into()); // Fallback to import position with no params
 
                         // Check if this needs library expansion (lib-* sublibraries)
-                        let expanded_paginator_names =
-                            if sublibrary_info.sublibrary.starts_with("lib-") {
-                                // lib-* sublibrary - try to expand using mappings
-                                lib_mappings
-                                    .and_then(|m| m.library_operation_expansions.get(&service))
-                                    .and_then(|lib| lib.get(&import_info.original_name))
-                                    .cloned()
-                                    .unwrap_or_else(|| {
-                                        // No mapping found - use original name as fallback
-                                        log::debug!(
-                                            "No mapping found for {}/{}, using original name",
-                                            service,
-                                            import_info.original_name
-                                        );
-                                        vec![import_info.original_name.clone()]
-                                    })
-                            } else {
-                                // client-* sublibrary - no expansion needed
-                                vec![import_info.original_name.clone()]
-                            };
+                        let expanded = Self::expand_lib_names(
+                            is_lib,
+                            &service,
+                            &import_info.original_name,
+                            lib_mappings,
+                        );
 
                         // Create operations for each expanded paginator
-                        for paginator_name in expanded_paginator_names {
-                            // Extract operation name from expanded name
-                            // Could be "QueryCommand" -> "Query" or "paginateQuery" -> "Query"
-                            let operation_name = if let Some(cmd_name) =
-                                paginator_name.strip_suffix("Command")
-                            {
-                                cmd_name.to_string()
-                            } else if let Some(op_name) = paginator_name.strip_prefix("paginate") {
-                                op_name.to_string()
-                            } else {
-                                paginator_name.clone()
-                            };
+                        for paginator_name in expanded {
+                            let operation_name = Self::strip_paginator_prefix(&paginator_name);
+                            operations.push(Self::build_sdk_method_call(
+                                &operation_name,
+                                &service,
+                                &result,
+                            ));
+                        }
+                    }
+                }
 
-                            // Keep PascalCase operation name to match service index
-                            let metadata = SdkMethodCallMetadata::new(
-                                result.text.to_string(),
-                                result.location.clone(),
-                            )
-                            .with_parameters(result.parameters.clone());
-
-                            let method_call = SdkMethodCall {
-                                name: operation_name,
-                                possible_services: vec![service.clone()],
-                                metadata: Some(metadata),
-                            };
-                            operations.push(method_call);
+                // Wildcard imports (e.g., import * as S3 from '@aws-sdk/client-s3')
+                if let Some(namespace) = &sublibrary_info.wildcard_namespace {
+                    for (paginator_name, usage) in
+                        scanner.find_namespace_paginate_with_args(namespace)
+                    {
+                        let expanded =
+                            Self::expand_lib_names(is_lib, &service, &paginator_name, lib_mappings);
+                        for name in expanded {
+                            let op = Self::strip_paginator_prefix(&name);
+                            operations.push(Self::build_sdk_method_call(&op, &service, &usage));
                         }
                     }
                 }
@@ -329,34 +308,36 @@ impl ExtractionUtils {
                     continue;
                 };
 
+                // Named imports (e.g., import { waitUntilBucketExists } from '@aws-sdk/client-s3')
                 for import_info in &sublibrary_info.imports {
                     // Check if this is a waiter function (starts with "waitUntil")
-                    if import_info.original_name.starts_with("waitUntil") {
-                        // Extract waiter name by removing "waitUntil" prefix
-                        if let Some(waiter_name) =
-                            import_info.original_name.strip_prefix("waitUntil")
-                        {
-                            // Try to find the actual waiter function call with arguments
-                            // Use the local name for the search (handles renames)
-                            let result = scanner
-                                .find_waiter_function_with_args(&import_info.local_name)
-                                .unwrap_or_else(|| import_info.into()); // Fallback to import position with no params
+                    if let Some(waiter_name) = import_info.original_name.strip_prefix("waitUntil") {
+                        // Try to find the actual waiter function call with arguments
+                        // Use the local name for the search (handles renames)
+                        let result = scanner
+                            .find_waiter_function_with_args(&import_info.local_name)
+                            .unwrap_or_else(|| import_info.into()); // Fallback to import position with no params
 
-                            // Keep PascalCase waiter name
-                            // e.g., "BucketExists" from "waitUntilBucketExists"
-                            // This will be resolved to the actual operation (e.g., "HeadBucket") in filter_map
-                            let metadata = SdkMethodCallMetadata::new(
-                                result.text.to_string(),
-                                result.location.clone(),
-                            )
-                            .with_parameters(result.parameters);
+                        // Keep PascalCase waiter name
+                        // e.g., "BucketExists" from "waitUntilBucketExists"
+                        // This will be resolved to the actual operation (e.g., "HeadBucket") in filter_map
+                        operations.push(Self::build_sdk_method_call(
+                            waiter_name,
+                            &service,
+                            &result,
+                        ));
+                    }
+                }
 
-                            let method_call = SdkMethodCall {
-                                name: waiter_name.to_string(),
-                                possible_services: vec![service.clone()],
-                                metadata: Some(metadata),
-                            };
-                            operations.push(method_call);
+                // Wildcard imports (e.g., import * as S3 from '@aws-sdk/client-s3')
+                if let Some(namespace) = &sublibrary_info.wildcard_namespace {
+                    for (waiter_name, usage) in scanner.find_namespace_waiter_with_args(namespace) {
+                        if let Some(waiter_state) = waiter_name.strip_prefix("waitUntil") {
+                            operations.push(Self::build_sdk_method_call(
+                                waiter_state,
+                                &service,
+                                &usage,
+                            ));
                         }
                     }
                 }
@@ -454,6 +435,7 @@ impl ExtractionUtils {
                     continue;
                 };
 
+                // Named imports (e.g., import { Upload } from '@aws-sdk/lib-storage')
                 for import_info in &sublibrary_info.imports {
                     // Skip if already handled by other extractors
                     if Self::is_command_name_pattern(&import_info.original_name) {
@@ -475,18 +457,39 @@ impl ExtractionUtils {
                         for command_name in expanded_commands {
                             // Extract operation name by removing "Command" suffix
                             if let Some(operation_name) = command_name.strip_suffix("Command") {
-                                let metadata = SdkMethodCallMetadata::new(
-                                    result.text.to_string(),
-                                    result.location.clone(),
-                                )
-                                .with_parameters(result.parameters.clone());
+                                operations.push(Self::build_sdk_method_call(
+                                    operation_name,
+                                    &service,
+                                    &result,
+                                ));
+                            }
+                        }
+                    }
+                }
 
-                                let method_call = SdkMethodCall {
-                                    name: operation_name.to_string(),
-                                    possible_services: vec![service.clone()],
-                                    metadata: Some(metadata),
-                                };
-                                operations.push(method_call);
+                // Wildcard imports (e.g., import * as S3Storage from '@aws-sdk/lib-storage')
+                // Handles namespace-prefixed classes like S3Storage.Upload(...)
+                if let Some(namespace) = &sublibrary_info.wildcard_namespace {
+                    let service_mappings = lib_mappings.library_operation_expansions.get(&service);
+
+                    if let Some(service_mappings) = service_mappings {
+                        for (class_name, expanded_commands) in service_mappings {
+                            // Skip classes already handled by command/paginate/waiter extractors
+                            if Self::is_command_name_pattern(class_name) {
+                                continue;
+                            }
+
+                            // Scan for `new NS.ClassName($$$ARGS)`
+                            let usages =
+                                scanner.find_namespace_command_with_args(namespace, class_name);
+                            for (_matched_name, usage) in usages {
+                                for command_name in expanded_commands {
+                                    if let Some(op) = command_name.strip_suffix("Command") {
+                                        operations.push(Self::build_sdk_method_call(
+                                            op, &service, &usage,
+                                        ));
+                                    }
+                                }
                             }
                         }
                     }
@@ -598,6 +601,54 @@ impl ExtractionUtils {
             || name.starts_with("paginate")
             || name.starts_with("waitUntil")
             || name.ends_with("CommandInput")
+    }
+
+    /// Expand a name through lib-* mappings if applicable, or return it as-is for client-* packages.
+    fn expand_lib_names(
+        is_lib: bool,
+        service: &str,
+        name: &str,
+        lib_mappings: Option<&JsV3LibrariesMapping>,
+    ) -> Vec<String> {
+        if is_lib {
+            lib_mappings
+                .and_then(|m| m.library_operation_expansions.get(service))
+                .and_then(|lib| lib.get(name))
+                .cloned()
+                .unwrap_or_else(|| {
+                    log::debug!("No mapping found for {service}/{name}, using original name");
+                    vec![name.to_string()]
+                })
+        } else {
+            vec![name.to_string()]
+        }
+    }
+
+    /// Strip paginator/command prefixes to get the operation name.
+    fn strip_paginator_prefix(name: &str) -> String {
+        if let Some(cmd) = name.strip_suffix("Command") {
+            cmd.to_string()
+        } else if let Some(op) = name.strip_prefix("paginate") {
+            op.to_string()
+        } else {
+            name.to_string()
+        }
+    }
+
+    /// Build an `SdkMethodCall` from a matched operation name, service, and usage site.
+    fn build_sdk_method_call(
+        operation_name: &str,
+        service: &str,
+        usage: &CommandUsage<'_>,
+    ) -> SdkMethodCall {
+        let metadata = SdkMethodCallMetadata::new(usage.text.to_string(), usage.location.clone())
+            .with_parameters(usage.parameters.clone());
+
+        SdkMethodCall {
+            name: operation_name.to_string(),
+            possible_services: vec![service.to_string()],
+            metadata: Some(metadata),
+        }
     }
 }
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/shared.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/shared.rs
@@ -3,6 +3,8 @@
 //! This module contains common functionality shared between JavaScript and TypeScript
 //! extractors.
 
+use std::collections::HashSet;
+
 use crate::extraction::javascript::types::{ImportInfo, JavaScriptScanResults};
 use crate::extraction::{Parameter, ParameterValue, SdkMethodCall, SdkMethodCallMetadata};
 use crate::Location;
@@ -102,6 +104,7 @@ impl ExtractionUtils {
         T: ast_grep_language::LanguageExt,
     {
         let mut method_calls = Vec::new();
+        let mut handled_names = HashSet::new();
 
         // Load library mappings once for reuse across all extraction functions
         let lib_mappings = load_libraries_mapping();
@@ -111,6 +114,7 @@ impl ExtractionUtils {
             scan_results,
             scanner,
             lib_mappings.as_ref(),
+            &mut handled_names,
         ));
 
         // Extract operations from paginate function imports (e.g., paginateQuery -> Query operation)
@@ -118,22 +122,30 @@ impl ExtractionUtils {
             scan_results,
             scanner,
             lib_mappings.as_ref(),
+            &mut handled_names,
         ));
 
         // Extract operations from waiter function imports (e.g., waitUntilBucketExists -> BucketExists waiter)
-        method_calls.extend(Self::extract_waiter_operations(scan_results, scanner));
+        method_calls.extend(Self::extract_waiter_operations(
+            scan_results,
+            scanner,
+            &mut handled_names,
+        ));
 
         // Extract operations from CommandInput imports (e.g., QueryCommandInput -> Query operation)
         method_calls.extend(Self::extract_command_input_operations(
             scan_results,
             scanner,
+            &mut handled_names,
         ));
 
         // Extract operations from generic lib-* class imports (e.g., Upload -> multiple S3 commands)
+        // Uses handled_names to skip names already processed by the extractors above
         method_calls.extend(Self::extract_library_class_operations(
             scan_results,
             scanner,
             lib_mappings.as_ref(),
+            &handled_names,
         ));
 
         method_calls
@@ -144,6 +156,7 @@ impl ExtractionUtils {
         scan_results: &JavaScriptScanResults,
         scanner: &mut crate::extraction::javascript::scanner::ASTScanner<T>,
         lib_mappings: Option<&JsV3LibrariesMapping>,
+        handled_names: &mut HashSet<String>,
     ) -> Vec<SdkMethodCall>
     where
         T: ast_grep_language::LanguageExt,
@@ -166,6 +179,7 @@ impl ExtractionUtils {
                 for import_info in &sublibrary_info.imports {
                     // Check if this is a Command type (ends with "Command")
                     if import_info.original_name.ends_with("Command") {
+                        handled_names.insert(import_info.original_name.clone());
                         // Try to find the actual constructor instantiation with arguments
                         // Use the local name for the search (handles renames)
                         let result = scanner
@@ -199,6 +213,7 @@ impl ExtractionUtils {
                     for (command_name, usage) in
                         scanner.find_namespace_command_with_args(namespace, "Command")
                     {
+                        handled_names.insert(command_name.clone());
                         let expanded =
                             Self::expand_lib_names(is_lib, &service, &command_name, lib_mappings);
                         for name in expanded {
@@ -219,6 +234,7 @@ impl ExtractionUtils {
         scan_results: &JavaScriptScanResults,
         scanner: &mut crate::extraction::javascript::scanner::ASTScanner<T>,
         lib_mappings: Option<&JsV3LibrariesMapping>,
+        handled_names: &mut HashSet<String>,
     ) -> Vec<SdkMethodCall>
     where
         T: ast_grep_language::LanguageExt,
@@ -241,6 +257,7 @@ impl ExtractionUtils {
                 for import_info in &sublibrary_info.imports {
                     // Check if this is a paginate function (starts with "paginate")
                     if import_info.original_name.starts_with("paginate") {
+                        handled_names.insert(import_info.original_name.clone());
                         // Try to find the actual paginate function call with arguments
                         // Use the local name for the search (handles renames)
                         let result = scanner
@@ -255,11 +272,13 @@ impl ExtractionUtils {
                             lib_mappings,
                         );
 
-                        // Create operations for each expanded paginator
-                        for paginator_name in expanded {
-                            let operation_name = Self::strip_paginator_prefix(&paginator_name);
+                        for name in expanded {
+                            let operation_name = name
+                                .strip_suffix("Command")
+                                .or_else(|| name.strip_prefix("paginate"))
+                                .unwrap_or(&name);
                             operations.push(Self::build_sdk_method_call(
-                                &operation_name,
+                                operation_name,
                                 &service,
                                 &result,
                             ));
@@ -272,11 +291,15 @@ impl ExtractionUtils {
                     for (paginator_name, usage) in
                         scanner.find_namespace_paginate_with_args(namespace)
                     {
+                        handled_names.insert(paginator_name.clone());
                         let expanded =
                             Self::expand_lib_names(is_lib, &service, &paginator_name, lib_mappings);
                         for name in expanded {
-                            let op = Self::strip_paginator_prefix(&name);
-                            operations.push(Self::build_sdk_method_call(&op, &service, &usage));
+                            let op = name
+                                .strip_suffix("Command")
+                                .or_else(|| name.strip_prefix("paginate"))
+                                .unwrap_or(&name);
+                            operations.push(Self::build_sdk_method_call(op, &service, &usage));
                         }
                     }
                 }
@@ -292,6 +315,7 @@ impl ExtractionUtils {
     pub(crate) fn extract_waiter_operations<T>(
         scan_results: &JavaScriptScanResults,
         scanner: &mut crate::extraction::javascript::scanner::ASTScanner<T>,
+        handled_names: &mut HashSet<String>,
     ) -> Vec<SdkMethodCall>
     where
         T: ast_grep_language::LanguageExt,
@@ -312,6 +336,7 @@ impl ExtractionUtils {
                 for import_info in &sublibrary_info.imports {
                     // Check if this is a waiter function (starts with "waitUntil")
                     if let Some(waiter_name) = import_info.original_name.strip_prefix("waitUntil") {
+                        handled_names.insert(import_info.original_name.clone());
                         // Try to find the actual waiter function call with arguments
                         // Use the local name for the search (handles renames)
                         let result = scanner
@@ -332,6 +357,7 @@ impl ExtractionUtils {
                 // Wildcard imports (e.g., import * as S3 from '@aws-sdk/client-s3')
                 if let Some(namespace) = &sublibrary_info.wildcard_namespace {
                     for (waiter_name, usage) in scanner.find_namespace_waiter_with_args(namespace) {
+                        handled_names.insert(waiter_name.clone());
                         if let Some(waiter_state) = waiter_name.strip_prefix("waitUntil") {
                             operations.push(Self::build_sdk_method_call(
                                 waiter_state,
@@ -351,6 +377,7 @@ impl ExtractionUtils {
     pub(crate) fn extract_command_input_operations<T>(
         scan_results: &JavaScriptScanResults,
         scanner: &mut crate::extraction::javascript::scanner::ASTScanner<T>,
+        handled_names: &mut HashSet<String>,
     ) -> Vec<SdkMethodCall>
     where
         T: ast_grep_language::LanguageExt,
@@ -370,6 +397,7 @@ impl ExtractionUtils {
                 for import_info in &sublibrary_info.imports {
                     // Check if this is a CommandInput or Input type
                     let operation_name = if import_info.original_name.ends_with("CommandInput") {
+                        handled_names.insert(import_info.original_name.clone());
                         // Extract operation name by removing "CommandInput" suffix
                         import_info.original_name.strip_suffix("CommandInput")
                     } else {
@@ -410,6 +438,7 @@ impl ExtractionUtils {
         scan_results: &JavaScriptScanResults,
         scanner: &mut crate::extraction::javascript::scanner::ASTScanner<T>,
         lib_mappings: Option<&JsV3LibrariesMapping>,
+        handled_names: &HashSet<String>,
     ) -> Vec<SdkMethodCall>
     where
         T: ast_grep_language::LanguageExt,
@@ -437,8 +466,7 @@ impl ExtractionUtils {
 
                 // Named imports (e.g., import { Upload } from '@aws-sdk/lib-storage')
                 for import_info in &sublibrary_info.imports {
-                    // Skip if already handled by other extractors
-                    if Self::is_command_name_pattern(&import_info.original_name) {
+                    if handled_names.contains(&import_info.original_name) {
                         continue;
                     }
 
@@ -474,8 +502,7 @@ impl ExtractionUtils {
 
                     if let Some(service_mappings) = service_mappings {
                         for (class_name, expanded_commands) in service_mappings {
-                            // Skip classes already handled by command/paginate/waiter extractors
-                            if Self::is_command_name_pattern(class_name) {
+                            if handled_names.contains(class_name) {
                                 continue;
                             }
 
@@ -596,13 +623,6 @@ impl ExtractionUtils {
 
     /// Check if a name matches any of the known AWS SDK Command/paginate/waiter/Input patterns
     /// that are handled by other extractors
-    fn is_command_name_pattern(name: &str) -> bool {
-        name.ends_with("Command")
-            || name.starts_with("paginate")
-            || name.starts_with("waitUntil")
-            || name.ends_with("CommandInput")
-    }
-
     /// Expand a name through lib-* mappings if applicable, or return it as-is for client-* packages.
     fn expand_lib_names(
         is_lib: bool,
@@ -621,17 +641,6 @@ impl ExtractionUtils {
                 })
         } else {
             vec![name.to_string()]
-        }
-    }
-
-    /// Strip paginator/command prefixes to get the operation name.
-    fn strip_paginator_prefix(name: &str) -> String {
-        if let Some(cmd) = name.strip_suffix("Command") {
-            cmd.to_string()
-        } else if let Some(op) = name.strip_prefix("paginate") {
-            op.to_string()
-        } else {
-            name.to_string()
         }
     }
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/javascript/types.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/javascript/types.rs
@@ -48,6 +48,8 @@ pub(crate) struct SublibraryInfo {
     pub(crate) imports: Vec<ImportInfo>,
     /// Mapping from local names to original names for quick lookup
     pub(crate) name_mappings: HashMap<String, String>,
+    /// Wildcard import namespace (e.g., "S3" from `import * as S3 from '@aws-sdk/client-s3'`)
+    pub(crate) wildcard_namespace: Option<String>,
 }
 
 impl SublibraryInfo {
@@ -57,6 +59,7 @@ impl SublibraryInfo {
             sublibrary,
             imports: Vec::new(),
             name_mappings: HashMap::new(),
+            wildcard_namespace: None,
         }
     }
 
@@ -67,6 +70,11 @@ impl SublibraryInfo {
             import_info.original_name.clone(),
         );
         self.imports.push(import_info);
+    }
+
+    /// Set the wildcard namespace for this sublibrary
+    pub(crate) fn set_wildcard_namespace(&mut self, namespace: String) {
+        self.wildcard_namespace = Some(namespace);
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* Resolves #95

*Description of changes:*

Adds support for wildcard/namespace import patterns (`import * as S3 from '@aws-sdk/client-s3'`) in the JavaScript/TypeScript extractor. Operations accessed through the namespace prefix are now detected:

- Commands: `new S3.CreateBucketCommand({ Bucket: "my-bucket" })`
- Paginators: `S3.paginateListObjectsV2({ client }, { Bucket: "my-bucket" })`
- Waiters: `await S3.waitUntilBucketExists({ client }, { Bucket: "my-bucket" })`
- Library classes: `new S3Storage.Upload({ client, params })`

Implementation:
- Added `wildcard_namespace` field to `SublibraryInfo` to track namespace aliases
- Extended `scan_aws_imports` to detect `import * as NS from '@aws-sdk/...'` patterns
- Integrated wildcard scanning into existing extractors (`extract_command_operations`, `extract_paginate_operations`, `extract_waiter_operations`, `extract_library_class_operations`)
- Added generic `find_namespace_calls` scanner method using `$$$ARGS` for variadic matching
- Includes lib-* expansion support for the rare case of wildcard-imported library packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
