### PR TITLE
fix(ci): Use intermediate env vars to mitigate script injection

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -107,13 +107,16 @@ jobs:
 
     - name: Test wheel installation and functionality
       shell: bash
+      env:
+        USE_QEMU: ${{ matrix.use-qemu }}
+        EXPECTED_VERSION: ${{ github.event.release.tag_name }}
       run: |
-        if [[ "${{ matrix.use-qemu }}" == "true" ]]; then
+        if [[ "$USE_QEMU" == "true" ]]; then
           # Test aarch64 wheel in Docker with QEMU
           docker run --rm --platform linux/arm64 \
             -v $(pwd)/wheels:/wheels \
             -v $(pwd)/iam-policy-autopilot-cli/tests/resources:/test-resources \
-            -e EXPECTED_VERSION='${{ github.event.release.tag_name }}' \
+            -e EXPECTED_VERSION="$EXPECTED_VERSION" \
             python:3.11-slim bash -c "
               set -e
               pip install /wheels/*.whl
@@ -161,7 +164,6 @@ jobs:
           fi
           echo '=== Verifying version matches release tag ==='
           VERSION=$(iam-policy-autopilot --version | awk '{print $2}')
-          EXPECTED_VERSION='${{ github.event.release.tag_name }}'
           echo "Binary version: $VERSION"
           echo "Expected version: $EXPECTED_VERSION"
           if [[ "$VERSION" != "$EXPECTED_VERSION" ]]; then
@@ -187,6 +189,8 @@ jobs:
 
     - name: Extract and package binaries
       shell: bash
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
       run: |
         mkdir -p binaries
         
@@ -224,7 +228,7 @@ jobs:
           
           # Package binary
           cd binaries
-          ARCHIVE_NAME="iam-policy-autopilot-${{ github.event.release.tag_name }}-${simple_target}"
+          ARCHIVE_NAME="iam-policy-autopilot-${RELEASE_TAG}-${simple_target}"
           
           if [[ "$binary_ext" == ".exe" ]]; then
             zip "${ARCHIVE_NAME}.zip" "${BINARY_NAME}"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,10 +203,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install Python LSP test dependencies
+        env:
+          WORKSPACE_DIR: ${{ github.workspace }}
         run: |
           python3 -m venv .lsp-venv
           .lsp-venv/bin/pip install 'ty>=0.0.39,<0.1' boto3 'boto3-stubs[essential]'
-          echo "${{ github.workspace }}/.lsp-venv/bin" >> $GITHUB_PATH
+          echo "${WORKSPACE_DIR}/.lsp-venv/bin" >> $GITHUB_PATH
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/weekly_submodule_update.yml
+++ b/.github/workflows/weekly_submodule_update.yml
@@ -68,13 +68,16 @@ jobs:
 
     - name: Compare versions
       id: compare
+      env:
+        PYPI_OUTPUT: ${{ steps.pypi.outputs.output }}
+        BUILT_OUTPUT: ${{ steps.built.outputs.output }}
       run: |
         extract_hash() { echo "$1" | grep "$2" | sed 's/.*data_hash=\([^ ]*\).*/\1/'; }
         
-        PYPI_BOTO3_HASH=$(extract_hash "${{ steps.pypi.outputs.output }}" "boto3")
-        PYPI_BOTOCORE_HASH=$(extract_hash "${{ steps.pypi.outputs.output }}" "botocore")
-        BUILT_BOTO3_HASH=$(extract_hash "${{ steps.built.outputs.output }}" "boto3")
-        BUILT_BOTOCORE_HASH=$(extract_hash "${{ steps.built.outputs.output }}" "botocore")
+        PYPI_BOTO3_HASH=$(extract_hash "$PYPI_OUTPUT" "boto3")
+        PYPI_BOTOCORE_HASH=$(extract_hash "$PYPI_OUTPUT" "botocore")
+        BUILT_BOTO3_HASH=$(extract_hash "$BUILT_OUTPUT" "boto3")
+        BUILT_BOTOCORE_HASH=$(extract_hash "$BUILT_OUTPUT" "botocore")
 
         echo "PyPI boto3 hash: $PYPI_BOTO3_HASH"
         echo "Built boto3 hash: $BUILT_BOTO3_HASH"
@@ -105,14 +108,17 @@ jobs:
       run: echo "name=auto/update-submodules-$(date +%Y%m%d)" >> $GITHUB_OUTPUT
 
     - name: Update submodules
+      env:
+        BOTO3_TAG: ${{ needs.check_versions.outputs.boto3_tag }}
+        BOTOCORE_TAG: ${{ needs.check_versions.outputs.botocore_tag }}
       run: |
         cd iam-policy-autopilot-policy-generation/resources/config/sdks/boto3
         git fetch --tags
-        git checkout ${{ needs.check_versions.outputs.boto3_tag }}
+        git checkout "$BOTO3_TAG"
 
         cd ../botocore-data
         git fetch --tags
-        git checkout ${{ needs.check_versions.outputs.botocore_tag }}
+        git checkout "$BOTOCORE_TAG"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION


Closes #

## Description

Move inline ${{ }} expressions from run: script blocks into step-level env: declarations per [GitHub's recommended security pattern](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable). This prevents potential script injection attacks where expression values could be interpreted as shell commands.

Affected workflows:
- build_and_publish.yml: github.event.release.tag_name, matrix.use-qemu
- pr-checks.yml: github.workspace
- weekly_submodule_update.yml: step outputs, needs outputs

## Checklist

- [ ] ~~I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)~~
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
