### PR TITLE
fix: prevent nightly workflow from running in forks

### DIFF
--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   integration-tests:
+    if: github.repository == 'awslabs/iam-policy-autopilot'
     runs-on: ubuntu-latest
     timeout-minutes: 90   # CDK deploy + multi-language runs can take a while
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Prevent nightly workflow in forks, which don't have the necessary secrets to run it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
