### PR TITLE
chore: remove unused deps, add cargo-machete to CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -188,6 +188,30 @@ jobs:
         with:
           args: "format --check ."
 
+  unused-deps:
+    name: Unused Dependencies (cargo-machete)
+    needs: [changes]
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-machete
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+
+      - name: Check for unused dependencies
+        run: cargo machete
+
   custom-lints:
     name: Custom Lints (dylint)
     needs: [changes]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,8 +2007,6 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "toml",
- "visibility",
  "walkdir",
  "wiremock",
 ]
@@ -2781,7 +2779,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3307,7 +3305,6 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3654,15 +3651,6 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4150,27 +4138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4181,26 +4148,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "winnow 1.0.2",
 ]
@@ -4213,12 +4166,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.2",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4720,17 +4667,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "visibility"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "vsimd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,10 @@ env_logger = "0.11"
 log = "0.4"
 walkdir = "2.5"
 hcl-rs = "0.18"
-toml = "0.8"
 glob = "0.3"
 colored = "2.2"
 indicatif = "0.17"
 regex = "1.12"
-visibility = "0.1"
 
 # Testing utilities
 assert_cmd = "2.2"

--- a/iam-policy-autopilot-policy-generation/Cargo.toml
+++ b/iam-policy-autopilot-policy-generation/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 description = "Core library for IAM permission analysis and AWS SDK method extraction"
 
+[package.metadata.cargo-machete]
+ignored = ["hcl-rs"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
@@ -30,10 +33,7 @@ async-trait.workspace = true
 strsim.workspace = true
 derive-new.workspace = true
 hcl-rs.workspace = true
-toml.workspace = true
 walkdir.workspace = true
-visibility.workspace = true
-
 
 # Build dependencies
 [build-dependencies]

--- a/integration-tests/runner/Cargo.toml
+++ b/integration-tests/runner/Cargo.toml
@@ -24,7 +24,6 @@ serde             = { workspace = true }
 serde_json        = { workspace = true }
 chrono            = { workspace = true }
 anyhow            = { workspace = true }
-thiserror         = { workspace = true }
 tracing           = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 


### PR DESCRIPTION
*Issue #, if available:* #206

*Description of changes:*
- Add `cargo-machete` CI job to PR checks to detect unused dependencies (closes #206)
- Remove unused dependencies: `toml` and `visibility` from `iam-policy-autopilot-policy-generation`, `thiserror` from `integration-tests/runner`
- Remove `toml` and `visibility` from workspace dependencies (no remaining consumers)
- Add `[package.metadata.cargo-machete] ignored = ["hcl-rs"]` to handle the known false positive (crate exports as `hcl`, not `hcl_rs`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
