### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-17
+
 ### Added
 
 - Variable type tracking for boto3 clients and resources — improves extraction precision when clients are passed across function boundaries (#128)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["iam-policy-autopilot-lints"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/iam-policy-autopilot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 # Standard Python package metadata
 [project]
 name = "iam-policy-autopilot" # The name it will have on PyPI
-version = "0.2.2"
+version = "0.2.3"
 description = "An open source Model Context Protocol (MCP) server and command-line tool that helps your AI coding assistants quickly create baseline IAM policies that you can refine as your application evolves, so you can build faster. IAM Policy Autopilot analyzes your application code locally to generate identity-based policies for application roles, enabling faster IAM policy creation and reducing access troubleshooting time. IAM Policy Autopilot supports applications built in Python, Go, TypeScript, and Java."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Description

### Added

- Variable type tracking for boto3 clients and resources — improves extraction precision when clients are passed across function boundaries (#128)
- Support for `boto3.Session().client()` / `.resource()` patterns in variable type tracking (#232)
- `--resource-cutoff` CLI flag and `resource_cutoff` MCP input to configure when resource lists collapse to `*` (#217)
- Support for namespace imports in TypeScript/JavaScript (#190)
- Added partial support for permissions needed by [aws-lambda-powertools](https://pypi.org/project/aws-lambda-powertools/) (#186)
### Fixed
- We now respect the system's native certificate store instead of using bundled certificates (#209)
- `--explain` now shows every call site when the same operation appears multiple times (#188)
- Condition values for the same key are now merged instead of overwritten when serializing policies (#199)
### Changed
- `EnrichmentEngine::new` now requires a `resource_cutoff` parameter; use `DEFAULT_RESOURCE_CUTOFF` to preserve existing behavior (#217)

## Checklist

- [X] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
