### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        pass_filenames: false
+        files: '(\.rs$|Cargo\.toml$|Cargo\.lock$|rust-toolchain$|^\.cargo/)'
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --workspace -- -D warnings
+        language: system
+        pass_filenames: false
+        files: '(\.rs$|Cargo\.toml$|Cargo\.lock$|rust-toolchain$|^\.cargo/)'
+
+      - id: cargo-dylint
+        name: cargo dylint
+        entry: cargo dylint --all --workspace
+        language: system
+        pass_filenames: false
+        files: '(\.rs$|Cargo\.toml$|Cargo\.lock$|rust-toolchain$|^\.cargo/|^dylint\.toml$|^iam-policy-autopilot-lints/)'
+
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check .
+        language: system
+        pass_filenames: false
+        files: '(\.py$|^pyproject\.toml$)'
+
+      - id: ruff-format
+        name: ruff format
+        entry: ruff format --check .
+        language: system
+        pass_filenames: false
+        files: '(\.py$|^pyproject\.toml$)'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,18 @@ To send us a pull request, please:
 
 Ensure your changes pass all linters. The CI will enforce these checks automatically.
 
+### Pre-commit Hooks
+
+The repository includes a pre-commit configuration for local checks.
+
+```bash
+# Install pre-commit
+pip install pre-commit
+
+# Install hooks into .git/hooks/pre-commit
+pre-commit install
+```
+
 **Rust**
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ exclude = [
     "iam-policy-autopilot-policy-generation/tests/resources",
     "iam-policy-autopilot-cli/tests/resources",
     "iam-policy-autopilot-mcp-server/tests/test_data",
+    "integration-tests/projects",
     "target",
 ]
 


### PR DESCRIPTION
*Issue #, if available:*
Closes #166

*Description of changes:*

- Add local pre-commit hooks for `cargo fmt`, `cargo clippy`, `cargo dylint`, and `ruff`.
- Document pre-commit setup and required local tools.
- Exclude integration test project fixtures from Ruff so root-level Ruff checks are runnable.

*Testing:*

- `uvx pre-commit validate-config .pre-commit-config.yaml`
- `uvx pre-commit run --all-files`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo dylint --all --path iam-policy-autopilot-lints --workspace`
- `ruff check .`
- `ruff format --check .`
- `cargo test --workspace`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.