### PR TITLE
feat: use native certificate store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +740,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -709,6 +748,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -909,6 +957,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-oid"
@@ -1132,6 +1190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1221,20 @@ checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid 0.9.6",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1861,7 +1939,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1934,7 +2011,7 @@ dependencies = [
  "log",
  "quote",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rstest",
  "serde",
  "serde_json",
@@ -1960,7 +2037,7 @@ dependencies = [
  "iam-policy-autopilot-common",
  "iam-policy-autopilot-policy-generation",
  "log",
- "reqwest 0.12.28",
+ "reqwest",
  "rmcp",
  "rstest",
  "schemars",
@@ -1976,6 +2053,7 @@ name = "iam-policy-autopilot-policy-generation"
 version = "0.2.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "ast-grep-config",
  "ast-grep-core",
  "ast-grep-language",
@@ -1987,16 +2065,23 @@ dependencies = [
  "env_logger",
  "git2",
  "hcl-rs",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
  "iam-policy-autopilot-common",
  "iam-policy-autopilot-policy-generation",
  "log",
  "paste",
+ "pem",
  "proptest",
+ "rcgen",
  "regex",
  "relative-path 2.0.1",
- "reqwest 0.12.28",
+ "reqwest",
  "rstest",
  "rust-embed",
+ "rustls 0.23.40",
+ "rustls-pki-types",
  "schemars",
  "serde",
  "serde_json",
@@ -2005,6 +2090,7 @@ dependencies = [
  "test-log",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-test",
  "tokio-util",
  "toml",
@@ -2301,6 +2387,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2632,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2654,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2556,6 +2717,15 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2633,6 +2803,16 @@ name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2836,7 +3016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand 0.9.4",
@@ -2880,6 +3060,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3036,6 +3217,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,13 +3311,14 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -3136,45 +3332,12 @@ dependencies = [
  "quinn",
  "rustls 0.23.40",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3236,7 +3399,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -3365,6 +3528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,8 +3568,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -3425,6 +3597,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3785,6 +3984,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4007,6 +4222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4913,10 +5129,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5338,6 +5554,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5348,6 +5582,16 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ast-grep-config = "0.39"
 ast-grep-core = "0.39"
 schemars = { version = "^1", features = ["derive"] }
 rust-embed = { version = "8.11", features = ["compression", "include-exclude"] }
-reqwest = { version = "0.12.28", features = ["rustls-tls"], default-features = false }
+reqwest = { version = "0.13.3", features = ["rustls"], default-features = false }
 derive-new = "0.7.0"
 
 # Native async runtime and parallel processing

--- a/iam-policy-autopilot-policy-generation/Cargo.toml
+++ b/iam-policy-autopilot-policy-generation/Cargo.toml
@@ -70,6 +70,17 @@ paste.workspace = true
 test-log = "0.2"
 env_logger.workspace = true
 wiremock = "0.6"
+assert_cmd.workspace = true
+# TLS integration test: verifies the HTTP client respects the OS certificate store
+# (corporate CAs trusted via SSL_CERT_FILE) when connecting to the service reference endpoint
+rcgen = "0.14"
+tokio-rustls = "0.26"
+rustls = "0.23"
+rustls-pki-types = "1"
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+pem = "3"
 iam-policy-autopilot-policy-generation = { path = ".", features = ["integ-test"]}
 
 # Documentation configuration

--- a/iam-policy-autopilot-policy-generation/src/enrichment/engine.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/engine.rs
@@ -149,8 +149,8 @@ impl Engine {
                 }
                 Err(e) => {
                     return Err(ExtractorError::enrichment_error(
-                        &method.name,
-                        format!("Failed to enrich method call: {e}"),
+                        method.possible_services.join(", "),
+                        format!("Failed to enrich method call '{}': {e}", method.name),
                     ));
                 }
             }

--- a/iam-policy-autopilot-policy-generation/src/enrichment/engine.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/engine.rs
@@ -149,8 +149,9 @@ impl Engine {
                 }
                 Err(e) => {
                     return Err(ExtractorError::enrichment_error(
-                        method.possible_services.join(", "),
-                        format!("Failed to enrich method call '{}': {e}", method.name),
+                        &method.name,
+                        &method.possible_services,
+                        format!("{e}"),
                     ));
                 }
             }

--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -170,6 +170,7 @@ impl ResourceMatcher {
         if parsed_call.possible_services.is_empty() {
             return Err(ExtractorError::enrichment_error(
                 &parsed_call.name,
+                &parsed_call.possible_services,
                 "No matching services found for method call",
             ));
         }

--- a/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
@@ -440,9 +440,8 @@ impl RemoteServiceReferenceLoader {
             .user_agent(user_agent)
             .build()
             .map_err(|e| ExtractorError::Configuration {
-                message: format!(
-                    "Failed to initialize the HTTP client for the service reference endpoint: {e}"
-                ),
+                message: "Failed to initialize the HTTP client for the service reference endpoint"
+                    .to_string(),
                 source: Some(Box::new(e)),
             })
     }

--- a/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
@@ -286,8 +286,11 @@ fn deserialize_service_reference_mapping(
     for entry in entries {
         let url = Url::parse(&entry.url).map_err(|e| {
             ExtractorError::service_reference_parse_error_with_source(
-                "RemoteServiceReferenceLoaderMappingInitialization",
-                "Failed to parse service reference mapping",
+                &entry.service,
+                format!(
+                    "Failed to parse URL '{}' in service reference mapping",
+                    entry.url
+                ),
                 e,
             )
         })?;
@@ -311,13 +314,18 @@ pub(crate) struct RemoteServiceReferenceLoader {
     disable_file_system_cache: bool,
 }
 
+const DEFAULT_MAPPING_URL: &str = "https://servicereference.us-east-1.amazonaws.com";
+const MAPPING_URL_ENV_VAR: &str = "IAM_POLICY_AUTOPILOT_SERVICE_REFERENCE_URL";
+
 impl RemoteServiceReferenceLoader {
     pub(crate) fn new(disable_file_system_cache: bool) -> crate::errors::Result<Self> {
+        let mapping_url =
+            std::env::var(MAPPING_URL_ENV_VAR).unwrap_or_else(|_| DEFAULT_MAPPING_URL.to_string());
         Ok(Self {
             client: Self::create_client()?,
             service_reference_mapping: OnceCell::new(),
             service_cache: RwLock::new(HashMap::new()),
-            mapping_url: "https://servicereference.us-east-1.amazonaws.com".to_string(),
+            mapping_url,
             disable_file_system_cache,
         })
     }
@@ -361,44 +369,49 @@ impl RemoteServiceReferenceLoader {
                     .get(&self.mapping_url)
                     .send()
                     .await
-                    .map_err(|e| {
-                        ExtractorError::service_reference_parse_error_with_source(
-                            "RemoteServiceReferenceLoaderMappingInitialization",
-                            "Failed to send request".to_string(),
-                            e,
-                        )
+                    .map_err(|e| ExtractorError::Network {
+                        message: format!(
+                            "Failed to connect to the service reference endpoint at '{}'. \
+                             Verify that this URL is reachable from your network \
+                             (e.g. not blocked by a firewall or VPN). \
+                             If you need to route through a proxy, \
+                             set the HTTPS_PROXY environment variable \
+                             (see https://docs.rs/reqwest/latest/reqwest/#proxies)",
+                            self.mapping_url
+                        ),
+                        source: Some(Box::new(e)),
                     })?
                     .error_for_status()
-                    .map_err(|e| {
-                        ExtractorError::service_reference_parse_error_with_source(
-                            "RemoteServiceReferenceLoaderMappingInitialization",
-                            "Failed to fetch mapping".to_string(),
-                            e,
-                        )
+                    .map_err(|e| ExtractorError::Network {
+                        message: format!(
+                            "Service reference endpoint at '{}' returned an error status",
+                            self.mapping_url
+                        ),
+                        source: Some(Box::new(e)),
                     })?
                     .text()
                     .await
-                    .map_err(|e| {
-                        ExtractorError::service_reference_parse_error_with_source(
-                            "RemoteServiceReferenceLoaderMappingInitialization",
-                            "Failed to read response".to_string(),
-                            e,
-                        )
+                    .map_err(|e| ExtractorError::Network {
+                        message: format!(
+                            "Failed to read response body from service reference endpoint at '{}'",
+                            self.mapping_url
+                        ),
+                        source: Some(Box::new(e)),
                     })?;
 
                 let json_value: serde_json::Value =
                     serde_json::from_str(&json_text).map_err(|e| {
                         ExtractorError::service_reference_parse_error_with_source(
-                            "RemoteServiceReferenceLoaderMappingInitialization",
-                            "Failed to parse JSON".to_string(),
+                            &self.mapping_url,
+                            "Failed to parse JSON from service reference endpoint".to_string(),
                             e,
                         )
                     })?;
 
                 let mapping = deserialize_service_reference_mapping(json_value).map_err(|e| {
                     ExtractorError::service_reference_parse_error_with_source(
-                        "RemoteServiceReferenceLoaderMappingInitialization",
-                        "Failed to deserialize mapping".to_string(),
+                        &self.mapping_url,
+                        "Failed to deserialize service reference mapping".to_string(),
                         e,
                     )
                 })?;
@@ -426,12 +439,11 @@ impl RemoteServiceReferenceLoader {
         Client::builder()
             .user_agent(user_agent)
             .build()
-            .map_err(|e| {
-                ExtractorError::service_reference_parse_error_with_source(
-                    "RemoteServiceReferenceLoaderClientInitialization",
-                    "Failed to create service reference client".to_string(),
-                    e,
-                )
+            .map_err(|e| ExtractorError::Configuration {
+                message: format!(
+                    "Failed to initialize the HTTP client for the service reference endpoint: {e}"
+                ),
+                source: Some(Box::new(e)),
             })
     }
 
@@ -953,5 +965,29 @@ mod tests {
         let authorized_action = &operation.authorized_actions[0];
 
         assert!(authorized_action.context.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_network_failure_error_message() {
+        let loader = RemoteServiceReferenceLoader::new(true)
+            .unwrap()
+            .with_mapping_url("http://127.0.0.1:1".to_string());
+
+        let result = loader.load("s3").await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Failed to connect to the service reference endpoint"),
+            "Error should contain connection failure guidance, got: {err}"
+        );
+        assert!(
+            err.contains("http://127.0.0.1:1"),
+            "Error should contain the URL that was attempted, got: {err}"
+        );
+        assert!(
+            err.contains("HTTPS_PROXY"),
+            "Error should mention HTTPS_PROXY env var, got: {err}"
+        );
     }
 }

--- a/iam-policy-autopilot-policy-generation/src/errors/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/errors/mod.rs
@@ -181,10 +181,12 @@ pub enum ExtractorError {
     },
 
     /// General enrichment errors for method call enrichment
-    #[error("Enrichment error for service '{service_name}': {message}")]
+    #[error("Enrichment failed for method '{method_name}' ({services}): {message}")]
     EnrichmentError {
-        /// Service being enriched
-        service_name: String,
+        /// Method name that failed enrichment
+        method_name: String,
+        /// Pre-formatted service label (e.g. "service 's3'" or "services 's3', 'iam'")
+        services: String,
         /// Detailed error message
         message: String,
         /// Optional underlying error
@@ -281,11 +283,19 @@ impl ExtractorError {
 
     /// Create an enrichment error
     pub(crate) fn enrichment_error(
-        service_name: impl Into<String>,
+        method_name: impl Into<String>,
+        services: &[String],
         message: impl Into<String>,
     ) -> Self {
+        let services_label = if services.len() == 1 {
+            format!("service '{}'", services[0])
+        } else {
+            let names: Vec<_> = services.iter().map(|s| format!("'{s}'")).collect();
+            format!("services {}", names.join(", "))
+        };
         Self::EnrichmentError {
-            service_name: service_name.into(),
+            method_name: method_name.into(),
+            services: services_label,
             message: message.into(),
             source: None,
         }

--- a/iam-policy-autopilot-policy-generation/src/errors/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/errors/mod.rs
@@ -60,6 +60,16 @@ pub enum ExtractorError {
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
     },
 
+    /// Network errors for HTTP requests to external endpoints
+    #[error("Network error: {message}")]
+    Network {
+        /// Detailed error message
+        message: String,
+        /// Underlying network error
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+
     /// Input validation errors for user-provided data
     #[error("Validation error: {message}")]
     Validation {

--- a/iam-policy-autopilot-policy-generation/tests/native_cert_store_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/native_cert_store_test.rs
@@ -1,0 +1,277 @@
+//! Integration test verifying that the HTTP client loads trusted CAs from the platform
+//! rather than from a bundle compiled into the binary.
+//!
+//! We use `SSL_CERT_FILE` as a proxy for the OS certificate store in this test.
+//! On Linux, `rustls-platform-verifier` delegates to `rustls-native-certs`, which
+//! honors `SSL_CERT_FILE` / `SSL_CERT_DIR` as overrides for the system cert paths.
+//! A hardcoded bundle (e.g. `webpki-roots`) would ignore these env vars entirely.
+//!
+//! The positive test injects a custom CA via `SSL_CERT_FILE` and verifies the CLI
+//! trusts it. The negative test provides a wrong CA and verifies rejection.
+//! Together they prove that trusted CAs come from `rustls-native-certs` (the platform
+//! mechanism), not from a compiled-in bundle.
+//!
+//! This test only runs on Linux. On other platforms, `rustls-platform-verifier` uses
+//! native APIs directly (CryptoAPI on Windows, Security.framework on macOS) with no
+//! env var override available for testing.
+#![cfg(target_os = "linux")]
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::process::Output;
+use std::sync::Arc;
+
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use rcgen::{BasicConstraints, CertificateParams, IsCa, Issuer, KeyPair};
+use rustls::ServerConfig;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+
+fn mapping_response(server_url: &str) -> String {
+    serde_json::json!([
+        {"service": "s3", "url": format!("{server_url}/s3.json")}
+    ])
+    .to_string()
+}
+
+fn s3_service_reference_response() -> String {
+    serde_json::json!({
+        "Name": "s3",
+        "Actions": [
+            {
+                "Name": "GetObject",
+                "Resources": [{"Name": "object"}],
+                "ActionConditionKeys": []
+            }
+        ],
+        "Resources": [
+            {
+                "Name": "object",
+                "ARNFormats": ["arn:${Partition}:s3:::${BucketName}/${ObjectName}"]
+            }
+        ],
+        "Operations": [
+            {
+                "Name": "GetObject",
+                "AuthorizedActions": [
+                    {"Name": "GetObject", "Service": "s3"}
+                ]
+            }
+        ]
+    })
+    .to_string()
+}
+
+fn generate_ca_and_server_cert(
+    server_name: &str,
+) -> (
+    CertificateDer<'static>,
+    CertificateDer<'static>,
+    PrivateKeyDer<'static>,
+) {
+    let ca_key_pair = KeyPair::generate().unwrap();
+    let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let ca_cert = ca_params.self_signed(&ca_key_pair).unwrap();
+    let ca_issuer = Issuer::from_params(&ca_params, &ca_key_pair);
+
+    let server_key_pair = KeyPair::generate().unwrap();
+    let server_params = CertificateParams::new(vec![server_name.to_string()]).unwrap();
+    let server_cert = server_params
+        .signed_by(&server_key_pair, &ca_issuer)
+        .unwrap();
+
+    let ca_cert_der = CertificateDer::from(ca_cert.der().to_vec());
+    let server_cert_der = CertificateDer::from(server_cert.der().to_vec());
+    let server_key_der =
+        PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(server_key_pair.serialize_der()));
+
+    (ca_cert_der, server_cert_der, server_key_der)
+}
+
+async fn start_tls_server(
+    server_cert: CertificateDer<'static>,
+    server_key: PrivateKeyDer<'static>,
+) -> SocketAddr {
+    let server_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![server_cert], server_key)
+        .unwrap();
+
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server_url = format!("https://localhost:{}", addr.port());
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(_) => continue,
+            };
+            let acceptor = acceptor.clone();
+            let server_url = server_url.clone();
+            tokio::spawn(async move {
+                let Ok(tls_stream) = acceptor.accept(stream).await else {
+                    return;
+                };
+                let io = TokioIo::new(tls_stream);
+                let server_url = server_url.clone();
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(
+                        io,
+                        service_fn(move |req: Request<hyper::body::Incoming>| {
+                            let server_url = server_url.clone();
+                            async move {
+                                let body = if req.uri().path() == "/s3.json" {
+                                    s3_service_reference_response()
+                                } else {
+                                    mapping_response(&server_url)
+                                };
+                                Ok::<_, hyper::Error>(Response::new(Full::new(Bytes::from(body))))
+                            }
+                        }),
+                    )
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Runs the CLI against the given TLS server address with the specified cert env vars.
+/// `ssl_cert_file` controls what the client trusts; `ssl_cert_dir` overrides the system dir.
+async fn run_cli_against_tls_server(
+    addr: SocketAddr,
+    ssl_cert_file: &std::path::Path,
+    ssl_cert_dir: Option<&std::path::Path>,
+) -> Output {
+    let mut py_file = tempfile::NamedTempFile::with_suffix(".py").unwrap();
+    py_file
+        .write_all(
+            b"import boto3\nclient = boto3.client('s3')\nclient.get_object(Bucket='b', Key='k')\n",
+        )
+        .unwrap();
+    py_file.flush().unwrap();
+
+    let cli_bin = assert_cmd::cargo::cargo_bin("iam-policy-autopilot");
+
+    let mut cmd = std::process::Command::new(&cli_bin);
+    cmd.args([
+        "generate-policies",
+        py_file.path().to_str().unwrap(),
+        "--region",
+        "us-east-1",
+        "--account",
+        "123456789012",
+        "--disable-cache",
+    ])
+    .env("SSL_CERT_FILE", ssl_cert_file)
+    .env(
+        "IAM_POLICY_AUTOPILOT_SERVICE_REFERENCE_URL",
+        format!("https://localhost:{}", addr.port()),
+    )
+    .env("DISABLE_IAM_POLICY_AUTOPILOT_TELEMETRY", "true")
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::piped());
+
+    if let Some(dir) = ssl_cert_dir {
+        cmd.env("SSL_CERT_DIR", dir);
+    }
+
+    let child = cmd.spawn().expect("failed to spawn CLI binary");
+
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        tokio::task::spawn_blocking(move || child.wait_with_output().unwrap())
+            .await
+            .unwrap()
+    })
+    .await
+    .expect("CLI timed out after 30s — likely a TLS handshake hang")
+}
+
+/// With the custom CA in `SSL_CERT_FILE`, the CLI should successfully connect
+/// to our TLS server and produce a valid IAM policy.
+#[tokio::test]
+async fn test_native_cert_store_with_cli() {
+    let (ca_cert_der, server_cert_der, server_key_der) = generate_ca_and_server_cert("localhost");
+    let addr = start_tls_server(server_cert_der, server_key_der).await;
+
+    let ca_pem = pem::encode(&pem::Pem::new("CERTIFICATE", ca_cert_der.to_vec()));
+    let mut cert_file = tempfile::NamedTempFile::new().unwrap();
+    cert_file.write_all(ca_pem.as_bytes()).unwrap();
+    cert_file.flush().unwrap();
+
+    let output = run_cli_against_tls_server(addr, cert_file.path(), None).await;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "CLI failed. This likely means the native certificate store is not being respected.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("s3:GetObject"),
+        "Expected policy output with s3:GetObject action.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+/// With the wrong CA in the trust store, the CLI should fail with a certificate error.
+/// This proves the positive test above is meaningful — TLS verification is real.
+#[tokio::test]
+async fn test_native_cert_store_fails_with_wrong_ca() {
+    let (_ca_cert_der, server_cert_der, server_key_der) = generate_ca_and_server_cert("localhost");
+    let addr = start_tls_server(server_cert_der, server_key_der).await;
+
+    // Generate a different CA that did NOT sign the server cert
+    let wrong_ca_key = KeyPair::generate().unwrap();
+    let mut wrong_ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    wrong_ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let wrong_ca_cert = wrong_ca_params.self_signed(&wrong_ca_key).unwrap();
+    let wrong_ca_pem = pem::encode(&pem::Pem::new("CERTIFICATE", wrong_ca_cert.der().to_vec()));
+
+    let mut wrong_cert_file = tempfile::NamedTempFile::new().unwrap();
+    wrong_cert_file.write_all(wrong_ca_pem.as_bytes()).unwrap();
+    wrong_cert_file.flush().unwrap();
+
+    // Use the wrong CA as the only trusted cert, with an empty cert dir
+    // to prevent the system store from being used
+    let empty_cert_dir = tempfile::tempdir().unwrap();
+
+    let output =
+        run_cli_against_tls_server(addr, wrong_cert_file.path(), Some(empty_cert_dir.path())).await;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !output.status.success(),
+        "CLI should have failed with the wrong CA in the trust store.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let url = format!("https://localhost:{}", addr.port());
+    let expected_error = format!(
+        "Error: Enrichment error for service 's3': \
+         Failed to enrich method call 'get_object': \
+         Network error: Failed to connect to the service reference endpoint at '{url}'. \
+         Verify that this URL is reachable from your network \
+         (e.g. not blocked by a firewall or VPN). \
+         If you need to route through a proxy, \
+         set the HTTPS_PROXY environment variable \
+         (see https://docs.rs/reqwest/latest/reqwest/#proxies)"
+    );
+    assert!(
+        stderr.lines().any(|line| line == expected_error),
+        "Expected exact error line in stderr.\nExpected: {expected_error}\nGot: {stderr}"
+    );
+}

--- a/iam-policy-autopilot-policy-generation/tests/native_cert_store_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/native_cert_store_test.rs
@@ -261,8 +261,7 @@ async fn test_native_cert_store_fails_with_wrong_ca() {
 
     let url = format!("https://localhost:{}", addr.port());
     let expected_error = format!(
-        "Error: Enrichment error for service 's3': \
-         Failed to enrich method call 'get_object': \
+        "Error: Enrichment failed for method 'get_object' (service 's3'): \
          Network error: Failed to connect to the service reference endpoint at '{url}'. \
          Verify that this URL is reachable from your network \
          (e.g. not blocked by a firewall or VPN). \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We did not use the OS's native certificate store, but bundled certificates. This can cause issues with network traffic in monitored networks.

This PR also improves the error message to highlight the network request to the service endpoint URL failed.

For testability I added an env var for overriding the endpoint URL. I opted not to document it as part of this change, but we could in the future, in case users ask to host their own version of the service reference.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
