### PR TITLE
fix(ci): Collapse multi-line expressions in Slack workflow payload

### DIFF
--- a/.github/workflows/slack_notifications.yml
+++ b/.github/workflows/slack_notifications.yml
@@ -184,16 +184,13 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": "${{ steps.context.outputs.emoji }} ${{ steps.context.outputs.label }} #${{
-steps.context.outputs.number }} ${{ steps.context.outputs.action }} by ${{ steps.context.outputs.sender }} in ${{
-steps.context.outputs.repo }}",
+              "text": "${{ steps.context.outputs.emoji }} ${{ steps.context.outputs.label }} #${{ steps.context.outputs.number }} ${{ steps.context.outputs.action }} by ${{ steps.context.outputs.sender }} in ${{ steps.context.outputs.repo }}",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "${{ steps.context.outputs.emoji }} ${{ steps.context.outputs.label }} ${{
-steps.context.outputs.action }}",
+                    "text": "${{ steps.context.outputs.emoji }} ${{ steps.context.outputs.label }} ${{ steps.context.outputs.action }}",
                     "emoji": true
                   }
                 },
@@ -201,8 +198,7 @@ steps.context.outputs.action }}",
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<${{ steps.context.outputs.url }}|#${{ steps.context.outputs.number }} ${{
-steps.context.outputs.title }}>"
+                    "text": "<${{ steps.context.outputs.url }}|#${{ steps.context.outputs.number }} ${{ steps.context.outputs.title }}>"
                   },
                   "accessory": {
                     "type": "button",
@@ -218,8 +214,7 @@ steps.context.outputs.title }}>"
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Action by:* ${{ steps.context.outputs.sender }}  •  *Repo:* ${{
-steps.context.outputs.repo }}"
+                      "text": "*Action by:* ${{ steps.context.outputs.sender }}  •  *Repo:* ${{ steps.context.outputs.repo }}"
                     }
                   ]
                 },
@@ -227,8 +222,7 @@ steps.context.outputs.repo }}"
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ steps.mentions.outputs.mentions && format('cc {0}', steps.mentions.outputs.mentions) ||
-' ' }}"
+                    "text": "${{ steps.mentions.outputs.mentions && format('cc {0}', steps.mentions.outputs.mentions) || ' ' }}"
                   }
                 }
               ]


### PR DESCRIPTION
GitHub Actions YAML parser does not support ${{ }} expressions split across multiple lines in block scalars. Consolidate each expression onto a single line to fix the syntax error on line 188.

Closes #

## Description

Fixed multi-line JSON breaking GH yaml parsing.

## Checklist

- [ ] ~~I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)~~
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
