### PR TITLE
fix: remove hardcoded paths leading to failure with llvm-cov

### DIFF
--- a/iam-policy-autopilot-mcp-server/tests/mcp_server_integration_test.rs
+++ b/iam-policy-autopilot-mcp-server/tests/mcp_server_integration_test.rs
@@ -14,9 +14,28 @@ use tokio::net::TcpStream;
 use tokio::process::{Child, Command};
 use tokio::time::{sleep, Duration};
 
+/// Resolve the `iam-policy-autopilot` CLI binary from the test executable's own
+/// location instead of hardcoding `../target/debug`. The integration test binary
+/// lives in `target/<profile>/deps/` (or `target/llvm-cov-target/<profile>/deps/`
+/// under `cargo llvm-cov`), and the CLI binary is built into the sibling
+/// `target/<profile>/` directory, so deriving the path keeps this working under
+/// coverage builds that use a different target dir.
+fn cli_binary_path() -> std::path::PathBuf {
+    let mut path = std::env::current_exe().expect("failed to locate test executable");
+    path.pop(); // drop the test binary file name -> .../deps
+    if path.ends_with("deps") {
+        path.pop(); // -> .../<profile>
+    }
+    path.push(format!(
+        "iam-policy-autopilot{}",
+        std::env::consts::EXE_SUFFIX
+    ));
+    path
+}
+
 async fn setup_stdio() -> RunningService<RoleClient, ()> {
     // Create MCP client using TokioChildProcess with debug binary
-    let mut command = Command::new("../target/debug/iam-policy-autopilot");
+    let mut command = Command::new(cli_binary_path());
     command.args(&["mcp-server"]);
 
     ().serve(
@@ -46,7 +65,7 @@ async fn setup_http_with_bind_address(
     bind_address: &str,
 ) -> (RunningService<RoleClient, InitializeRequestParams>, Child) {
     // Start HTTP server as a background process using debug binary
-    let mut command = Command::new("../target/debug/iam-policy-autopilot");
+    let mut command = Command::new(cli_binary_path());
     command
         .args(&[
             "mcp-server",

--- a/iam-policy-autopilot-mcp-server/tests/telemetry_notification_test.rs
+++ b/iam-policy-autopilot-mcp-server/tests/telemetry_notification_test.rs
@@ -16,6 +16,25 @@ use serial_test::serial;
 use tokio::process::Command;
 use tokio::time::{sleep, Duration};
 
+/// Resolve the `iam-policy-autopilot` CLI binary from the test executable's own
+/// location instead of hardcoding `../target/debug`. The integration test binary
+/// lives in `target/<profile>/deps/` (or `target/llvm-cov-target/<profile>/deps/`
+/// under `cargo llvm-cov`), and the CLI binary is built into the sibling
+/// `target/<profile>/` directory, so deriving the path keeps this working under
+/// coverage builds that use a different target dir.
+fn cli_binary_path() -> std::path::PathBuf {
+    let mut path = std::env::current_exe().expect("failed to locate test executable");
+    path.pop(); // drop the test binary file name -> .../deps
+    if path.ends_with("deps") {
+        path.pop(); // -> .../<profile>
+    }
+    path.push(format!(
+        "iam-policy-autopilot{}",
+        std::env::consts::EXE_SUFFIX
+    ));
+    path
+}
+
 /// A custom MCP client handler that captures `notifications/message` notifications.
 #[derive(Clone)]
 struct NotificationCapture {
@@ -57,7 +76,7 @@ async fn connect_mcp_client(
 ) -> (NotificationCapture, impl std::any::Any) {
     let capture = NotificationCapture::new();
 
-    let mut command = Command::new("../target/debug/iam-policy-autopilot");
+    let mut command = Command::new(cli_binary_path());
     command.args(["mcp-server"]);
     // Default: clear env var so config file choice takes effect
     command.env_remove("DISABLE_IAM_POLICY_AUTOPILOT_TELEMETRY");

--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -246,7 +246,7 @@ impl ResourceMatcher {
                     if let Some(operation_to_authorized_actions) =
                         &service_reference.operation_to_authorized_actions
                     {
-                        log::debug!("Looking up {}", &op.service_operation_name());
+                        log::debug!("Looking up {}", op.service_operation_name());
                         if let Some(operation_to_authorized_action) =
                             operation_to_authorized_actions.get(&op.service_operation_name())
                         {

--- a/iam-policy-autopilot-policy-generation/src/extraction/go/extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/go/extractor.rs
@@ -151,10 +151,9 @@ rule:
             .map(|obj_node| obj_node.text().to_string());
 
         // Extract the method name
-        let method_name = if let Some(method_node) = env.get_match("METHOD") {
+        let method_name = {
+            let method_node = env.get_match("METHOD")?;
             method_node.text()
-        } else {
-            return None;
         };
 
         // Extract arguments - ARGS captures the entire argument_list node
@@ -278,7 +277,7 @@ rule:
         );
         log::debug!(
             "Node text (first 100 chars): {:?}",
-            &node.text().chars().take(100).collect::<String>()
+            node.text().chars().take(100).collect::<String>()
         );
 
         // Check if this node is directly a composite_literal

--- a/iam-policy-autopilot-policy-generation/src/extraction/go/paginator_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/go/paginator_extractor.rs
@@ -121,10 +121,9 @@ impl<'a> GoPaginatorExtractor<'a> {
 
         // Extract client parameter from arguments (first argument)
         let args_nodes = env.get_multiple_matches("ARGS");
-        let client_receiver = if let Some(first_arg) = args_nodes.first() {
+        let client_receiver = {
+            let first_arg = args_nodes.first()?;
             first_arg.text().to_string()
-        } else {
-            return None; // Paginator creation should have at least one argument (the client)
         };
 
         // Extract creation arguments (skip client, get input struct)
@@ -182,10 +181,9 @@ impl<'a> GoPaginatorExtractor<'a> {
 
         // Extract client parameter from creation arguments (first argument)
         let args_nodes = env.get_multiple_matches("ARGS");
-        let client_receiver = if let Some(first_arg) = args_nodes.first() {
+        let client_receiver = {
+            let first_arg = args_nodes.first()?;
             first_arg.text().to_string()
-        } else {
-            return None;
         };
 
         // Extract creation arguments (skip client, get input struct)

--- a/iam-policy-autopilot-policy-generation/src/extraction/go/waiter_extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/go/waiter_extractor.rs
@@ -140,10 +140,9 @@ impl<'a> GoWaiterExtractor<'a> {
 
         // Extract client parameter from arguments (first argument)
         let args_nodes = env.get_multiple_matches("ARGS");
-        let client_receiver = if let Some(first_arg) = args_nodes.first() {
+        let client_receiver = {
+            let first_arg = args_nodes.first()?;
             first_arg.text().to_string()
-        } else {
-            return None; // Waiter creation should have at least one argument (the client)
         };
 
         // Extract waiter name from function name (remove "New" prefix and "Waiter" suffix)

--- a/iam-policy-autopilot-policy-generation/src/extraction/python/extractor.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/python/extractor.rs
@@ -52,10 +52,9 @@ impl PythonExtractor {
             .map(|obj_node| obj_node.text().to_string());
 
         // Extract the method name
-        let method_name = if let Some(method_node) = env.get_match("METHOD") {
+        let method_name = {
+            let method_node = env.get_match("METHOD")?;
             method_node.text()
-        } else {
-            return None;
         };
 
         // Extract arguments - get_multiple_matches returns Vec<Node> directly


### PR DESCRIPTION
Closes #

## Description

Fixes the build failure in https://github.com/awslabs/iam-policy-autopilot/actions/runs/29348799953/job/87147279335?pr=250

Also fixes `cargo clippy` findings.

## Checklist

- [X] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
