### PR TITLE
test: fix flaky enrichment tests

### DIFF
--- a/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
@@ -676,8 +676,6 @@ pub(crate) mod mock_remote_service_reference {
 
     pub(crate) async fn setup_mock_server_with_loader() -> (MockServer, RemoteServiceReferenceLoader)
     {
-        // Add small delay to avoid port conflicts in parallel tests
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         let mock_server = MockServer::start().await;
         let mock_server_url = mock_server.uri();
 

--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -435,7 +435,7 @@ mod tests {
 
         let service_cfg = create_test_service_configuration();
 
-        let (_, service_reference_loader) =
+        let (_mock_server, service_reference_loader) =
             mock_remote_service_reference::setup_mock_server_with_loader().await;
 
         let matcher = ResourceMatcher::new(Arc::new(service_cfg), HashMap::new(), SdkType::Boto3);
@@ -577,7 +577,7 @@ mod tests {
             metadata: None,
         };
 
-        let (_, loader) = mock_remote_service_reference::setup_mock_server_with_loader_without_operation_to_action_mapping().await;
+        let (_mock_server, loader) = mock_remote_service_reference::setup_mock_server_with_loader_without_operation_to_action_mapping().await;
 
         let result = matcher.enrich_method_call(&parsed_call, &loader).await;
         assert!(
@@ -855,7 +855,7 @@ mod tests {
             resource_overrides,
         };
 
-        let (_, service_reference_loader) =
+        let (_mock_server, service_reference_loader) =
             mock_remote_service_reference::setup_mock_server_with_loader().await;
 
         let matcher = ResourceMatcher::new(Arc::new(service_cfg), HashMap::new(), SdkType::Boto3);

--- a/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
@@ -572,7 +572,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_functionality() {
-        let (_, loader) = mock_remote_service_reference::setup_mock_server_with_loader().await;
+        let (_mock_server, loader) =
+            mock_remote_service_reference::setup_mock_server_with_loader().await;
 
         let loader = std::sync::Arc::new(loader);
         let mut handles = vec![];
@@ -605,7 +606,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_memory_cache_expiry() {
-        let (_, loader) = mock_remote_service_reference::setup_mock_server_with_loader().await;
+        let (_mock_server, loader) =
+            mock_remote_service_reference::setup_mock_server_with_loader().await;
 
         // Load and cache s3
         let result = loader.load("s3").await;
@@ -736,7 +738,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_filesystem_cache() {
-        let (_, mut loader) = mock_remote_service_reference::setup_mock_server_with_loader().await;
+        let (_mock_server, mut loader) =
+            mock_remote_service_reference::setup_mock_server_with_loader().await;
         // setup_mock_server_with_loader disables file system cache by default
         loader.disable_file_system_cache = false;
         let cache_path = RemoteServiceReferenceLoader::get_cache_path("s3");


### PR DESCRIPTION
*Issue #, if available:* Resolves #141

*Description of changes:*

Fix flaky tests `test_enrich_method_call` and `test_error_for_missing_operation_action_map_when_required` by keeping the `MockServer` alive for the duration of each test.

The root cause was using `let (_, loader) = setup_mock_server_with_loader().await` — in Rust, `_` in a destructuring pattern drops the value immediately at end of statement, unlike `_name` which keeps it alive until end of scope. This caused the mock server to shut down and release its port mid-test. When tests ran concurrently, another test's mock server could bind to the same port, causing the loader to fetch data from the wrong server.

The fix replaces `_` with `_mock_server` in all affected test bindings and removes the ineffective 10ms sleep workaround in `setup_mock_server_with_loader()` that was attempting to paper over this issue. Verified with 50 consecutive full test suite runs, zero failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
