### PR TITLE
fix: add resource override for cloudwatch:PutMetricData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - An unrecognized method on a known boto3 resource no longer expands to every action of that resource. Such calls now contribute no permissions instead of over-approximating
 - Generated policy statements are now sorted globally by service before being assigned to policies, so statements for the same service stay together (within size limits), producing deterministic, review-friendly output and stable diffs. Note: when cross-service action merging is enabled (`--minimize-policy-size` / `allow_cross_service_merging = true`), statements are grouped by shared resource rather than by service, so a single service's actions may be merged into a statement keyed on another service and the "same service stays together" grouping does not hold. This is expected for that option, which exists to produce more compact policies; the sort remains deterministic. (#153)
 
+### Fixed
+
+- `cloudwatch:PutMetricData` no longer scopes to `dataset/*` resources — the AWS service reference added `dataset` as a resource type, but regular custom metric publishing requires `Resource: "*"`
+
 ## [0.2.3] - 2026-06-17
 
 ### Added

--- a/iam-policy-autopilot-policy-generation/resources/config/service-configuration.json
+++ b/iam-policy-autopilot-policy-generation/resources/config/service-configuration.json
@@ -268,6 +268,9 @@
   "ResourceOverrides": {
     "iam:GetUser": {
         "user": "*"
+    },
+    "cloudwatch:PutMetricData": {
+        "dataset": "*"
     }
   }
 }


### PR DESCRIPTION
Closes #

## Description

The AWS service reference lists dataset as a resource for cloudwatch:PutMetricData, but this resource is optional — it only applies when publishing to CloudWatch Datasets. For regular custom metric publishing, Resource: "*" is required.

The tool currently has no way to detect whether a resource is optional or what would trigger its inclusion in the request. It always looks up the resource in the service reference and generates a scoped ARN, which leads to permission denial when the resource is not present in the actual API call.

This adds a resource override for PutMetricData so the dataset resource type resolves to "*". Looking for a long-term solution that can distinguish optional resources from required ones.

## Checklist

- [X] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
