### PR TITLE
chore: bump version to 0.2.2-rc.1/0.2.2rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## [Unreleased]
 
+## [0.2.2rc1] - 2026-05-29
+
 ### Added
 
 - Support for namespace imports in TypeScript/JavaScript (#190)
+- Added partial support for permissions needed by [aws-lambda-powertools](https://pypi.org/project/aws-lambda-powertools/) (#186)
 
 ### Fixed
 
+- IAM Policy Autopilot now uses the system's native certificate store (#209)
 - `fix_access_denied` MCP tool now applies the user-confirmed policy instead of regenerating one (#202)
 - `--explain` now shows every call site when the same operation appears multiple times (#188)
 - Condition values for the same key are now merged instead of overwritten when serializing policies (#199)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- IAM Policy Autopilot now uses the system's native certificate store (#209)
+- We now respect the system's native certificate store instead of using bundled certificates (#209)
 - `fix_access_denied` MCP tool now applies the user-confirmed policy instead of regenerating one (#202)
 - `--explain` now shows every call site when the same operation appears multiple times (#188)
 - Condition values for the same key are now merged instead of overwritten when serializing policies (#199)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-access-denied"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 dependencies = [
  "aws-config",
  "aws-sdk-iam",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-cli"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-common"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 dependencies = [
  "iam-policy-autopilot-proc-macros",
  "log",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-mcp-server"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-policy-generation"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-proc-macros"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-tools"
-version = "0.2.1"
+version = "0.2.2-rc.1"
 dependencies = [
  "aws-config",
  "aws-sdk-iam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["iam-policy-autopilot-lints"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2-rc.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/iam-policy-autopilot"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -82,6 +82,8 @@ Update the [version](https://doc.rust-lang.org/cargo/reference/semver.html) in b
 # To:     version = "X.Y.Z"
 ```
 
+For pre-release versions, use SemVer format in Cargo.toml (e.g., `X.Y.Z-rc.1`) and PEP 440 format in pyproject.toml (e.g., `X.Y.Zrc1`). Maturin normalizes the Cargo version to PEP 440 automatically. PyPI will not serve pre-releases to users running `pip install iam-policy-autopilot` unless they explicitly opt in with `--pre` or pin the exact version.
+
 Verify the version is correct:
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -139,8 +139,10 @@ Or manually create the PR through the GitHub web interface.
 
 It's recommended to create the new release and tag directly via the GitHub web interface, where you can automatically generate release notes, create a tag, and draft a release before publishing it.
 
+If you are releasing a release candidate, mark the release as Pre-release.
+
 Notes:
-- The new tag should be the same as the version to be released
+- The new tag must match the version string in Cargo.toml
 - Make sure to select the correct release branch as the target when creating the tag
   - The main branch can be used if it's identical to the release branch (i.e., no cherry-picked commits in the release branch)
 - Be sure to `Save draft` and review it once before publishing the release.

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/basic_multi_resource/expected_merged_policy.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/basic_multi_resource/expected_merged_policy.json
@@ -114,7 +114,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/basic_multi_resource/expected_policies.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/basic_multi_resource/expected_policies.json
@@ -52,16 +52,6 @@
         "Statement": [
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-              "arn:aws:iam::123456789012:role/data-processor-role"
-            ],
-            "Sid": "AllowIAMDeleteServiceLinkedRole"
-          },
-          {
-            "Action": [
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/basic_multi_resource/expected_with_explanations.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/basic_multi_resource/expected_with_explanations.json
@@ -16,7 +16,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/multi_service_real_world/expected_merged_policy.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/multi_service_real_world/expected_merged_policy.json
@@ -141,7 +141,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/multi_service_real_world/expected_policies.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/multi_service_real_world/expected_policies.json
@@ -52,16 +52,6 @@
         "Statement": [
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-              "arn:aws:iam::123456789012:role/event-processor-role"
-            ],
-            "Sid": "AllowIAMDeleteServiceLinkedRole"
-          },
-          {
-            "Action": [
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/multi_service_real_world/expected_with_explanations.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/multi_service_real_world/expected_with_explanations.json
@@ -16,7 +16,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_all_explanations.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_all_explanations.json
@@ -16,7 +16,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_no_explanations.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_no_explanations.json
@@ -16,7 +16,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_no_match_explanations.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_no_match_explanations.json
@@ -16,7 +16,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_s3_only_explanations.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_s3_only_explanations.json
@@ -16,7 +16,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_s3_sqs_explanations.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/resource_arn_filtering/expected_s3_sqs_explanations.json
@@ -16,7 +16,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/state_precedence/expected_merged_policy.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/state_precedence/expected_merged_policy.json
@@ -114,7 +114,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/state_precedence/expected_policies.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/state_precedence/expected_policies.json
@@ -52,16 +52,6 @@
         "Statement": [
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-              "arn:aws:iam::123456789012:role/data-processor-role"
-            ],
-            "Sid": "AllowIAMDeleteServiceLinkedRole"
-          },
-          {
-            "Action": [
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/iam-policy-autopilot-policy-generation/tests/resources/terraform/state_precedence/expected_with_explanations.json
+++ b/iam-policy-autopilot-policy-generation/tests/resources/terraform/state_precedence/expected_with_explanations.json
@@ -16,7 +16,6 @@
           },
           {
             "Action": [
-              "iam:DeleteServiceLinkedRole",
               "iam:GetRole"
             ],
             "Effect": "Allow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 # Standard Python package metadata
 [project]
 name = "iam-policy-autopilot" # The name it will have on PyPI
-version = "0.2.1"
+version = "0.2.2rc1"
 description = "An open source Model Context Protocol (MCP) server and command-line tool that helps your AI coding assistants quickly create baseline IAM policies that you can refine as your application evolves, so you can build faster. IAM Policy Autopilot analyzes your application code locally to generate identity-based policies for application roles, enabling faster IAM policy creation and reducing access troubleshooting time. IAM Policy Autopilot supports applications built in Python, Go, TypeScript, and Java."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Closes #

## Description

Pre-release for testing out the certificate store change
* Bumped versions
* Updated the `RELEASE.md` about version numbers to use in pre-releases (Cargo and Python differ here)
* Added missing entries to `CHANGELOG.md`

## Checklist

- [x] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
