### PR TITLE
feat: add read-only mode for MCP server

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -43,6 +43,7 @@ Telemetry records which commands and parameters are used, and whether the comman
 |-----------|---------------|
 | `transport` | actual value (McpTransport) |
 | `port` | not collected |
+| `read_only` | actual value (boolean) |
 
 ### MCP: `mcp-tool-generate-policies`
 

--- a/iam-policy-autopilot-cli/src/main.rs
+++ b/iam-policy-autopilot-cli/src/main.rs
@@ -140,7 +140,9 @@ Examples:
 
   iam-policy-autopilot mcp-server
 
-  iam-policy-autopilot mcp-server --transport http --port 8001";
+  iam-policy-autopilot mcp-server --read-only
+
+  iam-policy-autopilot mcp-server --transport http --port 8001 --read-only";
 
 #[derive(Parser, Debug)]
 #[command(
@@ -488,6 +490,16 @@ Only used when --transport=http. The server will bind to the specified address o
 Only used when --transport=http. Defaults to 127.0.0.1 (localhost). \
 Use 0.0.0.0 to listen on all interfaces.")]
         bind_address: String,
+
+        /// Disable MCP tools that apply IAM policy changes
+        #[arg(
+            long = "read-only",
+            default_value_t = false,
+            long_help = "Run the MCP server in read-only mode. Policy generation tools remain available, \
+but MCP tools that apply IAM policy changes to AWS accounts are rejected."
+        )]
+        #[telemetry(value)]
+        read_only: bool,
     },
 
     #[command(
@@ -810,8 +822,9 @@ async fn main() {
             transport,
             port,
             bind_address,
+            read_only,
         } => {
-            match start_mcp_server(transport, port, &bind_address).await {
+            match start_mcp_server(transport, port, &bind_address, read_only).await {
                 Ok(()) => ExitCode::Success,
                 Err(e) => {
                     print_cli_command_error(e);

--- a/iam-policy-autopilot-cli/tests/cli_args.rs
+++ b/iam-policy-autopilot-cli/tests/cli_args.rs
@@ -179,6 +179,11 @@ fn test_mcp_server_help_shows_bind_address() {
         "mcp-server help should mention --bind-address: {}",
         stdout
     );
+    assert!(
+        stdout.contains("--read-only"),
+        "mcp-server help should mention --read-only: {}",
+        stdout
+    );
 }
 
 #[test]

--- a/iam-policy-autopilot-mcp-server/src/lib.rs
+++ b/iam-policy-autopilot-mcp-server/src/lib.rs
@@ -80,7 +80,7 @@ pub async fn start_mcp_server(
         McpTransport::Stdio => {
             info!("Starting STDIO MCP server");
 
-            crate::mcp::begin_stdio_transport_with_read_only(path_str, read_only)
+            crate::mcp::begin_stdio_transport(path_str, read_only)
                 .await
                 .with_context(|| "Failed to start STDIO Server".to_string())?;
         }

--- a/iam-policy-autopilot-mcp-server/src/lib.rs
+++ b/iam-policy-autopilot-mcp-server/src/lib.rs
@@ -31,8 +31,9 @@ pub async fn start_mcp_server(
     transport: McpTransport,
     port: u16,
     bind_address: &str,
+    read_only: bool,
 ) -> Result<()> {
-    info!("Starting MCP server with transport: {transport}");
+    info!("Starting MCP server with transport: {transport}, read_only: {read_only}");
 
     let env = env_logger::Env::default().filter_or("IAMPA_LOG_LEVEL", "debug");
 
@@ -72,14 +73,14 @@ pub async fn start_mcp_server(
             let addr: String = format!("{bind_address}:{port}");
             info!("Starting HTTP MCP server at {addr}");
 
-            crate::mcp::begin_http_transport(addr.as_str(), path_str)
+            crate::mcp::begin_http_transport(addr.as_str(), path_str, read_only)
                 .await
                 .with_context(|| format!("Failed to start HTTP Server at '{addr}'"))?;
         }
         McpTransport::Stdio => {
             info!("Starting STDIO MCP server");
 
-            crate::mcp::begin_stdio_transport(path_str)
+            crate::mcp::begin_stdio_transport_with_read_only(path_str, read_only)
                 .await
                 .with_context(|| "Failed to start STDIO Server".to_string())?;
         }

--- a/iam-policy-autopilot-mcp-server/src/mcp.rs
+++ b/iam-policy-autopilot-mcp-server/src/mcp.rs
@@ -136,6 +136,8 @@ impl IamAutoPilotMcpServer {
     #[tool(
         description = "Tool that applies IAM Policy fix generated for IAM AccessDenied exceptions to the user's AWS account\
         \
+        READ-ONLY MODE: If the MCP server was started with --read-only, this tool refuses to apply policy changes. Use generate_policy_for_access_denied to generate a policy for manual review instead. \
+        \
         INSTRUCTIONS: \
         1. Ensure the user has aws profile setup and has active AWS credentials
         2. Only use the tool if the original policy was first generated using generate_policy_for_access_denied tool and surfaced to the user
@@ -277,11 +279,7 @@ pub async fn begin_http_transport(
     Ok(())
 }
 
-pub async fn begin_stdio_transport(log_file: Option<String>) -> anyhow::Result<()> {
-    begin_stdio_transport_with_read_only(log_file, false).await
-}
-
-pub async fn begin_stdio_transport_with_read_only(
+pub async fn begin_stdio_transport(
     log_file: Option<String>,
     read_only: bool,
 ) -> anyhow::Result<()> {
@@ -322,6 +320,15 @@ mod tests {
 
     fn fix_tool_params() -> CallToolRequestParams {
         CallToolRequestParams::new("fix_access_denied").with_arguments(
+            json!({ "ErrorMessage": ERROR_MSG })
+                .as_object()
+                .cloned()
+                .unwrap(),
+        )
+    }
+
+    fn generate_policy_for_access_denied_tool_params() -> CallToolRequestParams {
+        CallToolRequestParams::new("generate_policy_for_access_denied").with_arguments(
             json!({ "ErrorMessage": ERROR_MSG })
                 .as_object()
                 .cloned()
@@ -499,6 +506,25 @@ mod tests {
             "unexpected error message: {}",
             mcp_error.message
         );
+
+        let _ = client.cancel().await;
+        let _ = server_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_read_only_allows_policy_generation() {
+        policy_autopilot::set_mock_plan_return(Ok(test_plan()));
+
+        let (client, server_handle) = setup_read_only(TestClient::accepting()).await;
+        let result = client
+            .call_tool(generate_policy_for_access_denied_tool_params())
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        let text = &result.content.first().unwrap().raw.as_text().unwrap().text;
+        let output: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert!(output["Policy"].is_string());
 
         let _ = client.cancel().await;
         let _ = server_handle.await;

--- a/iam-policy-autopilot-mcp-server/src/mcp.rs
+++ b/iam-policy-autopilot-mcp-server/src/mcp.rs
@@ -25,12 +25,16 @@ use crate::tools::{
 #[derive(Clone)]
 struct IamAutoPilotMcpServer {
     log_file: Option<String>,
+    read_only: bool,
 }
 
 #[tool_router]
 impl IamAutoPilotMcpServer {
-    pub fn new(log_file: Option<String>) -> Self {
-        Self { log_file }
+    pub fn new(log_file: Option<String>, read_only: bool) -> Self {
+        Self {
+            log_file,
+            read_only,
+        }
     }
 
     fn format_mcp_error(&self, msg: &str, e: anyhow::Error) -> McpError {
@@ -44,6 +48,17 @@ impl IamAutoPilotMcpServer {
             message: format!("{msg}: {e:#}.{log_file_suffix}").into(),
             data: None,
         }
+    }
+
+    fn ensure_write_allowed(&self) -> Result<(), McpError> {
+        if self.read_only {
+            return Err(McpError::invalid_request(
+                "MCP server is running in read-only mode; refusing to apply IAM policy changes. Use generate_policy_for_access_denied to generate a policy for manual review.",
+                None,
+            ));
+        }
+
+        Ok(())
     }
 
     #[tool(
@@ -138,6 +153,8 @@ impl IamAutoPilotMcpServer {
         context: RequestContext<RoleServer>,
         params: Parameters<FixAccessDeniedInput>,
     ) -> Result<Json<FixAccessDeniedOutput>, McpError> {
+        self.ensure_write_allowed()?;
+
         trace!("fix_access_denied input: {:#?}", params.0);
         let telemetry_event = params.0.to_telemetry_event();
 
@@ -158,12 +175,18 @@ impl IamAutoPilotMcpServer {
 #[tool_handler]
 impl ServerHandler for IamAutoPilotMcpServer {
     fn get_info(&self) -> ServerInfo {
+        let write_capability = if self.read_only {
+            "4. Run in read-only mode: direct policy application is disabled; use generated policies for manual review"
+        } else {
+            "4. Apply policy fixes directly to AWS accounts"
+        };
+
         ServerInfo::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .build(),
         )
-        .with_instructions("IAM Policy Autopilot specializes in AWS IAM policy generation and access management. \
+        .with_instructions(format!("IAM Policy Autopilot specializes in AWS IAM policy generation and access management. \
             \
             **ALWAYS use the generate_application_policies tool when users mention:** \
             - Writing policies, creating policies, generating policies \
@@ -176,12 +199,12 @@ impl ServerHandler for IamAutoPilotMcpServer {
             1. Generate IAM policies from source code analysis (Python, JavaScript, TypeScript, Go, Java) \
             2. Create minimal required permissions for AWS services used in code \
             3. Debug and fix AccessDenied issues with targeted policy generation \
-            4. Apply policy fixes directly to AWS accounts \
+            {write_capability} \
             \
             **CRITICAL: When generating policies, you MUST include ALL relevant source files that interact with AWS services.** \
             \
             **Usage priority:** Use generate_application_policies as the PRIMARY tool for any policy-related requests. \
-            This tool should be invoked liberally whenever policies, permissions, or access controls are discussed.")
+            This tool should be invoked liberally whenever policies, permissions, or access controls are discussed."))
     }
 
     /// Called after the MCP handshake completes. Sends the telemetry notice
@@ -215,9 +238,10 @@ impl ServerHandler for IamAutoPilotMcpServer {
 pub async fn begin_http_transport(
     bind_address: &str,
     log_file: Option<String>,
+    read_only: bool,
 ) -> anyhow::Result<()> {
     let service = StreamableHttpService::new(
-        move || Ok(IamAutoPilotMcpServer::new(log_file.clone())),
+        move || Ok(IamAutoPilotMcpServer::new(log_file.clone(), read_only)),
         LocalSessionManager::default().into(),
         Default::default(),
     );
@@ -254,7 +278,14 @@ pub async fn begin_http_transport(
 }
 
 pub async fn begin_stdio_transport(log_file: Option<String>) -> anyhow::Result<()> {
-    let server = IamAutoPilotMcpServer::new(log_file);
+    begin_stdio_transport_with_read_only(log_file, false).await
+}
+
+pub async fn begin_stdio_transport_with_read_only(
+    log_file: Option<String>,
+    read_only: bool,
+) -> anyhow::Result<()> {
+    let server = IamAutoPilotMcpServer::new(log_file, read_only);
     let service = server.serve(transport::stdio()).await?;
     service.waiting().await?;
     Ok(())
@@ -366,7 +397,25 @@ mod tests {
         >,
     ) {
         let (server_io, client_io) = tokio::io::duplex(4096);
-        let server = IamAutoPilotMcpServer::new(None);
+        let server = IamAutoPilotMcpServer::new(None, false);
+        let server_handle = tokio::spawn(async move { server.serve(server_io).await });
+        let client = test_client.serve(client_io).await.unwrap();
+        (client, server_handle)
+    }
+
+    async fn setup_read_only(
+        test_client: TestClient,
+    ) -> (
+        rmcp::service::RunningService<RoleClient, TestClient>,
+        tokio::task::JoinHandle<
+            Result<
+                rmcp::service::RunningService<rmcp::RoleServer, IamAutoPilotMcpServer>,
+                rmcp::service::ServerInitializeError,
+            >,
+        >,
+    ) {
+        let (server_io, client_io) = tokio::io::duplex(4096);
+        let server = IamAutoPilotMcpServer::new(None, true);
         let server_handle = tokio::spawn(async move { server.serve(server_io).await });
         let client = test_client.serve(client_io).await.unwrap();
         (client, server_handle)
@@ -429,6 +478,26 @@ mod tests {
         assert!(
             result.is_err(),
             "Should fail when client lacks elicitation capability"
+        );
+
+        let _ = client.cancel().await;
+        let _ = server_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_read_only_rejects_fix_access_denied() {
+        let (client, server_handle) = setup_read_only(TestClient::accepting()).await;
+        let result = client.call_tool(fix_tool_params()).await;
+
+        let err = result.expect_err("read-only mode should reject mutating MCP tools");
+        let rmcp::service::ServiceError::McpError(mcp_error) = err else {
+            panic!("expected MCP error, got {err:?}");
+        };
+        assert_eq!(mcp_error.code, ErrorCode::INVALID_REQUEST);
+        assert!(
+            mcp_error.message.contains("read-only mode"),
+            "unexpected error message: {}",
+            mcp_error.message
         );
 
         let _ = client.cancel().await;


### PR DESCRIPTION
## Summary

- add a `--read-only` flag to `iam-policy-autopilot mcp-server`
- pass read-only state through both stdio and HTTP MCP transports
- reject the mutating `fix_access_denied` MCP tool before policy planning/apply when read-only mode is enabled
- update MCP instructions, CLI help coverage, and telemetry disclosure

## Validation

- `cargo test -p iam-policy-autopilot-mcp-server --lib`
- `cargo test -p iam-policy-autopilot-cli --test cli_args test_mcp_server_help_shows_bind_address`
- `cargo test -p iam-policy-autopilot-cli test_cli_telemetry_fields_documented_in_telemetry_md`

Closes #92
