### PR TITLE
feat: call graph trait, implemented for Go

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -221,6 +221,9 @@ jobs:
       - name: Run Go LSP integration tests
         run: cargo test -p iam-policy-autopilot-policy-generation --features integ-test --test gopls_integration_tests -- --ignored
 
+      - name: Run call-graph tests
+        run: cargo test -p iam-policy-autopilot-policy-generation --features integ-test,call-graph --lib call_graph -- --include-ignored
+
   unused-deps:
     name: Unused Dependencies (cargo-machete)
     needs: [changes]

--- a/iam-policy-autopilot-policy-generation/Cargo.toml
+++ b/iam-policy-autopilot-policy-generation/Cargo.toml
@@ -56,6 +56,7 @@ convert_case.workspace = true
 [features]
 default = []
 integ-test = []
+call-graph = []
 # Development features
 dev = ["tokio/test-util"]
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/call_graph/gopls.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/call_graph/gopls.rs
@@ -1,0 +1,273 @@
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use lsp_types::{DocumentSymbolResponse, SymbolKind};
+
+use super::{CallGraph, CallGraphBuilder, CallGraphError, FunctionNode};
+use crate::lsp::gopls::GoplsClient;
+use crate::lsp::{file_url, LspClientOptions};
+use crate::Location;
+
+pub(crate) struct GoplsCallGraphBuilder {
+    client: GoplsClient,
+}
+
+impl GoplsCallGraphBuilder {
+    pub(crate) async fn new(workspace_root: &Path) -> Result<Self, CallGraphError> {
+        let options = LspClientOptions {
+            initialize_timeout: Duration::from_secs(30),
+            open_document_timeout: Duration::from_secs(10),
+            request_timeout: Duration::from_secs(10),
+            shutdown_timeout: Duration::from_secs(5),
+            // gopls returns Flat (SymbolInformation) by default, which lacks selection_range.
+            // Hierarchical mode gives us DocumentSymbol with selection_range — needed to
+            // position prepare_call_hierarchy on the function name, not the `func` keyword.
+            capabilities: Some(lsp_types::ClientCapabilities {
+                text_document: Some(lsp_types::TextDocumentClientCapabilities {
+                    document_symbol: Some(lsp_types::DocumentSymbolClientCapabilities {
+                        hierarchical_document_symbol_support: Some(true),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        };
+        let client = GoplsClient::create_with_options(workspace_root, options).await?;
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl CallGraphBuilder for GoplsCallGraphBuilder {
+    async fn build(
+        &mut self,
+        _workspace_root: &Path,
+        source_files: &[PathBuf],
+    ) -> Result<CallGraph, CallGraphError> {
+        let client = &mut self.client;
+
+        let source_file_set: BTreeSet<&PathBuf> = source_files.iter().collect();
+
+        for file in source_files {
+            let content = std::fs::read_to_string(file).map_err(|e| {
+                CallGraphError::Other(format!("Failed to read {}: {e}", file.display()))
+            })?;
+            client.open_document(file, &content).await?;
+        }
+
+        let mut nodes = Vec::new();
+        // Maps node index → (uri, selection_range start) for prepare_call_hierarchy
+        let mut name_positions: Vec<(lsp_types::Url, lsp_types::Position)> = Vec::new();
+
+        for file in source_files {
+            let uri = file_url(file)?;
+
+            let Some(symbols) = client.document_symbols(&uri).await? else {
+                continue;
+            };
+
+            match symbols {
+                DocumentSymbolResponse::Nested(syms) => {
+                    for sym in syms {
+                        if matches!(sym.kind, SymbolKind::FUNCTION | SymbolKind::METHOD) {
+                            if let Some(location) = Location::from_lsp(&uri, &sym.range) {
+                                name_positions.push((uri.clone(), sym.selection_range.start));
+                                nodes.push(FunctionNode {
+                                    name: sym.name,
+                                    qualified_name: sym.detail,
+                                    location,
+                                });
+                            }
+                        }
+                    }
+                }
+                DocumentSymbolResponse::Flat(infos) => {
+                    for info in infos {
+                        if matches!(info.kind, SymbolKind::FUNCTION | SymbolKind::METHOD) {
+                            if let Some(location) = Location::from_lsp(&uri, &info.location.range) {
+                                name_positions.push((uri.clone(), info.location.range.start));
+                                nodes.push(FunctionNode {
+                                    name: info.name,
+                                    qualified_name: info.container_name,
+                                    location,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut edges: HashMap<FunctionNode, Vec<FunctionNode>> = HashMap::new();
+        for (i, node) in nodes.iter().enumerate() {
+            let (ref uri, ref name_pos) = name_positions[i];
+
+            let item = match client
+                .prepare_call_hierarchy(uri, name_pos.line, name_pos.character)
+                .await
+            {
+                Ok(Some(mut items)) if !items.is_empty() => items.swap_remove(0),
+                Ok(_) => continue,
+                Err(e) => {
+                    log::debug!(
+                        "prepare_call_hierarchy failed for '{}' at {}:{}: {e}",
+                        node.name,
+                        name_pos.line,
+                        name_pos.character
+                    );
+                    continue;
+                }
+            };
+
+            let Some(outgoing) = client.outgoing_calls(item).await? else {
+                continue;
+            };
+
+            let callees: Vec<FunctionNode> = outgoing
+                .into_iter()
+                .filter_map(|call| {
+                    let callee_path = call.to.uri.to_file_path().ok()?;
+                    if !source_file_set.contains(&callee_path) {
+                        return None;
+                    }
+                    let location = Location::from_lsp(&call.to.uri, &call.to.range)?;
+                    Some(FunctionNode {
+                        name: call.to.name,
+                        qualified_name: call.to.detail,
+                        location,
+                    })
+                })
+                .collect();
+
+            edges.insert(node.clone(), callees);
+        }
+
+        Ok(CallGraph::new(nodes, edges))
+    }
+
+    async fn shutdown(self) -> Result<(), CallGraphError> {
+        self.client.shutdown().await?;
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "integ-test", feature = "call-graph"))]
+mod tests {
+    use super::*;
+    use crate::lsp::test_utils::go;
+    use tempfile::TempDir;
+    use tokio::fs;
+
+    async fn build_graph(source: &str) -> CallGraph {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path().to_path_buf();
+        fs::write(root.join("go.mod"), go::fixtures::GO_MOD)
+            .await
+            .unwrap();
+        fs::write(root.join("main.go"), source).await.unwrap();
+
+        let mut builder = GoplsCallGraphBuilder::new(&root).await.unwrap();
+        let graph = builder.build(&root, &[root.join("main.go")]).await.unwrap();
+        builder.shutdown().await.unwrap();
+        graph
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_build_simple_call_chain() {
+        if !go::is_ready() {
+            panic!("requires Go + gopls");
+        }
+
+        let graph = build_graph(go::fixtures::SIMPLE_CALL_CHAIN).await;
+
+        let names: Vec<&str> = graph.nodes().iter().map(|n| n.name.as_str()).collect();
+        assert!(names.contains(&"main"), "got: {names:?}");
+        assert!(names.contains(&"helper"), "got: {names:?}");
+        assert!(names.contains(&"deepHelper"), "got: {names:?}");
+        assert!(names.contains(&"unrelated"), "got: {names:?}");
+
+        let main_node = graph.nodes().iter().find(|n| n.name == "main").unwrap();
+        let main_callees: Vec<&str> = graph
+            .outgoing(main_node)
+            .iter()
+            .map(|n| n.name.as_str())
+            .collect();
+        assert!(
+            main_callees.contains(&"helper"),
+            "main calls: {main_callees:?}"
+        );
+
+        let helper_node = graph.nodes().iter().find(|n| n.name == "helper").unwrap();
+        let helper_callees: Vec<&str> = graph
+            .outgoing(helper_node)
+            .iter()
+            .map(|n| n.name.as_str())
+            .collect();
+        assert!(
+            helper_callees.contains(&"deepHelper"),
+            "helper calls: {helper_callees:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_build_struct_methods() {
+        if !go::is_ready() {
+            panic!("requires Go + gopls");
+        }
+
+        let graph = build_graph(go::fixtures::STRUCT_METHODS).await;
+
+        for node in graph.nodes() {
+            println!(
+                "node: name={:?}, qualified_name={:?}, location={:?}",
+                node.name, node.qualified_name, node.location
+            );
+        }
+
+        let handle = graph
+            .nodes()
+            .iter()
+            .find(|n| n.name.contains("HandleRequest"))
+            .expect("should find HandleRequest");
+
+        let callees: Vec<&str> = graph
+            .outgoing(handle)
+            .iter()
+            .map(|n| n.name.as_str())
+            .collect();
+        assert!(
+            callees.contains(&"fetchData"),
+            "HandleRequest calls: {callees:?}"
+        );
+        assert!(
+            callees.contains(&"format"),
+            "HandleRequest calls: {callees:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_external_calls_filtered() {
+        if !go::is_ready() {
+            panic!("requires Go + gopls");
+        }
+
+        let graph = build_graph(go::fixtures::SIMPLE_CALL_CHAIN).await;
+
+        let main_node = graph.nodes().iter().find(|n| n.name == "main").unwrap();
+        let callees: Vec<&str> = graph
+            .outgoing(main_node)
+            .iter()
+            .map(|n| n.name.as_str())
+            .collect();
+        assert!(
+            !callees.contains(&"Println"),
+            "external calls should be filtered: {callees:?}"
+        );
+    }
+}

--- a/iam-policy-autopilot-policy-generation/src/extraction/call_graph/gopls.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/call_graph/gopls.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -101,7 +101,7 @@ impl CallGraphBuilder for GoplsCallGraphBuilder {
             }
         }
 
-        let mut edges: HashMap<FunctionNode, Vec<FunctionNode>> = HashMap::new();
+        let mut edges: BTreeMap<FunctionNode, Vec<FunctionNode>> = BTreeMap::new();
         for (i, node) in nodes.iter().enumerate() {
             let (ref uri, ref name_pos) = name_positions[i];
 
@@ -122,8 +122,18 @@ impl CallGraphBuilder for GoplsCallGraphBuilder {
                 }
             };
 
-            let Some(outgoing) = client.outgoing_calls(item).await? else {
-                continue;
+            let outgoing = match client.outgoing_calls(item).await {
+                Ok(Some(outgoing)) => outgoing,
+                Ok(None) => continue,
+                Err(e) => {
+                    log::debug!(
+                        "outgoing_calls failed for '{}' at {}:{}: {e}",
+                        node.name,
+                        name_pos.line,
+                        name_pos.character
+                    );
+                    continue;
+                }
             };
 
             let callees: Vec<FunctionNode> = outgoing

--- a/iam-policy-autopilot-policy-generation/src/extraction/call_graph/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/call_graph/mod.rs
@@ -3,7 +3,7 @@
 
 pub(crate) mod gopls;
 
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
@@ -30,12 +30,12 @@ pub(crate) enum CallGraphError {
 
 /// The call graph for a set of source files.
 pub(crate) struct CallGraph {
-    edges: HashMap<FunctionNode, Vec<FunctionNode>>,
+    edges: BTreeMap<FunctionNode, Vec<FunctionNode>>,
     nodes: Vec<FunctionNode>,
 }
 
 impl CallGraph {
-    pub fn new(nodes: Vec<FunctionNode>, edges: HashMap<FunctionNode, Vec<FunctionNode>>) -> Self {
+    pub fn new(nodes: Vec<FunctionNode>, edges: BTreeMap<FunctionNode, Vec<FunctionNode>>) -> Self {
         Self { edges, nodes }
     }
 
@@ -182,7 +182,7 @@ mod tests {
             })
             .collect();
 
-        let mut edges: HashMap<FunctionNode, Vec<FunctionNode>> = HashMap::new();
+        let mut edges: BTreeMap<FunctionNode, Vec<FunctionNode>> = BTreeMap::new();
         for (caller_name, callee_name) in edge_pairs {
             let caller = nodes
                 .iter()
@@ -347,7 +347,7 @@ mod tests {
             location: Location::new(PathBuf::from("f.go"), (5, 1), (15, 1)),
         };
 
-        let graph = CallGraph::new(vec![outer, inner], HashMap::new());
+        let graph = CallGraph::new(vec![outer, inner], BTreeMap::new());
 
         let loc = Location::new(PathBuf::from("f.go"), (10, 5), (10, 15));
         assert_eq!(graph.enclosing_function(&loc).unwrap().name, "inner");

--- a/iam-policy-autopilot-policy-generation/src/extraction/call_graph/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/call_graph/mod.rs
@@ -1,0 +1,355 @@
+// TODO: remove once model_generation or CLI consumes this module
+#![allow(dead_code)]
+
+pub(crate) mod gopls;
+
+use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use crate::extraction::SdkMethodCall;
+use crate::Location;
+
+/// A node in the call graph representing a function or method.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct FunctionNode {
+    pub name: String,
+    pub qualified_name: Option<String>,
+    pub location: Location,
+}
+
+/// Error type for call graph operations.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CallGraphError {
+    #[error("LSP error: {0}")]
+    Lsp(#[from] crate::lsp::LspError),
+    #[error("{0}")]
+    Other(String),
+}
+
+/// The call graph for a set of source files.
+pub(crate) struct CallGraph {
+    edges: HashMap<FunctionNode, Vec<FunctionNode>>,
+    nodes: Vec<FunctionNode>,
+}
+
+impl CallGraph {
+    pub fn new(nodes: Vec<FunctionNode>, edges: HashMap<FunctionNode, Vec<FunctionNode>>) -> Self {
+        Self { edges, nodes }
+    }
+
+    pub fn nodes(&self) -> &[FunctionNode] {
+        &self.nodes
+    }
+
+    pub fn outgoing(&self, node: &FunctionNode) -> &[FunctionNode] {
+        self.edges.get(node).map_or(&[], Vec::as_slice)
+    }
+
+    /// Partition SDK calls by entry point based on call graph reachability.
+    ///
+    /// Each entry point maps to the SDK calls whose location falls within a function
+    /// reachable from that entry point. A call may appear under multiple entry points
+    /// if multiple entry points reach the same function.
+    pub fn partition_calls(
+        &self,
+        entry_points: &[FunctionNode],
+        sdk_calls: &[SdkMethodCall],
+    ) -> Vec<(FunctionNode, Vec<SdkMethodCall>)> {
+        let mut results = Vec::new();
+
+        for entry in entry_points {
+            let reachable = self.reachable_set(entry);
+            let mut calls_for_entry = Vec::new();
+
+            for call in sdk_calls {
+                let Some(location) = call.metadata.as_ref().map(|m| &m.location) else {
+                    continue;
+                };
+                if let Some(enclosing) = self.enclosing_function(location) {
+                    if reachable.contains(enclosing) {
+                        calls_for_entry.push(call.clone());
+                    }
+                }
+            }
+
+            results.push((entry.clone(), calls_for_entry));
+        }
+
+        results
+    }
+
+    fn enclosing_function(&self, location: &Location) -> Option<&FunctionNode> {
+        self.nodes
+            .iter()
+            .filter(|node| {
+                node.location.file_path == location.file_path
+                    && node.location.start_position <= location.start_position
+                    && node.location.end_position >= location.end_position
+            })
+            .min_by_key(|node| {
+                // Prefer the smallest enclosing range (innermost function)
+                (
+                    node.location.end_position.0 - node.location.start_position.0,
+                    node.location.end_position.1,
+                )
+            })
+    }
+
+    fn reachable_set<'a>(&'a self, from: &'a FunctionNode) -> BTreeSet<&'a FunctionNode> {
+        let mut visited = BTreeSet::new();
+        let mut queue = VecDeque::new();
+
+        visited.insert(from);
+        queue.push_back(from);
+
+        while let Some(current) = queue.pop_front() {
+            for callee in self.outgoing(current) {
+                if visited.insert(callee) {
+                    queue.push_back(callee);
+                }
+            }
+        }
+
+        visited
+    }
+}
+
+/// Trait for building a call graph from source files.
+#[async_trait]
+pub(crate) trait CallGraphBuilder: Send + Sync {
+    /// Build the call graph for the workspace, scoped to the given source files.
+    ///
+    /// Only function calls where both caller and callee are within `source_files`
+    /// appear as edges. Calls to external dependencies are not followed.
+    async fn build(
+        &mut self,
+        workspace_root: &Path,
+        source_files: &[PathBuf],
+    ) -> Result<CallGraph, CallGraphError>;
+
+    /// Shut down any underlying server/process.
+    /// If dynamic dispatch (`dyn CallGraphBuilder`) is needed, change to `self: Box<Self>`.
+    async fn shutdown(self) -> Result<(), CallGraphError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use std::path::PathBuf;
+
+    /// Build a CallGraph from a compact edge spec.
+    ///
+    /// Each string in `edge_specs` has the form `"caller -> callee1, callee2"`.
+    /// Nodes are auto-created with non-overlapping ranges in "test.go".
+    fn graph_from_spec(edge_specs: &[&str]) -> CallGraph {
+        let mut all_names = Vec::new();
+        let mut edge_pairs: Vec<(&str, &str)> = Vec::new();
+
+        for spec in edge_specs {
+            let parts: Vec<&str> = spec.split("->").collect();
+            let caller = parts[0].trim();
+            if !all_names.contains(&caller) {
+                all_names.push(caller);
+            }
+            if parts.len() == 2 {
+                for callee in parts[1].split(',') {
+                    let callee = callee.trim();
+                    if !all_names.contains(&callee) {
+                        all_names.push(callee);
+                    }
+                    edge_pairs.push((caller, callee));
+                }
+            }
+        }
+
+        let nodes: Vec<FunctionNode> = all_names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                let start_line = i * 10 + 1;
+                FunctionNode {
+                    name: name.to_string(),
+                    qualified_name: None,
+                    location: Location::new(
+                        PathBuf::from("test.go"),
+                        (start_line, 1),
+                        (start_line + 9, 1),
+                    ),
+                }
+            })
+            .collect();
+
+        let mut edges: HashMap<FunctionNode, Vec<FunctionNode>> = HashMap::new();
+        for (caller_name, callee_name) in edge_pairs {
+            let caller = nodes
+                .iter()
+                .find(|n| n.name == caller_name)
+                .unwrap()
+                .clone();
+            let callee = nodes
+                .iter()
+                .find(|n| n.name == callee_name)
+                .unwrap()
+                .clone();
+            edges.entry(caller).or_default().push(callee);
+        }
+
+        CallGraph::new(nodes, edges)
+    }
+
+    /// Place an SDK call inside a named function's range.
+    fn sdk_call_in(graph: &CallGraph, operation: &str, function_name: &str) -> SdkMethodCall {
+        use crate::extraction::SdkMethodCallMetadata;
+        let node = graph
+            .nodes()
+            .iter()
+            .find(|n| n.name == function_name)
+            .unwrap();
+        let line = node.location.start_line() + 1;
+        SdkMethodCall {
+            name: operation.to_string(),
+            possible_services: vec!["s3".to_string()],
+            metadata: Some(SdkMethodCallMetadata::new(
+                format!("client.{operation}(...)"),
+                Location::new(node.location.file_path.clone(), (line, 5), (line, 15)),
+            )),
+        }
+    }
+
+    fn reachable_names(graph: &CallGraph, from: &str) -> Vec<String> {
+        let node = graph.nodes().iter().find(|n| n.name == from).unwrap();
+        graph
+            .reachable_set(node)
+            .into_iter()
+            .map(|n| n.name.clone())
+            .collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // Reachability
+    // -----------------------------------------------------------------------
+
+    #[rstest]
+    #[case(&["a -> b", "b -> c"], "a", &["a", "b", "c"])]
+    #[case(&["a -> b", "b -> c"], "b", &["b", "c"])]
+    #[case(&["a -> b", "b -> c"], "c", &["c"])]
+    #[case(&["a -> b, c", "b -> d", "c -> d"], "a", &["a", "b", "c", "d"])]
+    #[case(&["a -> b", "b -> a"], "a", &["a", "b"])]
+    #[case(&["a"], "a", &["a"])]
+    fn test_reachable_set(
+        #[case] edge_specs: &[&str],
+        #[case] from: &str,
+        #[case] expected: &[&str],
+    ) {
+        let graph = graph_from_spec(edge_specs);
+        assert_eq!(reachable_names(&graph, from), expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // Partition calls
+    // -----------------------------------------------------------------------
+
+    #[rstest]
+    // Basic: handler calls fetch which has GetObject; unrelated has DeleteBucket
+    #[case(
+        &["handler -> fetch", "fetch", "unrelated"],
+        &[("GetObject", "fetch"), ("DeleteBucket", "unrelated")],
+        "handler",
+        &["GetObject"],
+    )]
+    // Shared callee: both entry points reach the same SDK call
+    #[case(
+        &["a -> shared", "b -> shared", "shared"],
+        &[("PutItem", "shared")],
+        "a",
+        &["PutItem"],
+    )]
+    // Direct: SDK call in the entry point itself
+    #[case(
+        &["handler"],
+        &[("GetObject", "handler")],
+        "handler",
+        &["GetObject"],
+    )]
+    // Unreachable: SDK call in a function not connected to entry point
+    #[case(
+        &["handler", "other"],
+        &[("GetObject", "other")],
+        "handler",
+        &[],
+    )]
+    fn test_partition_calls_single_entry(
+        #[case] edge_specs: &[&str],
+        #[case] calls: &[(&str, &str)],
+        #[case] entry_point: &str,
+        #[case] expected_ops: &[&str],
+    ) {
+        let graph = graph_from_spec(edge_specs);
+
+        let sdk_calls: Vec<SdkMethodCall> = calls
+            .iter()
+            .map(|(op, func)| sdk_call_in(&graph, op, func))
+            .collect();
+
+        let entry = graph
+            .nodes()
+            .iter()
+            .find(|n| n.name == entry_point)
+            .unwrap()
+            .clone();
+
+        let result = graph.partition_calls(&[entry], &sdk_calls);
+
+        let actual_names: Vec<&str> = result[0].1.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(actual_names, expected_ops);
+    }
+
+    #[test]
+    fn test_partition_calls_multiple_entry_points_share_call() {
+        let graph = graph_from_spec(&["a -> shared", "b -> shared", "shared"]);
+        let call = sdk_call_in(&graph, "PutItem", "shared");
+
+        let entries: Vec<FunctionNode> = ["a", "b"]
+            .iter()
+            .map(|name| {
+                graph
+                    .nodes()
+                    .iter()
+                    .find(|n| &n.name == name)
+                    .unwrap()
+                    .clone()
+            })
+            .collect();
+
+        let result = graph.partition_calls(&entries, &[call]);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].1.len(), 1);
+        assert_eq!(result[1].1.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Enclosing function
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_enclosing_function_finds_innermost() {
+        let outer = FunctionNode {
+            name: "outer".to_string(),
+            qualified_name: None,
+            location: Location::new(PathBuf::from("f.go"), (1, 1), (30, 1)),
+        };
+        let inner = FunctionNode {
+            name: "inner".to_string(),
+            qualified_name: None,
+            location: Location::new(PathBuf::from("f.go"), (5, 1), (15, 1)),
+        };
+
+        let graph = CallGraph::new(vec![outer, inner], HashMap::new());
+
+        let loc = Location::new(PathBuf::from("f.go"), (10, 5), (10, 15));
+        assert_eq!(graph.enclosing_function(&loc).unwrap().name, "inner");
+    }
+}

--- a/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/mod.rs
@@ -23,6 +23,9 @@ pub(crate) mod waiter_model;
 
 pub(crate) mod terraform;
 
+#[cfg(feature = "call-graph")]
+pub(crate) mod call_graph;
+
 // Re-export main types for convenience
 pub use engine::Engine;
 // Not part of the stable public API — exposed only for integration tests in tests/.

--- a/iam-policy-autopilot-policy-generation/src/lsp/error.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/error.rs
@@ -1,4 +1,6 @@
+use std::path::PathBuf;
 use std::time::Duration;
+
 use thiserror::Error;
 
 /// Errors that can occur during LSP operations.
@@ -27,6 +29,10 @@ pub enum LspError {
     /// Failed to parse an LSP response.
     #[error("Failed to parse LSP response: {0}")]
     ParseFailed(String),
+
+    /// Failed to convert a file path to a URI.
+    #[error("Failed to convert a file path to a URI: {0}")]
+    InvalidPath(PathBuf),
 
     /// The language server returned an error.
     #[error("Language server error: {0}")]

--- a/iam-policy-autopilot-policy-generation/src/lsp/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/lsp/mod.rs
@@ -68,6 +68,8 @@ pub struct LspClientOptions {
     pub request_timeout: Duration,
     /// Timeout for shutdown.
     pub shutdown_timeout: Duration,
+    /// Client capabilities to advertise during initialization.
+    pub capabilities: Option<ClientCapabilities>,
 }
 
 impl Default for LspClientOptions {
@@ -77,6 +79,7 @@ impl Default for LspClientOptions {
             initialize_timeout: Duration::from_secs(10),
             request_timeout: Duration::from_secs(5),
             shutdown_timeout: Duration::from_secs(2),
+            capabilities: None,
         }
     }
 }
@@ -190,7 +193,7 @@ impl<C: LspServerConfig> LspClient<C> {
         let init_params = InitializeParams {
             process_id: Some(std::process::id()),
             root_uri: Some(workspace_uri.clone()),
-            capabilities: ClientCapabilities::default(),
+            capabilities: options.capabilities.clone().unwrap_or_default(),
             workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
                 uri: workspace_uri,
                 name: workspace_root
@@ -233,9 +236,7 @@ impl<C: LspServerConfig> LspClient<C> {
         file_path: impl AsRef<Path>,
         content: &str,
     ) -> Result<(), LspError> {
-        let uri = Url::from_file_path(file_path.as_ref()).map_err(|()| {
-            LspError::ParseFailed(format!("Invalid file path: {:?}", file_path.as_ref()))
-        })?;
+        let uri = file_url(file_path.as_ref())?;
 
         let uri_string = uri.to_string();
         if self.opened_documents.contains(&uri_string) {
@@ -446,6 +447,11 @@ fn non_empty(s: &str) -> Option<String> {
     } else {
         Some(s.to_string())
     }
+}
+
+/// Convert a file path to a `file://` URL.
+pub fn file_url(path: &Path) -> Result<Url, LspError> {
+    Url::from_file_path(path).map_err(|()| LspError::InvalidPath(path.to_path_buf()))
 }
 
 #[cfg(test)]

--- a/iam-policy-autopilot-policy-generation/tests/gopls_integration_tests.rs
+++ b/iam-policy-autopilot-policy-generation/tests/gopls_integration_tests.rs
@@ -63,6 +63,7 @@ async fn open_workspace(fixture: &str) -> (GoTestWorkspace, GoplsClient) {
         open_document_timeout: Duration::from_secs(10),
         request_timeout: Duration::from_secs(10),
         shutdown_timeout: Duration::from_secs(5),
+        capabilities: None,
     };
 
     let mut client = GoplsClient::create_with_options(&workspace.root_path, options)


### PR DESCRIPTION
Closes #

## Description

- Call graph generation for Go using LSP (via `prepare_call_hierarchy`) to be used for library model generation
  - will be used for filtering the `SdkMethodCall` results from the extraction phase
  - adds language-agnostic `CallGraph` and the `CallGraphBuilder` trait. The trait is currently not object-safe, see comment on `shutdown`, we can change that in the future.
- gated behind the `call-graph` feature
- no customer facing change
- builds on https://github.com/awslabs/iam-policy-autopilot/pull/223 (this PR targets the `go-lsp` branch so the diff doesn't include those changes)

Addressed comments in https://github.com/mschlaipfer/iam-policy-autopilot/pull/17

## Checklist

- [X] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
