### PR TITLE
fix: make the filter when to run CI tests less restrictive

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
-      submodules: ${{ steps.filter.outputs.submodules }}
+      config: ${{ steps.filter.outputs.config }}
       python: ${{ steps.filter.outputs.python }}
-      should_test: ${{ steps.filter.outputs.rust == 'true' || steps.filter.outputs.submodules == 'true' }}
+      should_test: ${{ steps.filter.outputs.rust == 'true' || steps.filter.outputs.config == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,10 +30,8 @@ jobs:
               - '**/Cargo.lock'
               - '**/rust-toolchain'
               - '**/.cargo/**'
-            submodules:
-              - 'iam-policy-autopilot-policy-generation/resources/config/sdks/boto3/**'
-              - 'iam-policy-autopilot-policy-generation/resources/config/sdks/botocore-data/**'
-              - 'iam-policy-autopilot-policy-generation/resources/config/terraform/**'
+            config:
+              - 'iam-policy-autopilot-policy-generation/resources/config/**'
             python:
               - 'iam-policy-autopilot-policy-generation/scripts/**/*.py'
               - 'pyproject.toml'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I noticed we were missing a submodule in the filter that determines when to run tests in CI. I made the filter broader to catch any configuration changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
