### PR TITLE
fix: use user-confirmed policy in `fix_access_denied` MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `fix_access_denied` MCP tool ignoring the user-confirmed policy and applying a regenerated one instead
+
 ## [0.2.1] - 2026-05-08
 
 ### Fixed

--- a/iam-policy-autopilot-mcp-server/src/tools/fix_access_denied.rs
+++ b/iam-policy-autopilot-mcp-server/src/tools/fix_access_denied.rs
@@ -1,8 +1,8 @@
 use crate::tools::policy_autopilot;
 use anyhow::Error;
 use anyhow::{bail, Context};
-use iam_policy_autopilot_access_denied::{ApplyOptions, ApplyResult};
-use log::{debug, error, warn};
+use iam_policy_autopilot_access_denied::{ApplyOptions, ApplyResult, PolicyDocument};
+use log::{error, warn};
 use rmcp::{
     elicit_safe,
     service::{ElicitationError, RequestContext},
@@ -96,14 +96,10 @@ pub async fn fix_access_denied(
     context: RequestContext<RoleServer>,
     input: FixAccessDeniedInput,
 ) -> Result<FixAccessDeniedOutput, Error> {
-    // Parse the error message to extract principal ARN using the plan method
+    // Parse the error message to extract principal information
     let plan = policy_autopilot::plan(&input.error_message)
         .await
-        .context("Failed to generate access denied fix policy from error message")?;
-
-    let policy_str = serde_json::to_string(&plan.policy).context("Failed to serialize policy")?;
-
-    debug!("Generated policy: {policy_str}");
+        .context("Failed to parse access denied error message")?;
 
     // Get confirmation from the user
     let elicit_result = context
@@ -126,14 +122,22 @@ pub async fn fix_access_denied(
         Ok(Some(UserConfirmation(true))) => { /* no-op */ }
         Ok(Some(UserConfirmation(false)) | None) => {
             return Ok(FixAccessDeniedOutput {
-                policy: policy_str,
+                policy: input.access_denied_fix_policy,
                 fix_result: None,
             });
         }
     }
 
+    let user_policy: PolicyDocument = serde_json::from_str(&input.access_denied_fix_policy)
+        .context("Failed to parse user-confirmed policy JSON")?;
+
+    let plan_with_user_policy = iam_policy_autopilot_access_denied::PlanResult {
+        policy: user_policy,
+        ..plan
+    };
+
     let apply = policy_autopilot::apply(
-        &plan,
+        &plan_with_user_policy,
         ApplyOptions {
             skip_confirmation: true,
             skip_tty_check: true,
@@ -143,7 +147,7 @@ pub async fn fix_access_denied(
     .context("Failed to apply access denied fix")?;
 
     Ok(FixAccessDeniedOutput {
-        policy: policy_str,
+        policy: input.access_denied_fix_policy,
         fix_result: Some(FixResult::from(apply)),
     })
 }


### PR DESCRIPTION
*Description of changes:*

The `fix_access_denied` MCP tool receives the policy JSON that was previously generated by `generate_policy_for_access_denied` and shown to the user (`input.access_denied_fix_policy`), but it was never used. Instead, the tool called `plan()` again to regenerate a policy from scratch and applied that. The user confirmed one policy but a potentially different one was applied to AWS.

In practice this has not caused issues because both calls parse the same error message through the same `plan()` function, so they produce semantically identical policies today. The fix corrects the intent: `fix_access_denied` should apply the policy it was given, not regenerate one.

The fix parses `input.access_denied_fix_policy` after the user confirms via elicitation, and passes it to `apply()` instead of the regenerated policy. The `plan()` call is still needed for principal information (who to attach the policy to).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
