### PR TITLE
feat: support resource-operation chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Variable type tracking for boto3 clients and resources — improves extraction precision when clients are passed across function boundaries (#128)
 - Support for `boto3.Session().client()` / `.resource()` patterns in variable type tracking (#232)
+- Support for chained and nested boto3 sub-resource actions, including calls on a variable bound to a chain — e.g. `s3.Bucket("b").put_object(...)`, `s3.Bucket("b").Object("k").put(...)`, and `obj = s3.Bucket("b").Object("k"); obj.put(...)` now resolve to the underlying operation with identifiers injected from the chain
 - `--resource-cutoff` CLI flag and `resource_cutoff` MCP input to configure when resource lists collapse to `*` (#217)
 - Support for namespace imports in TypeScript/JavaScript (#190)
 - Added partial support for permissions needed by [aws-lambda-powertools](https://pypi.org/project/aws-lambda-powertools/) (#186)
@@ -17,6 +18,7 @@
 ### Changed
 
 - `EnrichmentEngine::new` now requires a `resource_cutoff` parameter; use `DEFAULT_RESOURCE_CUTOFF` to preserve existing behavior (#217)
+- An unrecognized method on a known boto3 resource no longer expands to every action of that resource. Such calls now contribute no permissions instead of over-approximating.
 
 ## [0.2.2] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 ## [Unreleased]
 
+### Added
+- Support for chained and nested boto3 sub-resource actions, including calls on a variable bound to a chain — e.g. `s3.Bucket("b").put_object(...)`, `s3.Bucket("b").Object("k").put(...)`, and `obj = s3.Bucket("b").Object("k"); obj.put(...)` now resolve to the underlying operation with identifiers injected from the chain
+
+### Changed
+
+- An unrecognized method on a known boto3 resource no longer expands to every action of that resource. Such calls now contribute no permissions instead of over-approximating
+
 ## [0.2.3] - 2026-06-17
 
 ### Added
 
 - Variable type tracking for boto3 clients and resources — improves extraction precision when clients are passed across function boundaries (#128)
 - Support for `boto3.Session().client()` / `.resource()` patterns in variable type tracking (#232)
-- Support for chained and nested boto3 sub-resource actions, including calls on a variable bound to a chain — e.g. `s3.Bucket("b").put_object(...)`, `s3.Bucket("b").Object("k").put(...)`, and `obj = s3.Bucket("b").Object("k"); obj.put(...)` now resolve to the underlying operation with identifiers injected from the chain
 - `--resource-cutoff` CLI flag and `resource_cutoff` MCP input to configure when resource lists collapse to `*` (#217)
 - Support for namespace imports in TypeScript/JavaScript (#190)
 - Added partial support for permissions needed by [aws-lambda-powertools](https://pypi.org/project/aws-lambda-powertools/) (#186)
@@ -20,7 +26,6 @@
 ### Changed
 
 - `EnrichmentEngine::new` now requires a `resource_cutoff` parameter; use `DEFAULT_RESOURCE_CUTOFF` to preserve existing behavior (#217)
-- An unrecognized method on a known boto3 resource no longer expands to every action of that resource. Such calls now contribute no permissions instead of over-approximating.
 
 ## [0.2.2] - 2026-06-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-access-denied"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aws-config",
  "aws-sdk-iam",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-common"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "iam-policy-autopilot-proc-macros",
  "log",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-mcp-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-policy-generation"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-proc-macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-tools"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aws-config",
  "aws-sdk-iam",

--- a/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
@@ -311,19 +311,6 @@ pub mod core {
                 }
             }
         }
-
-        /// Reduce this parameter to a positional argument at `position`, dropping any
-        /// keyword name. Used when a value is carried into a new call where it is supplied
-        /// positionally — e.g. carrying the `Bucket` identifier value forward from
-        /// `s3.Bucket("b")` into the synthesized `Object` constructor as its first arg.
-        pub(crate) fn into_positional(self, position: usize) -> Self {
-            Self::Positional {
-                value: self.value(),
-                position,
-                type_annotation: None,
-                struct_fields: None,
-            }
-        }
     }
 }
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
@@ -299,6 +299,32 @@ pub mod core {
             position: usize,
         },
     }
+
+    impl Parameter {
+        /// Get this parameter's value, regardless of variant. A [`Parameter::DictionarySplat`]
+        /// has no resolved value, so its unpacking expression is returned as unresolved.
+        pub(crate) fn value(&self) -> ParameterValue {
+            match self {
+                Self::Positional { value, .. } | Self::Keyword { value, .. } => value.clone(),
+                Self::DictionarySplat { expression, .. } => {
+                    ParameterValue::Unresolved(expression.clone())
+                }
+            }
+        }
+
+        /// Reduce this parameter to a positional argument at `position`, dropping any
+        /// keyword name. Used when a value is carried into a new call where it is supplied
+        /// positionally — e.g. carrying the `Bucket` identifier value forward from
+        /// `s3.Bucket("b")` into the synthesized `Object` constructor as its first arg.
+        pub(crate) fn into_positional(self, position: usize) -> Self {
+            Self::Positional {
+                value: self.value(),
+                position,
+                type_annotation: None,
+                struct_fields: None,
+            }
+        }
+    }
 }
 
 /// Output data structures for extraction results and metadata

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/boto3_resources_model.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/boto3_resources_model.rs
@@ -97,6 +97,12 @@ pub struct ResourceDefinition {
     pub(crate) identifiers: Vec<ResourceIdentifier>,
     pub(crate) actions: HashMap<String, ActionMapping>,
     pub(crate) has_many: HashMap<String, HasManySpec>, // Key: snake_case collection name
+    /// Singular sub-resources reachable from this resource (boto3 resource-level `has`).
+    /// Key: accessor name as written in code (e.g. `"Object"`, `"Acl"`). Note the
+    /// accessor frequently differs from the target resource type (e.g. `Bucket.Acl`
+    /// has type `BucketAcl`), which is why this is keyed by accessor, not type.
+    /// The value is the same [`ResourceRef`] shape used by `service.has`.
+    pub(crate) sub_resources: HashMap<String, ResourceRef>,
 }
 
 /// Resource identifier mapping
@@ -166,17 +172,22 @@ struct ServiceSpec {
     has_many: Option<HashMap<String, HasManySpecJson>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct HasSpec {
     resource: ResourceRef,
 }
 
-#[derive(Debug, Deserialize)]
-struct ResourceRef {
+/// A resource reference inside a `has`/`hasMany` spec: the target resource type plus
+/// its identifiers. Mirrors the JSON shape directly. Identifiers reuse [`ParamMapping`]
+/// (`{target, source, name}`); `source` is `"identifier"` (value carried from the
+/// parent identifier named by `name`) or `"input"` (value taken positionally from the
+/// navigation call's arguments).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResourceRef {
     #[serde(rename = "type")]
-    resource_type: String,
+    pub(crate) resource_type: String,
     #[serde(default)]
-    identifiers: Option<serde_json::Value>,
+    pub(crate) identifiers: Vec<ParamMapping>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -186,6 +197,7 @@ struct ResourceSpec {
     // Special operations
     load: Option<LoadSpec>,
     waiters: Option<HashMap<String, WaiterSpec>>,
+    has: Option<HashMap<String, HasSpec>>,
     #[serde(rename = "hasMany")]
     has_many: Option<HashMap<String, HasManySpecJson>>,
 }
@@ -437,13 +449,7 @@ impl Boto3ResourcesModel {
         // Parse service.has for resource constructors
         if let Some(has) = service.has {
             for (constructor_name, has_spec) in has {
-                let identifiers_count = has_spec
-                    .resource
-                    .identifiers
-                    .as_ref()
-                    .and_then(|v| v.as_array())
-                    .map(std::vec::Vec::len)
-                    .unwrap_or(0);
+                let identifiers_count = has_spec.resource.identifiers.len();
 
                 let constructor_spec = ServiceConstructorSpec {
                     resource_type: has_spec.resource.resource_type.clone(),
@@ -498,10 +504,19 @@ impl Boto3ResourcesModel {
             // Parse hasMany collections
             let has_many = Self::parse_has_many_collections(resource_spec.has_many)?;
 
+            // Parse singular sub-resources (resource-level `has`), keyed by accessor name.
+            let sub_resources = resource_spec
+                .has
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(accessor, has_spec)| (accessor, has_spec.resource))
+                .collect();
+
             let resource_def = ResourceDefinition {
                 identifiers: resource_spec.identifiers.unwrap_or_default(),
                 actions,
                 has_many,
+                sub_resources,
             };
 
             model.resource_types.insert(resource_name, resource_def);
@@ -634,6 +649,15 @@ impl Boto3ResourcesModel {
     /// Get constructor spec for a resource type
     pub fn get_constructor_spec(&self, constructor_name: &str) -> Option<&ServiceConstructorSpec> {
         self.service_constructors.get(constructor_name)
+    }
+
+    /// Get a singular sub-resource navigation by parent resource type and accessor name.
+    ///
+    /// `accessor` is the attribute/method written in code (e.g. `"Object"` in
+    /// `bucket.Object("key")`), which may differ from the returned resource type.
+    pub fn get_sub_resource(&self, resource_type: &str, accessor: &str) -> Option<&ResourceRef> {
+        let resource_def = self.resource_types.get(resource_type)?;
+        resource_def.sub_resources.get(accessor)
     }
 
     /// Get resource definition by type name

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/node_kinds.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/node_kinds.rs
@@ -33,3 +33,9 @@ pub(crate) const BLOCK: &str = "block";
 
 /// A decorated definition (function or class with decorators)
 pub(crate) const DECORATED_DEFINITION: &str = "decorated_definition";
+
+/// A function/method call node (e.g., `f(x)`, `obj.method(x)`)
+pub(crate) const CALL: &str = "call";
+
+/// An attribute access node (e.g., `obj.attr`)
+pub(crate) const ATTRIBUTE: &str = "attribute";

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/resource_direct_calls_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/resource_direct_calls_extractor.rs
@@ -38,6 +38,7 @@ use crate::extraction::python::boto3_resources_model::{
     Boto3ResourcesModel, Boto3ResourcesRegistry, HasManySpec, OperationType,
 };
 use crate::extraction::python::common::ArgumentExtractor;
+use crate::extraction::python::node_kinds;
 use crate::extraction::{
     AstWithSourceFile, Parameter, ParameterValue, SdkMethodCall, SdkMethodCallMetadata,
 };
@@ -76,30 +77,16 @@ impl ResourceMethodCallInfo {
     }
 }
 
-/// Resource usage classification for two-tier approach (Tier 3 is now separate)
+/// The leaf resource a sub-resource chain resolves to, with its identifier values.
+///
+/// INVARIANT: `identifier_args[i]` is the value for `resource_type`'s `identifiers[i]`,
+/// i.e. positional in the leaf resource's declared identifier order. This lets them be
+/// consumed directly as positional constructor args by the Tier 1 matcher.
 #[derive(Debug, Clone)]
-enum ResourceUsage {
-    /// All method calls matched to boto3 specs (Tier 1)
-    FullyMatched { matched_calls: Vec<SdkMethodCall> },
-    /// Has at least one unmatched method (Tier 2)
-    HasUnmatchedMethod {
-        matched_calls: Vec<SdkMethodCall>,
-        unmatched_method: ResourceMethodCallInfo,
-    },
-}
-
-/// Tracking structure for resource analysis
-#[derive(Debug)]
-struct ResourceAnalysis {
-    constructor: ResourceConstructorInfo,
-    usage: ResourceUsage,
-}
-
-/// Evidence source for synthetic call generation
-#[derive(Debug, Clone)]
-enum SyntheticEvidenceSource {
-    /// Use position from unmatched method call
-    UnmatchedMethod(ResourceMethodCallInfo),
+struct ResolvedResource {
+    service_name: String,
+    resource_type: String,
+    identifier_args: Vec<Parameter>,
 }
 
 /// Extractor for boto3 resource direct call patterns
@@ -128,52 +115,33 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
         ast: &AstWithSourceFile<Python>,
     ) -> Vec<SdkMethodCall> {
         // Step 1: Find all resource constructors using service-agnostic matching
-        let constructors = self.find_resource_constructors(ast, &self.registry);
+        let mut constructors = self.find_resource_constructors(ast, &self.registry);
 
         // Step 2: Find all method calls on resource objects
-        let method_calls = self.find_resource_method_calls(ast);
+        let mut method_calls = self.find_resource_method_calls(ast);
 
-        // Step 3: Analyze each resource's usage pattern
-        let resource_analyses =
-            self.analyze_resource_usage(&constructors, &method_calls, self.registry.models());
+        // Step 2b: Resolve nested sub-resource action calls, including those on a variable
+        // bound to a nested chain (e.g. `s3.Bucket("b").Object("k").put(...)` and
+        // `obj = s3.Bucket("b").Object("k"); obj.put(...)`). These synthesize a
+        // constructor + method-call pair sharing a unique variable name so the matching
+        // step below joins them (injecting the accumulated identifiers).
+        let (chained_constructors, chained_method_calls) =
+            self.find_chained_subresource_calls(ast, &self.registry);
+        constructors.extend(chained_constructors);
+        method_calls.extend(chained_method_calls);
 
-        // Step 4: Generate appropriate calls based on usage tier
-        let mut all_calls = Vec::new();
+        // Step 3: Match each method call against its resource's boto3 spec. Unmatched
+        // methods on a known resource simply produce nothing (an unknown method is not
+        // evidence for any particular operation).
+        let mut all_calls =
+            self.match_resource_method_calls(&constructors, &method_calls, self.registry.models());
 
-        for analysis in resource_analyses {
-            let boto3_model = match self.registry.get_model(&analysis.constructor.service_name) {
-                Some(model) => model,
-                None => continue,
-            };
-
-            match analysis.usage {
-                ResourceUsage::FullyMatched { matched_calls } => {
-                    // Tier 1: Add only matched calls (already have correct positions)
-                    all_calls.extend(matched_calls);
-                }
-                ResourceUsage::HasUnmatchedMethod {
-                    matched_calls,
-                    unmatched_method,
-                } => {
-                    // Tier 2: Add matched + all synthetic (using unmatched position)
-                    all_calls.extend(matched_calls);
-
-                    let synthetics = self.generate_synthetic_calls_for_resource(
-                        &analysis.constructor,
-                        boto3_model,
-                        SyntheticEvidenceSource::UnmatchedMethod(unmatched_method),
-                    );
-                    all_calls.extend(synthetics);
-                }
-            }
-        }
-
-        // Step 5: Find and generate synthetic calls for hasMany collections (Tier 2 approach)
+        // Step 4: Find and generate synthetic calls for hasMany collections
         let collection_synthetics =
             self.find_and_generate_collection_synthetics(ast, &constructors);
         all_calls.extend(collection_synthetics);
 
-        // Step 6: Collect matched positions for Tier 3 deduplication
+        // Step 5: Collect matched positions for Tier 3 deduplication
         let mut matched_locations = HashSet::new();
         for call in &all_calls {
             if let Some(metadata) = &call.metadata {
@@ -181,42 +149,37 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
             }
         }
 
-        // Step 7: New Tier 3 - service-agnostic fallback for unknown receivers
+        // Step 6: Service-agnostic fallback for unknown receivers
         let tier3_calls = self.find_unmatched_utility_and_collection_calls(ast, &matched_locations);
         all_calls.extend(tier3_calls);
 
         all_calls
     }
 
-    /// Analyze resource usage to classify into three tiers
-    fn analyze_resource_usage(
+    /// Match resource method calls against their resource's boto3 spec, returning the
+    /// resolved [`SdkMethodCall`]s. A method call resolves either to a direct action or to
+    /// the expansion of a utility method (e.g. `upload_file`). Method calls that match
+    /// neither produce nothing: an unknown method on a known resource is not evidence for
+    /// any particular operation.
+    fn match_resource_method_calls(
         &self,
         constructors: &[ResourceConstructorInfo],
         method_calls: &[ResourceMethodCallInfo],
         boto3_models: &HashMap<String, Boto3ResourcesModel>,
-    ) -> Vec<ResourceAnalysis> {
-        let mut analyses = Vec::new();
+    ) -> Vec<SdkMethodCall> {
+        let mut matched_calls = Vec::new();
 
         for constructor in constructors {
             // Find all method calls for this resource
-            let resource_methods: Vec<_> = method_calls
+            let resource_methods = method_calls
                 .iter()
-                .filter(|mc| mc.resource_var == constructor.variable_name)
-                .collect();
-
-            if resource_methods.is_empty() {
-                // Skip constructors with no method calls - these will be handled by new Tier 3
-                continue;
-            }
+                .filter(|mc| mc.resource_var == constructor.variable_name);
 
             // Try to match each method call
             let boto3_model = match boto3_models.get(&constructor.service_name) {
                 Some(model) => model,
                 None => continue,
             };
-
-            let mut matched_calls = Vec::new();
-            let mut first_unmatched = None;
 
             for method_call in resource_methods {
                 if let Some(call) = self.try_match_method(method_call, constructor, boto3_model) {
@@ -226,34 +189,11 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
 
                 let utility_calls =
                     self.try_expand_resource_utility_method(method_call, constructor, boto3_model);
-                if !utility_calls.is_empty() {
-                    matched_calls.extend(utility_calls);
-                    continue;
-                }
-
-                if first_unmatched.is_none() {
-                    first_unmatched = Some((*method_call).clone());
-                }
+                matched_calls.extend(utility_calls);
             }
-
-            let usage = if let Some(unmatched) = first_unmatched {
-                // Tier 2: Has unmatched method
-                ResourceUsage::HasUnmatchedMethod {
-                    matched_calls,
-                    unmatched_method: unmatched,
-                }
-            } else {
-                // Tier 1: Fully matched
-                ResourceUsage::FullyMatched { matched_calls }
-            };
-
-            analyses.push(ResourceAnalysis {
-                constructor: constructor.clone(),
-                usage,
-            });
         }
 
-        analyses
+        matched_calls
     }
 
     /// Try to match a method call to boto3 actions or collections
@@ -421,86 +361,6 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
         expanded_calls
     }
 
-    /// Generate synthetic calls for all resource operations
-    fn generate_synthetic_calls_for_resource(
-        &self,
-        constructor: &ResourceConstructorInfo,
-        boto3_model: &Boto3ResourcesModel,
-        evidence: SyntheticEvidenceSource,
-    ) -> Vec<SdkMethodCall> {
-        let resource_def = match boto3_model.get_resource_definition(&constructor.resource_type) {
-            Some(def) => def,
-            None => return Vec::new(),
-        };
-
-        let mut synthetic_calls = Vec::new();
-
-        // Extract position from evidence source
-        let (expr, location) = match evidence {
-            SyntheticEvidenceSource::UnmatchedMethod(ref method_call) => {
-                (method_call.expr.clone(), method_call.location.clone())
-            }
-        };
-
-        // Generate synthetic call for each action
-        for action_mapping in resource_def.actions.values() {
-            let mut parameters = Vec::new();
-
-            // Inject identifier parameters from constructor
-            for param_mapping in &action_mapping.identifier_params {
-                if let Some(param_name) = &param_mapping.name {
-                    if let Some(_identifier) = resource_def
-                        .identifiers
-                        .iter()
-                        .find(|id| id.name == *param_name)
-                    {
-                        // Get value from constructor args (first positional arg)
-                        if let Some(first_arg) = constructor.constructor_args.first() {
-                            let value = match first_arg {
-                                Parameter::Positional { value, .. } => value.clone(),
-                                Parameter::Keyword { value, .. } => value.clone(),
-                                Parameter::DictionarySplat { expression, .. } => {
-                                    ParameterValue::Unresolved(expression.clone())
-                                }
-                            };
-
-                            parameters.push(Parameter::Keyword {
-                                name: param_mapping.target.clone(),
-                                value,
-                                position: parameters.len(),
-                                type_annotation: None,
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Extract operation name using pattern matching
-            let method_name = match &action_mapping.operation {
-                OperationType::Waiter { waiter_name } => {
-                    // For waiters in synthetic generation, use the waiter name directly
-                    // The actual resolution happens in create_synthetic_method_call_with_waiter_resolution
-                    format!("wait_until_{}", waiter_name.to_case(Case::Snake))
-                }
-                OperationType::SdkOperation(op_name) | OperationType::Load(op_name) => {
-                    op_name.to_case(Case::Snake)
-                }
-            };
-
-            let metadata = SdkMethodCallMetadata::new(expr.clone(), location.clone())
-                .with_parameters(parameters)
-                .with_receiver(constructor.variable_name.clone()); // Use actual variable name from constructor
-
-            synthetic_calls.push(SdkMethodCall {
-                name: method_name,
-                possible_services: vec![constructor.service_name.clone()],
-                metadata: Some(metadata),
-            });
-        }
-
-        synthetic_calls
-    }
-
     /// Find all resource constructor calls in the AST using service-agnostic matching
     fn find_resource_constructors(
         &self,
@@ -572,6 +432,315 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
         }
 
         constructors
+    }
+
+    /// Find nested sub-resource action calls, including those on a variable bound to a
+    /// nested sub-resource chain.
+    ///
+    /// Handles:
+    /// - Inline action chains of any depth: `s3.Bucket("b").put_object(...)`,
+    ///   `s3.Bucket("b").Object("k").put(...)`.
+    /// - Nested assigned chains followed by an action:
+    ///   `obj = s3.Bucket("b").Object("k")` then `obj.put(...)`.
+    ///
+    /// The single-level *assigned* form (`bucket = s3.Bucket("b"); bucket.put_object(...)`)
+    /// is already handled by [`find_resource_constructors`] +
+    /// [`find_resource_method_calls`]. To avoid double-counting it, the assignment pass
+    /// here gates on chain depth ≥ 2; the inline action pass has no such overlap (an inline
+    /// constructor is never registered by the existing path) so it accepts any depth.
+    ///
+    /// Each resolved action becomes a synthetic constructor + method-call pair (sharing a
+    /// unique synthetic variable name) so the regular matching path joins them and injects
+    /// the accumulated identifiers. Any chain whose links do not all resolve is dropped
+    /// entirely (logged at debug), rather than emitting partial or speculative operations.
+    fn find_chained_subresource_calls(
+        &self,
+        ast: &AstWithSourceFile<Python>,
+        registry: &Boto3ResourcesRegistry,
+    ) -> (Vec<ResourceConstructorInfo>, Vec<ResourceMethodCallInfo>) {
+        let root = ast.ast.root();
+        let mut constructors = Vec::new();
+        let mut method_calls = Vec::new();
+
+        // First pass: resolve assignments whose RHS is a nested sub-resource chain, e.g.
+        // `obj = s3.Bucket("b").Object("k")`. Maps the assigned variable name to the
+        // resolved leaf resource so later `obj.method(...)` calls can be matched.
+        let assigned_resources = self.resolve_assigned_resource_chains(ast, registry);
+
+        // Second pass: every call `<receiver>.method(args)`. The receiver is either an
+        // inline nested chain or a variable bound to one (from the first pass).
+        for node_match in root.find_all("$RECEIVER.$METHOD($$$ARGS)") {
+            let env = node_match.get_env();
+            let call_node = node_match.get_node();
+
+            let method_name = match env.get_match("METHOD") {
+                Some(node) => node.text().to_string(),
+                None => continue,
+            };
+            let receiver_node = match env.get_match("RECEIVER") {
+                Some(node) => node,
+                None => continue,
+            };
+
+            let args_nodes = env.get_multiple_matches("ARGS");
+            let arguments = ArgumentExtractor::extract_arguments(&args_nodes);
+            let location = Location::from_node(ast.source_file.path.clone(), call_node);
+            let start = call_node.start_pos();
+
+            // Resolve the receiver to a leaf resource: either a variable bound to a nested
+            // chain, or an inline nested chain. `resolve_chain` yields one per service.
+            let receiver_text = receiver_node.text().to_string();
+            let resolved = match assigned_resources.get(&receiver_text) {
+                Some(by_var) => by_var.clone(),
+                None => self.resolve_chain(receiver_node, registry),
+            };
+
+            for resource in resolved {
+                let synthetic_var = format!(
+                    "__chained_{}_{}_{}_{}",
+                    resource.service_name,
+                    resource.resource_type,
+                    start.line() + 1,
+                    start.column(call_node) + 1
+                );
+
+                constructors.push(ResourceConstructorInfo {
+                    variable_name: synthetic_var.clone(),
+                    resource_type: resource.resource_type.clone(),
+                    service_name: resource.service_name.clone(),
+                    constructor_args: resource.identifier_args.clone(),
+                    start_position: (start.line() + 1, start.column(call_node) + 1),
+                    end_position: (start.line() + 1, start.column(call_node) + 1),
+                });
+
+                method_calls.push(ResourceMethodCallInfo {
+                    resource_var: synthetic_var,
+                    method_name: method_name.clone(),
+                    arguments: arguments.clone(),
+                    expr: node_match.text().to_string(),
+                    location: location.clone(),
+                });
+            }
+        }
+
+        (constructors, method_calls)
+    }
+
+    /// Resolve assignments of the form `var = <nested sub-resource chain>` (e.g.
+    /// `obj = s3.Bucket("b").Object("k")`), returning a map from the assigned variable
+    /// name to the resolved leaf resource(s). Assignments whose RHS does not resolve to a
+    /// nested resource chain are omitted.
+    fn resolve_assigned_resource_chains(
+        &self,
+        ast: &AstWithSourceFile<Python>,
+        registry: &Boto3ResourcesRegistry,
+    ) -> HashMap<String, Vec<ResolvedResource>> {
+        let root = ast.ast.root();
+        let mut assigned = HashMap::new();
+
+        for node_match in root.find_all("$VAR = $RHS") {
+            let env = node_match.get_env();
+            let var_name = match env.get_match("VAR") {
+                Some(node) => node.text().to_string(),
+                None => continue,
+            };
+            let rhs_node = match env.get_match("RHS") {
+                Some(node) => node,
+                None => continue,
+            };
+
+            // Only handle NESTED assignments here (depth ≥ 2, e.g.
+            // `obj = s3.Bucket("b").Object("k")`). Single-level assignments
+            // (`bucket = s3.Bucket("b")`) are owned by the existing constructor +
+            // method-call path; resolving them here too would double-count.
+            let depth = Self::collect_chain_links(rhs_node).map_or(0, |links| links.len());
+            if depth < 2 {
+                continue;
+            }
+
+            let resolved = self.resolve_chain(rhs_node, registry);
+            if !resolved.is_empty() {
+                assigned.insert(var_name, resolved);
+            }
+        }
+
+        assigned
+    }
+
+    /// Collect a method/navigation chain as `(accessor, args)` links in base-first order.
+    ///
+    /// For `s3.Bucket("b").Object("k")` this yields `[("Bucket", ["b"]), ("Object", ["k"])]`.
+    /// Walks the receiver inward (each link is a `call` whose function is an `attribute`),
+    /// stopping at the base object (e.g. the `s3` identifier). Returns `None` if the node
+    /// is malformed in a way that should abort resolution.
+    fn collect_chain_links(
+        node: &ast_grep_core::Node<ast_grep_core::tree_sitter::StrDoc<Python>>,
+    ) -> Option<Vec<(String, Vec<Parameter>)>> {
+        let mut links = Vec::new(); // (accessor, args), outermost first
+        let mut current = node.clone();
+        loop {
+            if current.kind() != node_kinds::CALL {
+                break;
+            }
+            let function = current.field("function")?;
+            if function.kind() != node_kinds::ATTRIBUTE {
+                // Base is not an attribute access (e.g. a bare name); the outermost
+                // construct must be `<receiver>.Accessor(args)` to be a chain.
+                break;
+            }
+            let accessor = function.field("attribute")?.text().to_string();
+            let args = match current.field("arguments") {
+                Some(arg_list) => {
+                    // `argument_list` children include punctuation tokens (`(`, `)`, `,`);
+                    // keep only named nodes so the extractor sees just the arguments.
+                    let arg_nodes: Vec<_> = arg_list
+                        .children()
+                        .filter(ast_grep_core::Node::is_named)
+                        .collect();
+                    ArgumentExtractor::extract_arguments(&arg_nodes)
+                }
+                None => Vec::new(),
+            };
+            links.push((accessor, args));
+            current = function.field("object")?;
+        }
+
+        // Collected outermost-first; reverse to base-first.
+        links.reverse();
+        Some(links)
+    }
+
+    /// Resolve an expression node to the leaf resource(s) of a boto3 sub-resource chain.
+    ///
+    /// Walks the chain outward from its base. The base must be a known resource
+    /// constructor call (e.g. `s3.Bucket("b")`); each subsequent link must be a known
+    /// sub-resource navigation (e.g. `.Object("k")`). Identifier values are accumulated
+    /// across links in the order of the leaf resource's identifiers. Returns one
+    /// [`ResolvedResource`] per service that provides the base resource type.
+    ///
+    /// Resolves chains of any depth, including a bare base (`s3.Bucket("b")`). Callers
+    /// that overlap with the existing single-level path (e.g. assignment resolution)
+    /// gate on chain depth themselves.
+    ///
+    /// Returns an empty vector if `node` is not a resource chain, or if any link fails to
+    /// resolve (unknown accessor, arg-count mismatch, missing model) — chains are resolved
+    /// fully or not at all.
+    fn resolve_chain(
+        &self,
+        node: &ast_grep_core::Node<ast_grep_core::tree_sitter::StrDoc<Python>>,
+        registry: &Boto3ResourcesRegistry,
+    ) -> Vec<ResolvedResource> {
+        let links = match Self::collect_chain_links(node) {
+            Some(links) => links,
+            None => return Vec::new(),
+        };
+
+        let (base_accessor, base_args) = match links.first() {
+            Some(first) => first,
+            None => return Vec::new(),
+        };
+
+        // The base accessor must be a known resource type provided by some service(s).
+        let services = registry.find_services_for_resource(base_accessor);
+        if services.is_empty() {
+            return Vec::new();
+        }
+
+        let mut results = Vec::new();
+        for service_name in services {
+            if let Some(resource) =
+                self.resolve_chain_for_service(&service_name, &links, base_args, registry)
+            {
+                results.push(resource);
+            }
+        }
+        results
+    }
+
+    /// Resolve a chain's links against a single service's model, accumulating identifier
+    /// values. Returns `None` if any link is unresolvable for this service.
+    fn resolve_chain_for_service(
+        &self,
+        service_name: &str,
+        links: &[(String, Vec<Parameter>)],
+        base_args: &[Parameter],
+        registry: &Boto3ResourcesRegistry,
+    ) -> Option<ResolvedResource> {
+        let model = registry.get_model(service_name)?;
+
+        // Base resource: validate constructor arg count against its identifiers.
+        let (base_accessor, _) = links.first()?;
+        let base_spec = model.get_constructor_spec(base_accessor)?;
+        if base_args.len() != base_spec.identifiers_count {
+            log::debug!(
+                "Chain base '{base_accessor}' arg count {} != identifiers {}",
+                base_args.len(),
+                base_spec.identifiers_count
+            );
+            return None;
+        }
+
+        // Accumulated identifier values for the current resource, as positional args in
+        // the order of that resource's identifiers. The base resource takes them directly
+        // from its constructor call.
+        let mut current_type = base_spec.resource_type.clone();
+        let mut identifier_args: Vec<Parameter> = base_args.to_vec();
+
+        // Walk the remaining links as sub-resource navigations.
+        for (accessor, nav_args) in &links[1..] {
+            let sub = model.get_sub_resource(&current_type, accessor)?;
+
+            // Build the child's identifiers in DECLARED ORDER, so the result stays
+            // positional in the child's identifier order (the ResolvedResource invariant).
+            // Each identifier value comes from the parent (source "identifier", resolved
+            // by name against the parent's own ordered args) or from this navigation's own
+            // arguments (source "input", consumed positionally).
+            let mut next_args: Vec<Parameter> = Vec::new();
+            let mut input_index = 0;
+            for ident in &sub.identifiers {
+                match ident.source.as_str() {
+                    "identifier" => {
+                        let parent_name = ident.name.as_deref()?;
+                        let parent_pos =
+                            self.identifier_position(model, &current_type, parent_name)?;
+                        let value = identifier_args.get(parent_pos)?.clone();
+                        next_args.push(value.into_positional(next_args.len()));
+                    }
+                    "input" => {
+                        let value = nav_args.get(input_index)?.clone();
+                        next_args.push(value.into_positional(next_args.len()));
+                        input_index += 1;
+                    }
+                    other => {
+                        log::debug!("Unsupported sub-resource identifier source '{other}'");
+                        return None;
+                    }
+                }
+            }
+
+            current_type = sub.resource_type.clone();
+            identifier_args = next_args;
+        }
+
+        Some(ResolvedResource {
+            service_name: service_name.to_string(),
+            resource_type: current_type,
+            identifier_args,
+        })
+    }
+
+    /// Position of a named identifier within a resource type's identifier list.
+    fn identifier_position(
+        &self,
+        model: &Boto3ResourcesModel,
+        resource_type: &str,
+        identifier_name: &str,
+    ) -> Option<usize> {
+        model
+            .get_resource_definition(resource_type)?
+            .identifiers
+            .iter()
+            .position(|id| id.name == identifier_name)
     }
 
     /// Find all method calls on potential resource objects

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/resource_direct_calls_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/resource_direct_calls_extractor.rs
@@ -797,19 +797,28 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
             }
         }
 
-        let mut positional = positional.into_iter();
+        // Assign exactly like Python: positional args fill the FIRST identifiers in
+        // declared order; keyword args then fill the REMAINING identifiers by name. A
+        // keyword that targets an already positionally-filled identifier is a collision
+        // ("got multiple values for argument") — invalid Python, so we bail.
         let mut assigned = HashMap::with_capacity(identifier_names.len());
-        for name in identifier_names {
-            let kwarg_name =
-                ServiceDiscovery::operation_to_method_name(name, crate::Language::Python);
-            let value = match keyword.remove(kwarg_name.as_str()) {
-                Some(value) => value.clone(),
-                None => positional.next()?.clone(),
-            };
-            assigned.insert((*name).to_string(), value);
+        let mut identifiers = identifier_names.iter();
+
+        for value in &positional {
+            // `args.len() == identifier_names.len()` guarantees a slot exists here.
+            let name = identifiers.next()?;
+            assigned.insert((*name).to_string(), (*value).clone());
         }
 
-        // Any keyword left over didn't match an identifier — the call doesn't line up.
+        for name in identifiers {
+            let kwarg_name =
+                ServiceDiscovery::operation_to_method_name(name, crate::Language::Python);
+            let value = keyword.remove(kwarg_name.as_str())?;
+            assigned.insert((*name).to_string(), value.clone());
+        }
+
+        // Any keyword left over either named an identifier already filled positionally
+        // (collision) or named no identifier at all — both mean the call doesn't line up.
         if !keyword.is_empty() {
             return None;
         }

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/resource_direct_calls_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/resource_direct_calls_extractor.rs
@@ -39,6 +39,7 @@ use crate::extraction::python::boto3_resources_model::{
 };
 use crate::extraction::python::common::ArgumentExtractor;
 use crate::extraction::python::node_kinds;
+use crate::extraction::sdk_model::ServiceDiscovery;
 use crate::extraction::{
     AstWithSourceFile, Parameter, ParameterValue, SdkMethodCall, SdkMethodCallMetadata,
 };
@@ -79,14 +80,14 @@ impl ResourceMethodCallInfo {
 
 /// The leaf resource a sub-resource chain resolves to, with its identifier values.
 ///
-/// INVARIANT: `identifier_args[i]` is the value for `resource_type`'s `identifiers[i]`,
-/// i.e. positional in the leaf resource's declared identifier order. This lets them be
-/// consumed directly as positional constructor args by the Tier 1 matcher.
+/// `identifiers` maps each identifier name on `resource_type` (e.g. `BucketName`, `Key`)
+/// to its resolved value. Keyed by name — not position — so values are carried and
+/// injected by identifier name throughout, matching how boto3 specs reference them.
 #[derive(Debug, Clone)]
 struct ResolvedResource {
     service_name: String,
     resource_type: String,
-    identifier_args: Vec<Parameter>,
+    identifiers: HashMap<String, ParameterValue>,
 }
 
 /// Extractor for boto3 resource direct call patterns
@@ -496,6 +497,20 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
             };
 
             for resource in resolved {
+                // `find_all` also matches the intermediate calls of a chain: for
+                // `s3.Bucket("b").Object("k").put(...)` it yields the `.Object("k")` call
+                // too, whose method is itself a sub-resource navigation rather than an
+                // action. Skip those — the outer match that includes the next link already
+                // covers them, and a navigation never resolves to an action downstream.
+                if let Some(model) = registry.get_model(&resource.service_name) {
+                    if model
+                        .get_sub_resource(&resource.resource_type, &method_name)
+                        .is_some()
+                    {
+                        continue;
+                    }
+                }
+
                 let synthetic_var = format!(
                     "__chained_{}_{}_{}_{}",
                     resource.service_name,
@@ -504,11 +519,25 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
                     start.column(call_node) + 1
                 );
 
+                // Carry each resolved identifier as a named keyword arg so the Tier 1
+                // matcher injects it by name into the operation's required parameters.
+                let constructor_args = resource
+                    .identifiers
+                    .iter()
+                    .enumerate()
+                    .map(|(position, (name, value))| Parameter::Keyword {
+                        name: name.clone(),
+                        value: value.clone(),
+                        position,
+                        type_annotation: None,
+                    })
+                    .collect();
+
                 constructors.push(ResourceConstructorInfo {
                     variable_name: synthetic_var.clone(),
                     resource_type: resource.resource_type.clone(),
                     service_name: resource.service_name.clone(),
-                    constructor_args: resource.identifier_args.clone(),
+                    constructor_args,
                     start_position: (start.line() + 1, start.column(call_node) + 1),
                     end_position: (start.line() + 1, start.column(call_node) + 1),
                 });
@@ -668,79 +697,124 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
     ) -> Option<ResolvedResource> {
         let model = registry.get_model(service_name)?;
 
-        // Base resource: validate constructor arg count against its identifiers.
+        // Base resource: assign the constructor args to its identifiers by name. Keyword
+        // args match the identifier's snake_case name; positional args fill the remaining
+        // identifiers in declared order. Yields a name -> value map for the base resource.
         let (base_accessor, _) = links.first()?;
         let base_spec = model.get_constructor_spec(base_accessor)?;
-        if base_args.len() != base_spec.identifiers_count {
-            log::debug!(
-                "Chain base '{base_accessor}' arg count {} != identifiers {}",
-                base_args.len(),
-                base_spec.identifiers_count
-            );
-            return None;
-        }
+        let base_identifier_names: Vec<&str> = model
+            .get_resource_definition(&base_spec.resource_type)?
+            .identifiers
+            .iter()
+            .map(|id| id.name.as_str())
+            .collect();
 
-        // Accumulated identifier values for the current resource, as positional args in
-        // the order of that resource's identifiers. The base resource takes them directly
-        // from its constructor call.
         let mut current_type = base_spec.resource_type.clone();
-        let mut identifier_args: Vec<Parameter> = base_args.to_vec();
+        let mut identifiers = Self::assign_args_to_identifiers(base_args, &base_identifier_names)?;
 
         // Walk the remaining links as sub-resource navigations.
         for (accessor, nav_args) in &links[1..] {
             let sub = model.get_sub_resource(&current_type, accessor)?;
 
-            // Build the child's identifiers in DECLARED ORDER, so the result stays
-            // positional in the child's identifier order (the ResolvedResource invariant).
-            // Each identifier value comes from the parent (source "identifier", resolved
-            // by name against the parent's own ordered args) or from this navigation's own
-            // arguments (source "input", consumed positionally).
-            let mut next_args: Vec<Parameter> = Vec::new();
-            let mut input_index = 0;
+            // The navigation's own arguments supply the `input`-sourced identifiers, in
+            // their declared order, keyed by their target name. This validates the count,
+            // so a navigation given the wrong number of args bails (like the base does).
+            let input_names: Vec<&str> = sub
+                .identifiers
+                .iter()
+                .filter(|id| id.source == "input")
+                .map(|id| id.target.as_str())
+                .collect();
+            let mut input_values = Self::assign_args_to_identifiers(nav_args, &input_names)?;
+
+            // Build the child's identifier map: each value comes from the parent (source
+            // "identifier", looked up by the named parent identifier) or from this
+            // navigation (source "input"), keyed by the child's target identifier name.
+            let mut next_identifiers = HashMap::new();
             for ident in &sub.identifiers {
-                match ident.source.as_str() {
-                    "identifier" => {
-                        let parent_name = ident.name.as_deref()?;
-                        let parent_pos =
-                            self.identifier_position(model, &current_type, parent_name)?;
-                        let value = identifier_args.get(parent_pos)?.clone();
-                        next_args.push(value.into_positional(next_args.len()));
-                    }
-                    "input" => {
-                        let value = nav_args.get(input_index)?.clone();
-                        next_args.push(value.into_positional(next_args.len()));
-                        input_index += 1;
-                    }
+                let value = match ident.source.as_str() {
+                    "identifier" => identifiers.get(ident.name.as_deref()?)?.clone(),
+                    "input" => input_values.remove(&ident.target)?,
                     other => {
                         log::debug!("Unsupported sub-resource identifier source '{other}'");
                         return None;
                     }
-                }
+                };
+                next_identifiers.insert(ident.target.clone(), value);
             }
 
             current_type = sub.resource_type.clone();
-            identifier_args = next_args;
+            identifiers = next_identifiers;
         }
 
         Some(ResolvedResource {
             service_name: service_name.to_string(),
             resource_type: current_type,
-            identifier_args,
+            identifiers,
         })
     }
 
-    /// Position of a named identifier within a resource type's identifier list.
-    fn identifier_position(
-        &self,
-        model: &Boto3ResourcesModel,
-        resource_type: &str,
-        identifier_name: &str,
-    ) -> Option<usize> {
-        model
-            .get_resource_definition(resource_type)?
-            .identifiers
+    /// Assign a call's arguments to the named `identifier_names`, returning a
+    /// `name -> value` map.
+    ///
+    /// boto3 resource constructors and sub-resource navigations accept their identifiers
+    /// positionally or by keyword, where the keyword is the snake_case of the identifier
+    /// name (e.g. `BucketName` -> `bucket_name`). Keyword args are matched to the identifier
+    /// whose snake_case name they equal; positional args fill the remaining identifiers in
+    /// declared order. Returns `None` unless every identifier is supplied exactly once and
+    /// no extra args remain — so a call with the wrong number or names of args bails rather
+    /// than mismapping.
+    fn assign_args_to_identifiers(
+        args: &[Parameter],
+        identifier_names: &[&str],
+    ) -> Option<HashMap<String, ParameterValue>> {
+        // A `**kwargs` splat hides identifier values we cannot map; bail.
+        if args
             .iter()
-            .position(|id| id.name == identifier_name)
+            .any(|a| matches!(a, Parameter::DictionarySplat { .. }))
+        {
+            return None;
+        }
+
+        // Wrong arg count can never line up one-to-one with the identifiers.
+        if args.len() != identifier_names.len() {
+            return None;
+        }
+
+        // Index keyword args by name; collect positional values in order.
+        let mut keyword: HashMap<&str, &ParameterValue> = HashMap::new();
+        let mut positional: Vec<&ParameterValue> = Vec::new();
+        for arg in args {
+            match arg {
+                Parameter::Keyword { name, value, .. } => {
+                    // A duplicate keyword would be invalid Python; treat as unresolvable.
+                    if keyword.insert(name.as_str(), value).is_some() {
+                        return None;
+                    }
+                }
+                Parameter::Positional { value, .. } => positional.push(value),
+                Parameter::DictionarySplat { .. } => unreachable!("splats rejected above"),
+            }
+        }
+
+        let mut positional = positional.into_iter();
+        let mut assigned = HashMap::with_capacity(identifier_names.len());
+        for name in identifier_names {
+            let kwarg_name =
+                ServiceDiscovery::operation_to_method_name(name, crate::Language::Python);
+            let value = match keyword.remove(kwarg_name.as_str()) {
+                Some(value) => value.clone(),
+                None => positional.next()?.clone(),
+            };
+            assigned.insert((*name).to_string(), value);
+        }
+
+        // Any keyword left over didn't match an identifier — the call doesn't line up.
+        if !keyword.is_empty() {
+            return None;
+        }
+
+        Some(assigned)
     }
 
     /// Find all method calls on potential resource objects
@@ -892,35 +966,26 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
         // Build parameters list starting with identifier parameters
         let mut combined_parameters = Vec::new();
 
-        // Inject identifier parameters from boto3 spec
+        // Inject identifier parameters from the boto3 spec. Each action `identifier_param`
+        // maps a resource identifier (named by `param_mapping.name`, e.g. `BucketName`) to
+        // the operation's target parameter (`param_mapping.target`, e.g. `Bucket`). Pull
+        // the value from the constructor arg with the *matching identifier name* — not the
+        // first arg — so a multi-identifier resource (e.g. `Object` -> `Bucket` + `Key`)
+        // gives each target its own value rather than repeating the first.
         for param_mapping in &action_mapping.identifier_params {
-            if let Some(param_name) = &param_mapping.name {
-                // Find the identifier definition to get the value position
-                if let Some(_identifier) = resource_def
-                    .identifiers
-                    .iter()
-                    .find(|id| id.name == *param_name)
-                {
-                    // Get value from constructor args
-                    // For now, we assume the first positional arg is the identifier value
-                    if let Some(first_arg) = constructor.constructor_args.first() {
-                        let value = match first_arg {
-                            Parameter::Positional { value, .. } => value.clone(),
-                            Parameter::Keyword { value, .. } => value.clone(),
-                            Parameter::DictionarySplat { expression, .. } => {
-                                ParameterValue::Unresolved(expression.clone())
-                            }
-                        };
-
-                        // Use the target parameter name from boto3 spec
-                        combined_parameters.push(Parameter::Keyword {
-                            name: param_mapping.target.clone(),
-                            value,
-                            position: combined_parameters.len(),
-                            type_annotation: None,
-                        });
-                    }
-                }
+            let Some(param_name) = &param_mapping.name else {
+                continue;
+            };
+            if let Some(value) =
+                Self::constructor_identifier_value(constructor, resource_def, param_name)
+            {
+                // Use the target parameter name from the boto3 spec.
+                combined_parameters.push(Parameter::Keyword {
+                    name: param_mapping.target.clone(),
+                    value,
+                    position: combined_parameters.len(),
+                    type_annotation: None,
+                });
             }
         }
 
@@ -966,6 +1031,47 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
             possible_services: vec![constructor.service_name.clone()],
             metadata: Some(metadata),
         })
+    }
+
+    /// Resolve the value of a resource identifier (e.g. `BucketName`) from a constructor's
+    /// arguments.
+    ///
+    /// The chain resolver labels each constructor arg with its identifier name, so the
+    /// arg whose keyword name matches is preferred — this is what lets a multi-identifier
+    /// resource map each identifier to its own value. For example, for
+    /// `s3.Bucket("b").Object("k").put(...)` the synthesized `Object` constructor carries
+    /// `[Bucket="b", Key="k"]`, so `BucketName` resolves to `"b"` and `Key` to `"k"`.
+    ///
+    /// The fallback (positional arg at the identifier's declared index) covers the
+    /// single-level path, where constructor args come straight from the user's call and
+    /// carry no identifier label — e.g. `bucket = s3.Bucket("my-bucket")` produces an
+    /// unnamed `Positional("my-bucket")`, which maps to `Name` at index 0.
+    fn constructor_identifier_value(
+        constructor: &ResourceConstructorInfo,
+        resource_def: &crate::extraction::python::boto3_resources_model::ResourceDefinition,
+        identifier_name: &str,
+    ) -> Option<ParameterValue> {
+        // Prefer the constructor arg explicitly labelled with this identifier's name.
+        let by_name = constructor
+            .constructor_args
+            .iter()
+            .find_map(|arg| match arg {
+                Parameter::Keyword { name, .. } if name == identifier_name => Some(arg.value()),
+                _ => None,
+            });
+        if by_name.is_some() {
+            return by_name;
+        }
+
+        // Fallback: positional arg at the identifier's declared index.
+        let index = resource_def
+            .identifiers
+            .iter()
+            .position(|id| id.name == identifier_name)?;
+        constructor
+            .constructor_args
+            .get(index)
+            .map(Parameter::value)
     }
 
     /// Find hasMany collection accesses and generate synthetic calls (Tier 2 approach)
@@ -1358,5 +1464,113 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
                 type_annotation: None,
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Language, SourceFile};
+    use ast_grep_core::tree_sitter::LanguageExt;
+    use rstest::rstest;
+    use std::path::PathBuf;
+
+    fn create_test_ast(source_code: &str) -> AstWithSourceFile<Python> {
+        let source_file =
+            SourceFile::with_language(PathBuf::new(), source_code.to_string(), Language::Python);
+        let ast_grep = Python.ast_grep(&source_file.content);
+        AstWithSourceFile::new(ast_grep, source_file.clone())
+    }
+
+    /// The value of the keyword parameter named `name`, or `None`. Returns the full
+    /// [`ParameterValue`] so tests can assert the resolution kind (`Resolved` literal vs
+    /// `Unresolved` expression), not just the text.
+    fn keyword_value<'a>(call: &'a SdkMethodCall, name: &str) -> Option<&'a ParameterValue> {
+        call.metadata
+            .as_ref()?
+            .parameters
+            .iter()
+            .find_map(|p| match p {
+                Parameter::Keyword { name: n, value, .. } if n == name => Some(value),
+                _ => None,
+            })
+    }
+
+    /// A chain's leaf operation must receive each identifier's *own* value — distinct
+    /// values for distinct identifiers, accumulated correctly across navigations, and
+    /// preserving each value's resolution kind. This asserts injected parameter VALUES
+    /// directly (not just the operation name), which is the only level at which the
+    /// per-identifier mapping is observable: disambiguation validates parameter names,
+    /// not values.
+    #[rstest]
+    // Two-identifier leaf: Bucket -> Object carries the bucket name and takes the key.
+    #[case::bucket_object_put(
+        r#"
+import boto3
+def handle():
+    s3 = boto3.resource("s3")
+    s3.Bucket("my-bucket").Object("my-key").put(Body="data")
+"#,
+        "put_object",
+        &[
+            ("Bucket", ParameterValue::Resolved("my-bucket".into())),
+            ("Key", ParameterValue::Resolved("my-key".into())),
+        ]
+    )]
+    // Non-literal arguments (a variable and a function call) must map to the correct
+    // identifiers AND stay unresolved — the chain logic carries the expression verbatim.
+    #[case::non_literal_values(
+        r#"
+import boto3
+def handle(bucket_var):
+    s3 = boto3.resource("s3")
+    s3.Bucket(bucket_var).Object(get_key()).put(Body="data")
+"#,
+        "put_object",
+        &[
+            ("Bucket", ParameterValue::Unresolved("bucket_var".into())),
+            ("Key", ParameterValue::Unresolved("get_key()".into())),
+        ]
+    )]
+    // Depth-3 chain accumulating three distinct identifiers into UploadPart.
+    #[case::deep_multipart_upload_part(
+        r#"
+import boto3
+def handle():
+    s3 = boto3.resource("s3")
+    s3.Object("my-bucket", "my-key").MultipartUpload("upload-id").Part(1).upload(Body="data")
+"#,
+        "upload_part",
+        &[
+            ("Bucket", ParameterValue::Resolved("my-bucket".into())),
+            ("Key", ParameterValue::Resolved("my-key".into())),
+            ("UploadId", ParameterValue::Resolved("upload-id".into())),
+        ]
+    )]
+    #[tokio::test]
+    async fn chain_injects_distinct_identifier_values(
+        #[case] source: &str,
+        #[case] operation: &str,
+        #[case] expected: &[(&str, ParameterValue)],
+    ) {
+        let service_index = ServiceDiscovery::load_service_index(Language::Python)
+            .await
+            .expect("failed to load service index");
+        let extractor = ResourceDirectCallsExtractor::new(&service_index);
+
+        let ast = create_test_ast(source);
+        let calls = extractor.extract_resource_method_calls(&ast);
+        let call = calls
+            .iter()
+            .find(|c| c.name == operation)
+            .unwrap_or_else(|| panic!("{operation} should be extracted, got: {calls:?}"));
+
+        for (name, value) in expected {
+            assert_eq!(
+                keyword_value(call, name),
+                Some(value),
+                "{name} should carry its own value {value:?}; call: {call:?}"
+            );
+        }
     }
 }

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/resource_direct_calls_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/resource_direct_calls_extractor.rs
@@ -761,27 +761,26 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
     /// positionally or by keyword, where the keyword is the snake_case of the identifier
     /// name (e.g. `BucketName` -> `bucket_name`). Keyword args are matched to the identifier
     /// whose snake_case name they equal; positional args fill the remaining identifiers in
-    /// declared order. Returns `None` unless every identifier is supplied exactly once and
-    /// no extra args remain — so a call with the wrong number or names of args bails rather
-    /// than mismapping.
+    /// declared order.
+    ///
+    /// A `**kwargs` dictionary splat is assumed to supply whatever identifiers the explicit
+    /// args do not — those get a `synthetic_<name>` placeholder value, so the chain still
+    /// resolves to its operation (avoiding under-permissioning) even though the specific
+    /// values are unknown. The disambiguator applies the same leniency for unpacking.
+    ///
+    /// Returns `None` when the explicit args cannot line up — too many args, an unknown
+    /// keyword, or a keyword colliding with a positionally-filled identifier — so a
+    /// malformed call bails rather than mismapping.
     fn assign_args_to_identifiers(
         args: &[Parameter],
         identifier_names: &[&str],
     ) -> Option<HashMap<String, ParameterValue>> {
-        // A `**kwargs` splat hides identifier values we cannot map; bail.
-        if args
+        let has_splat = args
             .iter()
-            .any(|a| matches!(a, Parameter::DictionarySplat { .. }))
-        {
-            return None;
-        }
+            .any(|a| matches!(a, Parameter::DictionarySplat { .. }));
 
-        // Wrong arg count can never line up one-to-one with the identifiers.
-        if args.len() != identifier_names.len() {
-            return None;
-        }
-
-        // Index keyword args by name; collect positional values in order.
+        // Index keyword args by name; collect positional values in order. (A splat carries
+        // no mappable name/value, so it is neither — it only relaxes the checks below.)
         let mut keyword: HashMap<&str, &ParameterValue> = HashMap::new();
         let mut positional: Vec<&ParameterValue> = Vec::new();
         for arg in args {
@@ -793,19 +792,33 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
                     }
                 }
                 Parameter::Positional { value, .. } => positional.push(value),
-                Parameter::DictionarySplat { .. } => unreachable!("splats rejected above"),
+                Parameter::DictionarySplat { .. } => {}
             }
+        }
+
+        // The explicit args must fit within the identifiers. Without a splat the counts
+        // must match exactly; with a splat the remaining identifiers come from the splat,
+        // so only require that the explicit args don't exceed the identifier count.
+        let explicit_count = positional.len() + keyword.len();
+        let fits = if has_splat {
+            explicit_count <= identifier_names.len()
+        } else {
+            explicit_count == identifier_names.len()
+        };
+        if !fits {
+            return None;
         }
 
         // Assign exactly like Python: positional args fill the FIRST identifiers in
         // declared order; keyword args then fill the REMAINING identifiers by name. A
         // keyword that targets an already positionally-filled identifier is a collision
-        // ("got multiple values for argument") — invalid Python, so we bail.
+        // ("got multiple values for argument") — invalid Python, so we bail. Any identifier
+        // still unfilled is assumed to come from the splat (placeholder value).
         let mut assigned = HashMap::with_capacity(identifier_names.len());
         let mut identifiers = identifier_names.iter();
 
         for value in &positional {
-            // `args.len() == identifier_names.len()` guarantees a slot exists here.
+            // `explicit_count <= identifier_names.len()` guarantees a slot exists here.
             let name = identifiers.next()?;
             assigned.insert((*name).to_string(), (*value).clone());
         }
@@ -813,8 +826,13 @@ impl<'a> ResourceDirectCallsExtractor<'a> {
         for name in identifiers {
             let kwarg_name =
                 ServiceDiscovery::operation_to_method_name(name, crate::Language::Python);
-            let value = keyword.remove(kwarg_name.as_str())?;
-            assigned.insert((*name).to_string(), value.clone());
+            let value = match keyword.remove(kwarg_name.as_str()) {
+                Some(value) => value.clone(),
+                // Unfilled by an explicit arg: provided by the splat, if present.
+                None if has_splat => ParameterValue::Unresolved(format!("synthetic_{kwarg_name}")),
+                None => return None,
+            };
+            assigned.insert((*name).to_string(), value);
         }
 
         // Any keyword left over either named an identifier already filled positionally

--- a/iam-policy-autopilot-policy-generation/tests/python_chained_subresource_action_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/python_chained_subresource_action_test.rs
@@ -129,6 +129,55 @@ def handle():
 "#,
     &[]
 )]
+// Depth-3 chain: verifies identifier accumulation recurses beyond two levels.
+// Object("b","k") -> MultipartUpload("id") -> Part(1) -> upload(...) carries
+// BucketName/ObjectKey from Object, UploadId from MultipartUpload, and PartNumber from
+// the Part navigation into the UploadPart operation.
+#[case::deep_chain_multipart_upload_part(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    s3.Object("my-bucket", "my-key").MultipartUpload("upload-id").Part(1).upload(Body="data")
+"#,
+    &[("s3", "upload_part")]
+)]
+// Accessor name differs from the target resource type (`Acl` -> type `BucketAcl`),
+// verifying that sub-resources are keyed by accessor, not by type.
+#[case::accessor_differs_from_type_bucket_acl(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    s3.Bucket("my-bucket").Acl().put(ACL="private")
+"#,
+    &[("s3", "put_bucket_acl")]
+)]
+// A chain through an unknown sub-resource accessor must resolve to nothing — a chain is
+// resolved fully or not at all, never partially or speculatively (no over-approximation).
+#[case::unknown_sub_resource_accessor(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    s3.Bucket("my-bucket").Sprocket("x").put(Body="data")
+"#,
+    &[]
+)]
+// A known nested resource with an unknown leaf action must also resolve to nothing.
+#[case::unknown_leaf_action(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    s3.Bucket("my-bucket").Object("my-key").frobnicate(X="data")
+"#,
+    &[]
+)]
 #[tokio::test]
 async fn subresource_action_resolves(#[case] src: &str, #[case] expected_ops: &[(&str, &str)]) {
     let actual = extract(src).await;

--- a/iam-policy-autopilot-policy-generation/tests/python_chained_subresource_action_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/python_chained_subresource_action_test.rs
@@ -191,6 +191,31 @@ def handle():
 "#,
     &[]
 )]
+// A `**kwargs` dictionary splat is assumed to supply the identifiers, so the chain still
+// resolves to its operation (the specific identifier values are unknown but the action is
+// known) — assuming all keys are provided avoids under-permissioning.
+#[case::dictionary_splat_constructor(
+    r#"
+import boto3
+
+def handle(ids):
+    s3 = boto3.resource("s3")
+    s3.Object(**ids).put(Body="data")
+"#,
+    &[("s3", "put_object")]
+)]
+// A splat combined with an explicit identifier: the explicit `Key` is taken as given, and
+// `Bucket` is assumed to come from the splat. Still resolves to the operation.
+#[case::dictionary_splat_with_explicit_arg(
+    r#"
+import boto3
+
+def handle(rest):
+    s3 = boto3.resource("s3")
+    s3.Object(key="my-key", **rest).put(Body="data")
+"#,
+    &[("s3", "put_object")]
+)]
 #[tokio::test]
 async fn subresource_action_resolves(#[case] src: &str, #[case] expected_ops: &[(&str, &str)]) {
     let actual = extract(src).await;

--- a/iam-policy-autopilot-policy-generation/tests/python_chained_subresource_action_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/python_chained_subresource_action_test.rs
@@ -178,6 +178,19 @@ def handle():
 "#,
     &[]
 )]
+// Mixing a positional and a keyword that target the same identifier is invalid Python
+// ("got multiple values for argument"). We must not silently mis-assign it — bail.
+// Here the positional "b" fills BucketName, and `bucket_name="x"` collides with it.
+#[case::positional_keyword_collision(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    s3.Object("b", bucket_name="x").put(Body="data")
+"#,
+    &[]
+)]
 #[tokio::test]
 async fn subresource_action_resolves(#[case] src: &str, #[case] expected_ops: &[(&str, &str)]) {
     let actual = extract(src).await;

--- a/iam-policy-autopilot-policy-generation/tests/python_chained_subresource_action_test.rs
+++ b/iam-policy-autopilot-policy-generation/tests/python_chained_subresource_action_test.rs
@@ -1,0 +1,143 @@
+//! Regression tests for chained and nested boto3 sub-resource action calls.
+//!
+//! boto3 resource actions can be invoked on an inline sub-resource constructor, on a
+//! variable bound to one, and on chains that navigate one or more sub-resources before
+//! the action. All of the following must resolve to `s3:PutObject`:
+//!
+//! ```python
+//! s3 = boto3.resource("s3")
+//! # assigned single-level
+//! bucket = s3.Bucket("b"); bucket.put_object(Key="k", Body=data)
+//! # chained single-level
+//! s3.Bucket("b").put_object(Key="k", Body=data)
+//! # nested chained
+//! s3.Bucket("b").Object("k").put(Body=data)
+//! # nested, assigned mid-chain
+//! obj = s3.Bucket("b").Object("k"); obj.put(Body=data)
+//! ```
+//!
+//! The resource model injects the required identifiers (`Bucket`, `Key`) from the
+//! resource's identifiers, so the call is valid even though only `Key`/`Body` appear at
+//! the action call site. Navigating a (sub-)resource without invoking an action is NOT
+//! an API call and must not produce any permissions.
+
+use iam_policy_autopilot_policy_generation::{ExtractionEngine, Language, SourceFile};
+use rstest::rstest;
+use std::path::PathBuf;
+
+/// Extract method calls as sorted `(service, method)` pairs for exact comparison.
+/// A call with multiple possible services yields one pair per service.
+async fn extract(src: &str) -> Vec<(String, String)> {
+    let engine = ExtractionEngine::new();
+    let sf = SourceFile::with_language(PathBuf::from("app.py"), src.to_string(), Language::Python);
+    let extracted = engine
+        .extract_sdk_method_calls(Language::Python, vec![sf])
+        .await
+        .expect("extraction should succeed");
+    let mut ops: Vec<(String, String)> = extracted
+        .methods
+        .iter()
+        .flat_map(|m| {
+            m.possible_services
+                .iter()
+                .map(move |service| (service.clone(), m.name.clone()))
+        })
+        .collect();
+    ops.sort();
+    ops
+}
+
+/// Each case asserts the *exact* set of extracted `(service, method)` operations — no
+/// missing and no spurious entries. The fix is keyed off resource type, so it
+/// generalizes across services.
+#[rstest]
+#[case::assigned_s3_put_object(
+    r#"
+import boto3
+
+def handle():
+    body = "data"
+    s3 = boto3.resource("s3")
+    bucket = s3.Bucket("my-bucket")
+    bucket.put_object(Key="k", Body=body)
+"#,
+    &[("s3", "put_object")]
+)]
+#[case::chained_s3_put_object(
+    r#"
+import boto3
+
+def handle():
+    body = "data"
+    s3 = boto3.resource("s3")
+    s3.Bucket("my-bucket").put_object(Key="k", Body=body)
+"#,
+    &[("s3", "put_object")]
+)]
+#[case::chained_dynamodb_get_item(
+    r#"
+import boto3
+
+def handle():
+    dynamodb = boto3.resource("dynamodb")
+    dynamodb.Table("my-table").get_item(Key={"id": "1"})
+"#,
+    &[("dynamodb", "get_item")]
+)]
+#[case::nested_bucket_object_put(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    s3.Bucket("my-bucket").Object("my-key").put(Body="data")
+"#,
+    &[("s3", "put_object")]
+)]
+#[case::assigned_nested_chain_then_action(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    obj = s3.Bucket("my-bucket").Object("my-key")
+    obj.put(Body="data")
+"#,
+    &[("s3", "put_object")]
+)]
+#[case::assigned_nested_chain_two_actions(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    obj = s3.Bucket("my-bucket").Object("my-key")
+    obj.put(Body="data")
+    obj.delete()
+"#,
+    &[("s3", "delete_object"), ("s3", "put_object")]
+)]
+// Assigning a (sub-)resource without invoking any action must not, on its own,
+// produce permissions — navigation is not an API call.
+#[case::assignment_only_no_action(
+    r#"
+import boto3
+
+def handle():
+    s3 = boto3.resource("s3")
+    obj = s3.Bucket("my-bucket").Object("my-key")
+"#,
+    &[]
+)]
+#[tokio::test]
+async fn subresource_action_resolves(#[case] src: &str, #[case] expected_ops: &[(&str, &str)]) {
+    let actual = extract(src).await;
+    let expected: Vec<(String, String)> = expected_ops
+        .iter()
+        .map(|(service, method)| (service.to_string(), method.to_string()))
+        .collect();
+    assert_eq!(
+        actual, expected,
+        "extracted operations should be exactly {expected:?}, got: {actual:?}"
+    );
+}


### PR DESCRIPTION
Closes #

## Description

Added support for boto3 resources with chained operation calls like `s3.Object("my-key").put(Body="data")` and sub-resources like `s3.Bucket("my-bucket").Object("my-key").put(Body="data")`.

Removed the fall-back that would extract all operations of a resource if the operation couldn't be found (as in `s3.Object("my-key")` without a `.put(..)`).

## Checklist

- [x] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
