### PR TITLE
chore: upgrade rmcp to 1.6

### DIFF
--- a/iam-policy-autopilot-mcp-server/Cargo.toml
+++ b/iam-policy-autopilot-mcp-server/Cargo.toml
@@ -22,17 +22,16 @@ env_logger.workspace = true
 tokio.workspace = true
 
 axum = "^0.8"
-rmcp = { version = "^0.8" , features = [
+rmcp = { version = "^1.6" , features = [
     "server",
     "macros",
     "client",
-    "transport-sse-server",
     "transport-io",
     "transport-streamable-http-server",
     "auth",
     "elicitation",
     "schemars",
-]}  # Replace with the actual version used
+]}
 
 iam-policy-autopilot-common = { path = "../iam-policy-autopilot-common" }
 iam-policy-autopilot-policy-generation = { path = "../iam-policy-autopilot-policy-generation" }
@@ -44,10 +43,10 @@ iam-policy-autopilot-common = { path = "../iam-policy-autopilot-common" }
 serial_test.workspace = true
 reqwest.workspace = true
 rstest.workspace = true
-rmcp = { version = "^0.8" , features = [
+rmcp = { version = "^1.6" , features = [
     "transport-child-process",
     "transport-streamable-http-client-reqwest",
-]}  # Replace with the actual version used
+]}
 tokio = {version = "^1", features = ["full"]}
 
 [lints]

--- a/iam-policy-autopilot-mcp-server/src/mcp.rs
+++ b/iam-policy-autopilot-mcp-server/src/mcp.rs
@@ -4,7 +4,7 @@ use iam_policy_autopilot_common::telemetry::{
 };
 use log::{error, info, trace};
 use rmcp::{
-    handler::server::{tool::ToolRouter, wrapper::Parameters},
+    handler::server::wrapper::Parameters,
     model::{
         ErrorCode, LoggingLevel, LoggingMessageNotificationParam, ServerCapabilities, ServerInfo,
     },
@@ -22,20 +22,15 @@ use crate::tools::{
     GeneratePolicyForAccessDeniedInput, GeneratePolicyForAccessDeniedOutput,
 };
 
-// Define the server struct
 #[derive(Clone)]
 struct IamAutoPilotMcpServer {
-    tool_router: ToolRouter<Self>,
     log_file: Option<String>,
 }
 
 #[tool_router]
 impl IamAutoPilotMcpServer {
     pub fn new(log_file: Option<String>) -> Self {
-        Self {
-            tool_router: Self::tool_router(),
-            log_file,
-        }
+        Self { log_file }
     }
 
     fn format_mcp_error(&self, msg: &str, e: anyhow::Error) -> McpError {
@@ -161,11 +156,12 @@ impl IamAutoPilotMcpServer {
 #[tool_handler]
 impl ServerHandler for IamAutoPilotMcpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            capabilities: ServerCapabilities::builder()
-            .enable_tools()
-            .build(),
-            instructions: Some("IAM Policy Autopilot specializes in AWS IAM policy generation and access management. \
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+        )
+        .with_instructions("IAM Policy Autopilot specializes in AWS IAM policy generation and access management. \
             \
             **ALWAYS use the generate_application_policies tool when users mention:** \
             - Writing policies, creating policies, generating policies \
@@ -183,9 +179,7 @@ impl ServerHandler for IamAutoPilotMcpServer {
             **CRITICAL: When generating policies, you MUST include ALL relevant source files that interact with AWS services.** \
             \
             **Usage priority:** Use generate_application_policies as the PRIMARY tool for any policy-related requests. \
-            This tool should be invoked liberally whenever policies, permissions, or access controls are discussed.".to_string()),
-                ..Default::default()
-        }
+            This tool should be invoked liberally whenever policies, permissions, or access controls are discussed.")
     }
 
     /// Called after the MCP handshake completes. Sends the telemetry notice

--- a/iam-policy-autopilot-mcp-server/tests/mcp_server_integration_test.rs
+++ b/iam-policy-autopilot-mcp-server/tests/mcp_server_integration_test.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use rmcp::model::InitializeRequestParam;
+use rmcp::model::InitializeRequestParams;
 use rmcp::RoleClient;
 use rmcp::{
-    model::{CallToolRequestParam, ClientCapabilities, ClientInfo, Implementation},
+    model::{CallToolRequestParams, ClientInfo, Implementation},
     service::RunningService,
     transport::{StreamableHttpClientTransport, TokioChildProcess},
     RmcpError, ServiceExt,
@@ -44,7 +44,7 @@ async fn wait_for_server_ready(bind_address: &str, port: u16, max_attempts: u32)
 async fn setup_http_with_bind_address(
     port: u16,
     bind_address: &str,
-) -> (RunningService<RoleClient, InitializeRequestParam>, Child) {
+) -> (RunningService<RoleClient, InitializeRequestParams>, Child) {
     // Start HTTP server as a background process using debug binary
     let mut command = Command::new("../target/debug/iam-policy-autopilot");
     command
@@ -73,24 +73,17 @@ async fn setup_http_with_bind_address(
     // Create HTTP client transport
     let transport =
         StreamableHttpClientTransport::from_uri(format!("http://{bind_address}:{port}/mcp"));
-    let client_info = ClientInfo {
-        protocol_version: Default::default(),
-        capabilities: ClientCapabilities::default(),
-        client_info: Implementation {
-            name: "test http client".to_string(),
-            title: None,
-            version: "0.0.1".to_string(),
-            website_url: None,
-            icons: None,
-        },
-    };
+    let client_info = ClientInfo::new(
+        Default::default(),
+        Implementation::new("test http client", "0.0.1"),
+    );
 
     let client = client_info.serve(transport).await.unwrap();
 
     (client, server_process)
 }
 
-async fn setup_http() -> (RunningService<RoleClient, InitializeRequestParam>, Child) {
+async fn setup_http() -> (RunningService<RoleClient, InitializeRequestParams>, Child) {
     setup_http_with_bind_address(8001, "127.0.0.1").await
 }
 
@@ -132,16 +125,18 @@ async fn test_stdio_generate_policy() {
 
     let client = setup_stdio().await;
     let tool_result = client
-        .call_tool(CallToolRequestParam {
-            name: "generate_application_policies".into(),
-            arguments: json!({
-                "SourceFiles": [test_file],
-                "Region": "us-east-1",
-                "Account": "123456789012"
-            })
-            .as_object()
-            .cloned(),
-        })
+        .call_tool(
+            CallToolRequestParams::new("generate_application_policies").with_arguments(
+                json!({
+                    "SourceFiles": [test_file],
+                    "Region": "us-east-1",
+                    "Account": "123456789012"
+                })
+                .as_object()
+                .cloned()
+                .expect("test arguments should be a valid JSON object"),
+            ),
+        )
         .await
         .unwrap();
 
@@ -152,14 +147,17 @@ async fn test_stdio_generate_policy() {
 async fn test_stdio_generate_policy_for_access_denied() {
     let client = setup_stdio().await;
     let tool_result = client
-        .call_tool(CallToolRequestParam {
-            name: "generate_policy_for_access_denied".into(),
-            arguments: json!({
-                "ErrorMessage": "User: arn:aws:iam::123456789012:user/test-user is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::test-bucket/test-file.txt"
-            })
-            .as_object()
-            .cloned(),
-        })
+        .call_tool(
+            CallToolRequestParams::new("generate_policy_for_access_denied")
+                .with_arguments(
+                    json!({
+                        "ErrorMessage": "User: arn:aws:iam::123456789012:user/test-user is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::test-bucket/test-file.txt"
+                    })
+                    .as_object()
+                    .cloned()
+                    .expect("test arguments should be a valid JSON object"),
+                ),
+        )
         .await
         .unwrap();
 
@@ -211,16 +209,18 @@ async fn test_http_generate_policy() {
 
     let (client, mut server_process) = setup_http_with_bind_address(8002, "127.0.0.1").await;
     let tool_result = client
-        .call_tool(CallToolRequestParam {
-            name: "generate_application_policies".into(),
-            arguments: json!({
-                "SourceFiles": [test_file],
-                "Region": "us-east-1",
-                "Account": "123456789012"
-            })
-            .as_object()
-            .cloned(),
-        })
+        .call_tool(
+            CallToolRequestParams::new("generate_application_policies").with_arguments(
+                json!({
+                    "SourceFiles": [test_file],
+                    "Region": "us-east-1",
+                    "Account": "123456789012"
+                })
+                .as_object()
+                .cloned()
+                .expect("test arguments should be a valid JSON object"),
+            ),
+        )
         .await
         .unwrap();
 
@@ -235,14 +235,17 @@ async fn test_http_generate_policy() {
 async fn test_http_generate_policy_for_access_denied() {
     let (client, mut server_process) = setup_http_with_bind_address(8003, "127.0.0.1").await;
     let tool_result = client
-        .call_tool(CallToolRequestParam {
-            name: "generate_policy_for_access_denied".into(),
-            arguments: json!({
-                "ErrorMessage": "User: arn:aws:iam::123456789012:user/test-user is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::test-bucket/test-file.txt"
-            })
-            .as_object()
-            .cloned(),
-        })
+        .call_tool(
+            CallToolRequestParams::new("generate_policy_for_access_denied")
+                .with_arguments(
+                    json!({
+                        "ErrorMessage": "User: arn:aws:iam::123456789012:user/test-user is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::test-bucket/test-file.txt"
+                    })
+                    .as_object()
+                    .cloned()
+                    .expect("test arguments should be a valid JSON object"),
+                ),
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bumps the version of `rmpc` from `^0.8` to `^1.6` and adapts server and test code to the 1.x API (builder constructors, renamed types, removed deprecated features).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
