### PR TITLE
feat: support session-based client/resource creation in variable type tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Variable type tracking for boto3 clients and resources — improves extraction precision when clients are passed across function boundaries (#128)
+- Support for `boto3.Session().client()` / `.resource()` patterns in variable type tracking (#232)
 - `--resource-cutoff` CLI flag and `resource_cutoff` MCP input to configure when resource lists collapse to `*` (#217)
 - Support for namespace imports in TypeScript/JavaScript (#190)
 - Added partial support for permissions needed by [aws-lambda-powertools](https://pypi.org/project/aws-lambda-powertools/) (#186)

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/mod.rs
@@ -3,6 +3,11 @@
 //! This module tracks boto3 client and resource assignments to improve
 //! SDK method call extraction precision when variables are passed across
 //! function boundaries.
+//!
+//! ## Not Yet Supported
+//!
+//! - **Function return values**: `def create_client(): return boto3.client('s3')`
+//! - **Class attributes**: `self.client = boto3.client('s3')`
 
 mod lookup;
 mod tracking;

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/tests.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/tests.rs
@@ -111,6 +111,162 @@ upload(s3)
     assert!(services.unwrap().contains("s3"));
 }
 
+// ========== Session-Based Creation Tests (parameterized) ==========
+
+#[rstest]
+#[case(
+    "session.client('s3')",
+    "boto3.Session(region_name='us-east-1')",
+    "s3_client",
+    "s3",
+    SdkObjectKind::Client
+)]
+#[case(
+    "session.client('ec2')",
+    "boto3.Session()",
+    "ec2_client",
+    "ec2",
+    SdkObjectKind::Client
+)]
+#[case(
+    "session.resource('dynamodb')",
+    "boto3.Session()",
+    "dynamodb",
+    "dynamodb",
+    SdkObjectKind::Resource
+)]
+#[case(
+    "session.client('s3', endpoint_url='http://localhost:4566')",
+    "boto3.Session(region_name='us-west-2', profile_name='dev')",
+    "s3",
+    "s3",
+    SdkObjectKind::Client
+)]
+fn test_session_factory_tracking(
+    #[case] factory_call: &str,
+    #[case] session_init: &str,
+    #[case] var_name: &str,
+    #[case] expected_service: &str,
+    #[case] expected_kind: SdkObjectKind,
+) {
+    let source_code =
+        format!("import boto3\nsession = {session_init}\n{var_name} = {factory_call}\n");
+    let ast = create_ast(&source_code);
+    let mut tracker = VariableTypeTracker::new();
+    tracker.track_boto3_assignments(&ast);
+
+    let info = tracker
+        .get_type_info_for_variable_in_context(var_name, None)
+        .unwrap();
+    assert_eq!(info.service_name, expected_service);
+    assert_eq!(info.kind, Some(expected_kind));
+}
+
+#[test]
+fn test_session_in_function_scope() {
+    let source_code = r#"
+import boto3
+
+def create_clients():
+    session = boto3.Session()
+    s3 = session.client('s3')
+    s3.list_buckets()
+"#;
+    let ast = create_ast(source_code);
+    let mut tracker = VariableTypeTracker::new();
+    tracker.track_boto3_assignments(&ast);
+
+    assert_eq!(
+        tracker.get_service_for_variable_in_context("s3", Some("create_clients")),
+        Some(&"s3".to_string())
+    );
+}
+
+#[test]
+fn test_non_session_variable_not_matched() {
+    let source_code = r#"
+import boto3
+other = SomeOtherClass()
+client = other.client('s3')
+"#;
+    let ast = create_ast(source_code);
+    let mut tracker = VariableTypeTracker::new();
+    tracker.track_boto3_assignments(&ast);
+
+    // 'other' is not a boto3.Session() — should not be tracked
+    assert!(tracker.get_service_for_variable("client").is_none());
+}
+
+#[test]
+fn test_session_scope_isolation() {
+    let source_code = r#"
+import boto3
+
+def setup_s3():
+    session = boto3.Session(region_name='us-east-1')
+    s3 = session.client('s3')
+
+def unrelated():
+    session = SomeOtherClass()
+    client = session.client('s3')
+"#;
+    let ast = create_ast(source_code);
+    let mut tracker = VariableTypeTracker::new();
+    tracker.track_boto3_assignments(&ast);
+
+    // setup_s3's session.client('s3') should be tracked
+    assert_eq!(
+        tracker.get_service_for_variable_in_context("s3", Some("setup_s3")),
+        Some(&"s3".to_string())
+    );
+
+    // unrelated's session is NOT a boto3.Session() — should not be tracked
+    assert!(tracker
+        .get_service_for_variable_in_context("client", Some("unrelated"))
+        .is_none());
+}
+
+#[test]
+fn test_local_reassignment_shadows_module_session() {
+    let source_code = r#"
+import boto3
+session = boto3.Session()
+
+def handler():
+    session = SomeOtherClass()
+    client = session.client('s3')
+"#;
+    let ast = create_ast(source_code);
+    let mut tracker = VariableTypeTracker::new();
+    tracker.track_boto3_assignments(&ast);
+
+    // Local `session` shadows the module-level boto3.Session —
+    // should NOT be tracked as an s3 client
+    assert!(tracker
+        .get_service_for_variable_in_context("client", Some("handler"))
+        .is_none());
+}
+
+#[test]
+fn test_module_session_accessible_from_function() {
+    let source_code = r#"
+import boto3
+session = boto3.Session()
+
+def create_client():
+    s3 = session.client('s3')
+"#;
+    let ast = create_ast(source_code);
+    let mut tracker = VariableTypeTracker::new();
+    tracker.track_boto3_assignments(&ast);
+
+    // Module-level session should be accessible from within functions
+    assert_eq!(
+        tracker.get_service_for_variable_in_context("s3", Some("create_client")),
+        Some(&"s3".to_string())
+    );
+}
+
 #[test]
 fn test_paginator_waiter_not_tracked() {
     let source_code = r#"

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/tests.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/tests.rs
@@ -183,6 +183,26 @@ def create_clients():
 }
 
 #[test]
+fn test_return_value_not_tracked() {
+    // Return value tracking is not yet supported — documenting the limitation.
+    let source_code = r#"
+import boto3
+
+def create_client():
+    session = boto3.Session()
+    return session.client('s3')
+
+client = create_client()
+"#;
+    let ast = create_ast(source_code);
+    let mut tracker = VariableTypeTracker::new();
+    tracker.track_boto3_assignments(&ast);
+
+    // The return value of create_client() is not tracked
+    assert!(tracker.get_service_for_variable("client").is_none());
+}
+
+#[test]
 fn test_non_session_variable_not_matched() {
     let source_code = r#"
 import boto3

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/tracking.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/tracking.rs
@@ -11,15 +11,20 @@ impl VariableTypeTracker {
     ///
     /// 1. **Client assignments**: `boto3.client('service')` at module and function level
     /// 2. **Resource assignments**: `boto3.resource('service')` at module and function level
-    /// 3. **Aliases**: `my_client = s3_client` at module and function level
-    /// 4. **Function calls**: Infer parameter types from arguments at call sites
-    /// 5. **Resource-derived variables**: `table = dynamodb.Table('name')`, `bucket = s3.Bucket('name')`
+    /// 3. **Session-based assignments**: `session = boto3.Session(...)` then `session.client('service')`
+    /// 4. **Aliases**: `my_client = s3_client` at module and function level
+    /// 5. **Function calls**: Infer parameter types from arguments at call sites
+    /// 6. **Resource-derived variables**: `table = dynamodb.Table('name')`, `bucket = s3.Bucket('name')`
     pub(crate) fn track_boto3_assignments(&mut self, ast: &AstWithSourceFile<Python>) {
         let root = ast.ast.root();
 
         self.detect_conflicted_function_names(&root);
+        self.collect_local_assignment_targets(&root);
         self.track_boto3_factory_assignments(&root, "client", SdkObjectKind::Client);
         self.track_boto3_factory_assignments(&root, "resource", SdkObjectKind::Resource);
+        self.track_session_variables(&root);
+        self.track_session_factory_assignments(&root, "client", SdkObjectKind::Client);
+        self.track_session_factory_assignments(&root, "resource", SdkObjectKind::Resource);
         self.track_aliases(&root);
         self.track_function_calls(&root);
         self.track_resource_derived_variables(&root);
@@ -63,9 +68,43 @@ impl VariableTypeTracker {
         }
     }
 
+    /// Collect all assignment target variable names per function.
+    /// Used to detect when a function locally shadows a module-level variable name.
+    fn collect_local_assignment_targets(
+        &mut self,
+        root: &ast_grep_core::Node<ast_grep_core::tree_sitter::StrDoc<Python>>,
+    ) {
+        let func_def_pattern = "def $FUNC($$$): $$$BODY";
+        let assign_pattern = "$VAR = $$$RHS";
+
+        for func_match in root.find_all(func_def_pattern) {
+            let env = func_match.get_env();
+            let func_name = if let Some(node) = env.get_match("FUNC") {
+                node.text().to_string()
+            } else {
+                continue;
+            };
+
+            let caller_node_id = func_match.get_node().node_id();
+            for node_match in func_match.get_node().find_all(assign_pattern) {
+                if has_intervening_function(&node_match, caller_node_id) {
+                    continue;
+                }
+
+                let assign_env = node_match.get_env();
+                if let Some(var_node) = assign_env.get_match("VAR") {
+                    if var_node.kind() == node_kinds::IDENTIFIER {
+                        self.local_assignments
+                            .entry(func_name.clone())
+                            .or_default()
+                            .insert(var_node.text().to_string());
+                    }
+                }
+            }
+        }
+    }
+
     /// Track boto3 factory assignments (client or resource) at both function and module level.
-    /// Note: session-based creation (`session.client('s3')`) is not yet supported.
-    /// See https://github.com/awslabs/iam-policy-autopilot/issues/226
     fn track_boto3_factory_assignments(
         &mut self,
         root: &ast_grep_core::Node<ast_grep_core::tree_sitter::StrDoc<Python>>,
@@ -164,6 +203,194 @@ impl VariableTypeTracker {
             return Some(Self::extract_string_literal(trimmed));
         }
         None
+    }
+
+    /// Track `boto3.Session(...)` assignments to identify session variables
+    fn track_session_variables(
+        &mut self,
+        root: &ast_grep_core::Node<ast_grep_core::tree_sitter::StrDoc<Python>>,
+    ) {
+        let pattern = "$VAR = boto3.Session($$$ARGS)";
+
+        // Track function-level session variables
+        let func_def_pattern = "def $FUNC($$$): $$$BODY";
+        for func_match in root.find_all(func_def_pattern) {
+            let env = func_match.get_env();
+            let func_name = if let Some(node) = env.get_match("FUNC") {
+                node.text().to_string()
+            } else {
+                continue;
+            };
+
+            let caller_node_id = func_match.get_node().node_id();
+            for node_match in func_match.get_node().find_all(pattern) {
+                if has_intervening_function(&node_match, caller_node_id) {
+                    continue;
+                }
+
+                let assign_env = node_match.get_env();
+                let var_name = if let Some(var_node) = assign_env.get_match("VAR") {
+                    var_node.text().to_string()
+                } else {
+                    continue;
+                };
+
+                log::debug!(
+                    "Tracked boto3.Session assignment in function '{func_name}': {var_name}"
+                );
+                self.session_variables
+                    .entry(Some(func_name.clone()))
+                    .or_default()
+                    .insert(var_name);
+            }
+        }
+
+        // Track module-level session variables
+        for node_match in root.find_all(pattern) {
+            if is_inside_function(&node_match) {
+                continue;
+            }
+
+            let env = node_match.get_env();
+            let var_name = if let Some(var_node) = env.get_match("VAR") {
+                var_node.text().to_string()
+            } else {
+                continue;
+            };
+
+            log::debug!("Tracked boto3.Session assignment at module level: {var_name}");
+            self.session_variables
+                .entry(None)
+                .or_default()
+                .insert(var_name);
+        }
+    }
+
+    /// Track `session.client('service')` / `session.resource('service')` assignments
+    /// where `session` is a known boto3.Session() variable in the same scope.
+    fn track_session_factory_assignments(
+        &mut self,
+        root: &ast_grep_core::Node<ast_grep_core::tree_sitter::StrDoc<Python>>,
+        factory_method: &str,
+        kind: SdkObjectKind,
+    ) {
+        let assign_pattern = format!("$VAR = $SESSION.{factory_method}($$$ARGS)");
+
+        // Track function-level assignments
+        let func_def_pattern = "def $FUNC($$$): $$$BODY";
+        for func_match in root.find_all(func_def_pattern) {
+            let env = func_match.get_env();
+
+            let func_name = if let Some(node) = env.get_match("FUNC") {
+                node.text().to_string()
+            } else {
+                continue;
+            };
+
+            let caller_node_id = func_match.get_node().node_id();
+            for node_match in func_match.get_node().find_all(assign_pattern.as_str()) {
+                if has_intervening_function(&node_match, caller_node_id) {
+                    continue;
+                }
+
+                let assign_env = node_match.get_env();
+
+                let session_name = if let Some(node) = assign_env.get_match("SESSION") {
+                    node.text().to_string()
+                } else {
+                    continue;
+                };
+
+                // Check function scope first, then fall back to module scope.
+                // Skip module fallback if the name is locally assigned within this
+                // function (shadowed), even if it's not a boto3 assignment we track.
+                let in_func_sessions = self
+                    .session_variables
+                    .get(&Some(func_name.clone()))
+                    .is_some_and(|vars| vars.contains(&session_name));
+
+                if !in_func_sessions {
+                    let locally_shadowed = self
+                        .local_assignments
+                        .get(&func_name)
+                        .is_some_and(|vars| vars.contains(&session_name));
+                    let in_module_sessions = !locally_shadowed
+                        && self
+                            .session_variables
+                            .get(&None)
+                            .is_some_and(|vars| vars.contains(&session_name));
+                    if !in_module_sessions {
+                        continue;
+                    }
+                }
+
+                let var_name = if let Some(var_node) = assign_env.get_match("VAR") {
+                    var_node.text().to_string()
+                } else {
+                    continue;
+                };
+
+                let Some(service_name) = Self::extract_first_positional_string_arg(assign_env)
+                else {
+                    continue;
+                };
+
+                log::debug!(
+                    "Tracked {session_name}.{factory_method} assignment in function '{func_name}': {var_name} -> {service_name}"
+                );
+
+                self.function_scopes
+                    .entry(func_name.clone())
+                    .or_default()
+                    .insert(
+                        var_name,
+                        VariableTypeInfo::from_service_with_kind(service_name, kind.clone()),
+                    );
+            }
+        }
+
+        // Track module-level assignments
+        for node_match in root.find_all(assign_pattern.as_str()) {
+            let env = node_match.get_env();
+
+            if is_inside_function(&node_match) {
+                continue;
+            }
+
+            let session_name = if let Some(node) = env.get_match("SESSION") {
+                node.text().to_string()
+            } else {
+                continue;
+            };
+
+            // Module-level: only check module-scope sessions
+            let is_known_session = self
+                .session_variables
+                .get(&None)
+                .is_some_and(|vars| vars.contains(&session_name));
+
+            if !is_known_session {
+                continue;
+            }
+
+            let var_name = if let Some(var_node) = env.get_match("VAR") {
+                var_node.text().to_string()
+            } else {
+                continue;
+            };
+
+            let Some(service_name) = Self::extract_first_positional_string_arg(env) else {
+                continue;
+            };
+
+            log::debug!(
+                "Tracked {session_name}.{factory_method} assignment at module level: {var_name} -> {service_name}"
+            );
+            self.module_scope.insert(
+                var_name,
+                VariableTypeInfo::from_service_with_kind(service_name, kind.clone()),
+            );
+        }
     }
 
     /// Track simple variable aliases at module and function level

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/types.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/variable_type_tracker/types.rs
@@ -84,6 +84,14 @@ pub(crate) struct VariableTypeTracker {
     /// Lookups against these names return None to avoid false narrowing.
     /// TODO: Resolve properly by qualifying with class name (e.g., "ClassName.method").
     pub(super) conflicted_functions: HashSet<String>,
+
+    /// Known boto3.Session() variables, scoped by function name (None = module scope).
+    /// Used to match session.client()/session.resource() only in the correct scope.
+    pub(super) session_variables: HashMap<Option<String>, HashSet<String>>,
+
+    /// All assignment target names per function, used to detect local shadowing
+    /// of module-level session variables.
+    pub(super) local_assignments: HashMap<String, HashSet<String>>,
 }
 
 impl VariableTypeTracker {
@@ -93,6 +101,8 @@ impl VariableTypeTracker {
             function_scopes: HashMap::new(),
             parameter_types: HashMap::new(),
             conflicted_functions: HashSet::new(),
+            session_variables: HashMap::new(),
+            local_assignments: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
Closes #226

## Description

Extends the variable type tracker to handle `boto3.Session().client('service')` and `boto3.Session().resource('service')` patterns, which are the recommended boto3 usage in production code (especially Lambda handlers and multi-region deployments).

### What's New

- **Session variable detection**: Tracks `session = boto3.Session(...)` assignments at module and function level
- **Session factory matching**: Resolves `session.client('s3')` / `session.resource('dynamodb')` to the correct service
- **Scope-aware lookup**: Session variables are scoped per-function -> a `boto3.Session()` in one function doesn't validate `.client()` calls in other functions
- **Local shadowing detection**: If a function locally reassigns a session variable name (e.g., `session = requests.Session()`), the module-level `boto3.Session()` fallback is skipped

### Example

```python
import boto3

session = boto3.Session(region_name='us-east-1')
acm_client = session.client('acm')
# list_certificates exists in acm, iot, AND transfer (all with no required params)
response = acm_client.list_certificates()
```

**Before (no session tracking):** `PossibleServices: ["acm", "iot", "transfer"]` -> 3 policy statements
**After (with session tracking):** `PossibleServices: ["acm"]` -> 1 policy statement

### Testing

- 61 unit tests (parameterized with rstest)
- Covers: session client/resource, extra kwargs, function-scoped sessions, non-session rejection, cross-scope isolation, local shadowing

## Checklist

- [x] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
