### PR TITLE
feat: include service reference modified dates in policy output for auditability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support for chained and nested boto3 sub-resource actions, including calls on a variable bound to a chain — e.g. `s3.Bucket("b").put_object(...)`, `s3.Bucket("b").Object("k").put(...)`, and `obj = s3.Bucket("b").Object("k"); obj.put(...)` now resolve to the underlying operation with identifiers injected from the chain
 - `Warnings` field in the `generate-policies` output flagging statements whose `Resource` fell back to the `"*"` wildcard (no ARN patterns available, an empty resource list, or the resource list was collapsed by the resource cutoff). Each warning carries a machine-recognizable `WarningType` plus policy and statement indices locating the flagged statement, so callers can construct their own review messages
 - New telemetry result metrics for generation runs: `num_statements_generated`, `num_actions_generated`, and `num_wildcard_resource_statements` (counts only, no policy content). See [TELEMETRY.md](TELEMETRY.md)
+- `ServiceReferenceModified` field in the `generate-policies` output with per-service epoch-second `modified` timestamps from the service reference index for services contributing to the generated policy, for auditability (#260)
 
 ### Changed
 

--- a/iam-policy-autopilot-mcp-server/src/tools/generate_policy.rs
+++ b/iam-policy-autopilot-mcp-server/src/tools/generate_policy.rs
@@ -242,6 +242,7 @@ mod tests {
             explanations: None,
             resource_binding_explanations: None,
             warnings: vec![],
+            service_reference_modified: Default::default(),
         }));
         let result = generate_application_policies(input).await;
 
@@ -292,6 +293,7 @@ mod tests {
             explanations: None,
             resource_binding_explanations: None,
             warnings: vec![],
+            service_reference_modified: Default::default(),
         }));
         let result = generate_application_policies(input).await;
 
@@ -368,6 +370,7 @@ mod tests {
             explanations: None,
             resource_binding_explanations: None,
             warnings: vec![],
+            service_reference_modified: Default::default(),
         }));
         let result = generate_application_policies(input).await;
 

--- a/iam-policy-autopilot-policy-generation/src/api/generate_policies.rs
+++ b/iam-policy-autopilot-policy-generation/src/api/generate_policies.rs
@@ -227,6 +227,7 @@ pub async fn generate_policies(config: &GeneratePolicyConfig) -> Result<Generate
             explanations: None,
             resource_binding_explanations: None,
             warnings: vec![],
+            service_reference_modified: BTreeMap::new(),
         });
     }
 
@@ -269,6 +270,7 @@ pub async fn generate_policies(config: &GeneratePolicyConfig) -> Result<Generate
             explanations: None,
             resource_binding_explanations: None,
             warnings: vec![],
+            service_reference_modified: BTreeMap::new(),
         });
     }
 
@@ -350,6 +352,12 @@ pub async fn generate_policies(config: &GeneratePolicyConfig) -> Result<Generate
     // policy indices and statements match what the caller receives
     let warnings = crate::api::model::PolicyWarning::wildcard_resource_warnings(&final_policies);
 
+    // Service-reference modified timestamps were captured at enrichment time
+    // (on each EnrichedSdkMethodCall) and aggregated in the policy engine —
+    // same pattern as explanations. Merging policies does not change which
+    // services informed enrichment, so no recompute is needed.
+    let service_reference_modified = result.service_reference_modified;
+
     iam_policy_autopilot_common::telemetry::span::record_result_number(
         "num_policies_generated",
         final_policies.len(),
@@ -383,6 +391,7 @@ pub async fn generate_policies(config: &GeneratePolicyConfig) -> Result<Generate
         explanations,
         resource_binding_explanations: binding_explanations,
         warnings,
+        service_reference_modified,
     })
 }
 

--- a/iam-policy-autopilot-policy-generation/src/api/model.rs
+++ b/iam-policy-autopilot-policy-generation/src/api/model.rs
@@ -6,6 +6,7 @@ use crate::{
     enrichment::Explanations, policy_generation::PolicyWithMetadata,
 };
 use anyhow::{anyhow, Result};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 /// Configuration for generate_policies API
@@ -64,6 +65,12 @@ pub struct GeneratePoliciesResult {
     /// Warnings about statements that could not be scoped to specific resources
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<PolicyWarning>,
+    /// Epoch-second `modified` timestamps from the service reference index
+    /// (https://servicereference.us-east-1.amazonaws.com/) for each service that
+    /// contributes actions to the generated policies. Enables auditability of
+    /// which service-reference versions informed the result.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub service_reference_modified: BTreeMap<String, u64>,
 }
 
 /// Machine-recognizable category of a [`PolicyWarning`].
@@ -324,6 +331,28 @@ mod tests {
         assert_eq!(json["Location"]["PolicyIndex"], 0);
         assert_eq!(json["Location"]["StatementIndex"], 1);
         assert_eq!(json["Message"], "test message");
+    }
+
+    #[test]
+    fn test_service_reference_modified_serialization() {
+        let mut service_reference_modified = BTreeMap::new();
+        service_reference_modified.insert("s3".to_string(), 1_700_000_001);
+        service_reference_modified.insert("ec2".to_string(), 1_700_000_002);
+
+        let result = GeneratePoliciesResult {
+            policies: vec![],
+            explanations: None,
+            resource_binding_explanations: None,
+            warnings: vec![],
+            service_reference_modified,
+        };
+
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["ServiceReferenceModified"]["s3"], 1_700_000_001_u64);
+        assert_eq!(json["ServiceReferenceModified"]["ec2"], 1_700_000_002_u64);
+        // Empty maps/options are omitted
+        assert!(json.get("Warnings").is_none());
+        assert!(json.get("Explanations").is_none());
     }
 
     #[test]

--- a/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/mod.rs
@@ -279,6 +279,11 @@ pub struct EnrichedSdkMethodCall<'a> {
     pub(crate) actions: Vec<Action>,
     /// The initial SDK method call
     pub(crate) sdk_method_call: &'a SdkMethodCall,
+    /// Epoch-second `modified` timestamp from the service reference index for
+    /// [`Self::service`], when available. Captured at enrichment time so policy
+    /// generation can report which service-reference version informed each call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) service_reference_modified: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema)]

--- a/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/resource_matcher.rs
@@ -315,11 +315,19 @@ impl ResourceMatcher {
             return Ok(None);
         }
 
+        // Capture index `modified` while we still know which service reference
+        // document informed this enrichment (audit trail for #260).
+        let service_reference_modified = service_reference_loader
+            .modified_for_service(original_service_name)
+            .await
+            .filter(|&m| m != 0);
+
         Ok(Some(EnrichedSdkMethodCall {
             method_name: parsed_call.name.clone(),
             service: original_service_name.to_string(),
             actions: enriched_actions,
             sdk_method_call: parsed_call,
+            service_reference_modified,
         }))
     }
 

--- a/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/service_reference.rs
@@ -264,21 +264,33 @@ where
         .collect())
 }
 
+/// A single entry in the service reference index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceReferenceEntry {
+    /// URL to fetch the full service reference document
+    pub(crate) url: Url,
+    /// Epoch-second timestamp when this service's reference was last modified
+    pub(crate) modified: u64,
+}
+
 /// represents the top level mapping returned by service reference
 /// to resolve the url for target service
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ServiceReferenceMapping {
     // represents the top level service reference mapping
-    pub(crate) service_reference_mapping: HashMap<String, Url>,
+    pub(crate) service_reference_mapping: HashMap<String, ServiceReferenceEntry>,
 }
 
 fn deserialize_service_reference_mapping(
     value: Value,
-) -> crate::errors::Result<HashMap<String, Url>> {
+) -> crate::errors::Result<HashMap<String, ServiceReferenceEntry>> {
     #[derive(Deserialize)]
     struct ServiceEntry {
         service: String,
         url: String,
+        /// Defaults to 0 for index entries that predate the `modified` field.
+        #[serde(default)]
+        modified: u64,
     }
 
     let entries: Vec<ServiceEntry> = serde_json::from_value(value)?;
@@ -294,7 +306,13 @@ fn deserialize_service_reference_mapping(
                 e,
             )
         })?;
-        map.insert(entry.service, url);
+        map.insert(
+            entry.service,
+            ServiceReferenceEntry {
+                url,
+                modified: entry.modified,
+            },
+        );
     }
     Ok(map)
 }
@@ -509,13 +527,13 @@ impl RemoteServiceReferenceLoader {
         }
 
         let mapping = self.get_or_init_mapping().await?;
-        let service_url = mapping.service_reference_mapping.get(service_name);
+        let service_entry = mapping.service_reference_mapping.get(service_name);
 
-        match service_url {
-            Some(service_url) => {
+        match service_entry {
+            Some(service_entry) => {
                 let service_reference_content = self
                     .client
-                    .get(service_url.as_ref())
+                    .get(service_entry.url.as_ref())
                     .send()
                     .await
                     .map_err(|e| {
@@ -558,6 +576,46 @@ impl RemoteServiceReferenceLoader {
             }
             None => Ok(None),
         }
+    }
+
+    /// Returns the epoch-second `modified` timestamp from the service reference
+    /// index for a single service, when present.
+    ///
+    /// Best-effort: if the index cannot be loaded or the service is unknown,
+    /// returns `None` and (on index failure) logs a warning.
+    pub(crate) async fn modified_for_service(&self, service_name: &str) -> Option<u64> {
+        let mapping = match self.get_or_init_mapping().await {
+            Ok(mapping) => mapping,
+            Err(e) => {
+                log::warn!("Could not load service reference index for modified timestamps: {e}");
+                return None;
+            }
+        };
+        mapping
+            .service_reference_mapping
+            .get(service_name)
+            .map(|entry| entry.modified)
+    }
+
+    /// Returns epoch-second `modified` timestamps from the service reference
+    /// index for the given service names. Unknown services are omitted.
+    ///
+    /// Best-effort: if the index cannot be loaded, returns an empty map and
+    /// logs a warning rather than failing policy generation.
+    pub(crate) async fn modified_for_services(
+        &self,
+        service_names: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> std::collections::BTreeMap<String, u64> {
+        use std::collections::BTreeMap;
+
+        let mut result = BTreeMap::new();
+        for service in service_names {
+            let service = service.as_ref();
+            if let Some(modified) = self.modified_for_service(service).await {
+                result.insert(service.to_string(), modified);
+            }
+        }
+        result
     }
 }
 
@@ -680,8 +738,8 @@ mod tests {
     #[tokio::test]
     async fn test_deserialize_service_reference_mapping() {
         let json = serde_json::json!([
-            {"service": "s3", "url": "https://example.com/s3.json"},
-            {"service": "ec2", "url": "https://example.com/ec2.json"}
+            {"service": "s3", "url": "https://example.com/s3.json", "modified": 1700000001},
+            {"service": "ec2", "url": "https://example.com/ec2.json", "modified": 1700000002}
         ]);
 
         let result = deserialize_service_reference_mapping(json);
@@ -691,8 +749,20 @@ mod tests {
         assert_eq!(mapping.len(), 2);
         assert!(mapping.contains_key("s3"));
         assert!(mapping.contains_key("ec2"));
-        assert_eq!(mapping["s3"].as_str(), "https://example.com/s3.json");
-        assert_eq!(mapping["ec2"].as_str(), "https://example.com/ec2.json");
+        assert_eq!(mapping["s3"].url.as_str(), "https://example.com/s3.json");
+        assert_eq!(mapping["ec2"].url.as_str(), "https://example.com/ec2.json");
+        assert_eq!(mapping["s3"].modified, 1700000001);
+        assert_eq!(mapping["ec2"].modified, 1700000002);
+    }
+
+    #[tokio::test]
+    async fn test_deserialize_service_reference_mapping_missing_modified_defaults_to_zero() {
+        let json = serde_json::json!([
+            {"service": "s3", "url": "https://example.com/s3.json"}
+        ]);
+
+        let mapping = deserialize_service_reference_mapping(json).unwrap();
+        assert_eq!(mapping["s3"].modified, 0);
     }
 
     #[tokio::test]
@@ -730,6 +800,42 @@ mod tests {
             cache_path.ends_with("IAMPolicyAutopilot/s3.json")
                 || cache_path.ends_with("IAMAutoPilot\\s3.json")
         );
+    }
+
+    #[tokio::test]
+    async fn test_modified_for_services() {
+        let mock_server = wiremock::MockServer::start().await;
+        let mock_server_url = mock_server.uri();
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {
+                        "service": "s3",
+                        "url": format!("{mock_server_url}/s3.json"),
+                        "modified": 1_700_000_001_u64
+                    },
+                    {
+                        "service": "ec2",
+                        "url": format!("{mock_server_url}/ec2.json"),
+                        "modified": 1_700_000_002_u64
+                    }
+                ])),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let loader = RemoteServiceReferenceLoader::new(true)
+            .unwrap()
+            .with_mapping_url(mock_server.uri());
+
+        let modified = loader
+            .modified_for_services(["s3", "ec2", "nonexistent"])
+            .await;
+        assert_eq!(modified.get("s3"), Some(&1_700_000_001));
+        assert_eq!(modified.get("ec2"), Some(&1_700_000_002));
+        assert!(!modified.contains_key("nonexistent"));
     }
 
     #[tokio::test]

--- a/iam-policy-autopilot-policy-generation/src/enrichment/terraform/resource_binder.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/terraform/resource_binder.rs
@@ -288,6 +288,7 @@ impl TerraformResourceResolver {
                     service: call.service.clone(),
                     actions: new_actions,
                     sdk_method_call: call.sdk_method_call,
+                    service_reference_modified: call.service_reference_modified,
                 }
             })
             .collect()
@@ -1050,6 +1051,7 @@ mod tests {
                 Explanation::default(),
             )],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         }];
 
         let mut resource_map = ResolvedResourceMap::new();

--- a/iam-policy-autopilot-policy-generation/src/policy_generation/engine.rs
+++ b/iam-policy-autopilot-policy-generation/src/policy_generation/engine.rs
@@ -275,6 +275,10 @@ impl<'a> Engine<'a> {
         // Collect explanations
         let explanations = extract_explanations(enriched_calls);
 
+        // Collect service-reference modified timestamps captured during enrichment
+        let service_reference_modified =
+            extract_service_reference_modified(enriched_calls);
+
         // Flag statements that fell back to Resource "*" so consumers can
         // surface them for review
         let warnings = PolicyWarning::wildcard_resource_warnings(&policies);
@@ -284,6 +288,7 @@ impl<'a> Engine<'a> {
             explanations: Some(explanations),
             resource_binding_explanations: None,
             warnings,
+            service_reference_modified,
         })
     }
 }
@@ -304,6 +309,23 @@ fn extract_explanations(enriched_calls: &[EnrichedSdkMethodCall<'_>]) -> Explana
     }
 
     Explanations::new(explanations)
+}
+
+/// Build the audit map of service → index `modified` from enrichment-time data.
+///
+/// Same shape as explanations: derive from [`EnrichedSdkMethodCall`] rather than
+/// re-scanning final policies, so timestamps reflect the service references that
+/// actually informed enrichment.
+fn extract_service_reference_modified(
+    enriched_calls: &[EnrichedSdkMethodCall<'_>],
+) -> BTreeMap<String, u64> {
+    let mut map = BTreeMap::new();
+    for call in enriched_calls {
+        if let Some(modified) = call.service_reference_modified {
+            map.entry(call.service.clone()).or_insert(modified);
+        }
+    }
+    map
 }
 
 #[cfg(test)]
@@ -343,6 +365,36 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_policy_includes_service_reference_modified_from_enriched_calls() {
+        let engine = create_test_engine();
+        let sdk_call = create_test_sdk_call();
+
+        let enriched_call = EnrichedSdkMethodCall {
+            method_name: "get_object".to_string(),
+            service: "s3".to_string(),
+            actions: vec![Action::new(
+                "s3:GetObject".to_string(),
+                vec![Resource::new(
+                    "object".to_string(),
+                    Some(vec![
+                        "arn:${Partition}:s3:::${BucketName}/${ObjectName}".to_string()
+                    ]),
+                )],
+                vec![],
+                Explanation::default(),
+            )],
+            sdk_method_call: &sdk_call,
+            service_reference_modified: Some(1_700_000_042),
+        };
+
+        let result = engine.generate_policies(&[enriched_call]).unwrap();
+        assert_eq!(
+            result.service_reference_modified.get("s3"),
+            Some(&1_700_000_042)
+        );
+    }
+
+    #[test]
     fn test_generate_policy_single_action() {
         let engine = create_test_engine();
         let sdk_call = create_test_sdk_call();
@@ -362,6 +414,7 @@ mod tests {
                 Explanation::default(),
             )],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();
@@ -411,6 +464,7 @@ mod tests {
                 ),
             ],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();
@@ -445,6 +499,7 @@ mod tests {
                 Explanation::default(),
             )],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();
@@ -481,6 +536,7 @@ mod tests {
                 )
             ],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();
@@ -507,6 +563,7 @@ mod tests {
             service: "s3".to_string(),
             actions: vec![],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let action = Action::new(
@@ -542,6 +599,7 @@ mod tests {
             service: "s3".to_string(),
             actions: vec![],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]);
@@ -952,6 +1010,7 @@ mod tests {
                 },
             )],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();
@@ -1007,6 +1066,7 @@ mod tests {
                 },
             )],
             sdk_method_call: &sdk_call1,
+            service_reference_modified: None,
         };
 
         let enriched_call2 = EnrichedSdkMethodCall {
@@ -1030,6 +1090,7 @@ mod tests {
                 },
             )],
             sdk_method_call: &sdk_call2,
+            service_reference_modified: None,
         };
 
         let result = engine
@@ -1104,6 +1165,7 @@ mod tests {
                 },
             )],
             sdk_method_call: sdk_call,
+            service_reference_modified: None,
         };
 
         let enriched_call1 = make_call(&sdk_call1, metadata_a);
@@ -1180,6 +1242,7 @@ mod tests {
                 ),
             ],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();
@@ -1254,6 +1317,7 @@ mod tests {
                 },
             )],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();

--- a/iam-policy-autopilot-policy-generation/src/policy_generation/integration_tests.rs
+++ b/iam-policy-autopilot-policy-generation/src/policy_generation/integration_tests.rs
@@ -76,6 +76,7 @@ mod tests {
             service: service.to_string(),
             actions,
             sdk_method_call: sdk_call,
+            service_reference_modified: None,
         }
     }
 
@@ -483,6 +484,7 @@ mod tests {
                 ),
             ],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         // Generate policies
@@ -543,6 +545,7 @@ mod tests {
                     Explanation::default(),
                 )],
                 sdk_method_call: &sdk_call1,
+                service_reference_modified: None,
             },
             EnrichedSdkMethodCall {
                 method_name: "put_object".to_string(),
@@ -559,6 +562,7 @@ mod tests {
                     Explanation::default(),
                 )],
                 sdk_method_call: &sdk_call2,
+                service_reference_modified: None,
             },
         ];
 
@@ -611,6 +615,7 @@ mod tests {
                 )
             ],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();
@@ -647,6 +652,7 @@ mod tests {
                 Explanation::default(),
             )],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();
@@ -683,6 +689,7 @@ mod tests {
                 Explanation::default(),
             )],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         // Should fail due to empty placeholder
@@ -711,6 +718,7 @@ mod tests {
                 Explanation::default(),
             )],
             sdk_method_call: &sdk_call,
+            service_reference_modified: None,
         };
 
         let result = engine.generate_policies(&[enriched_call]).unwrap();


### PR DESCRIPTION
Closes #260

## Description

Service reference publishes a per-service `modified` epoch timestamp at https://servicereference.us-east-1.amazonaws.com/. This change includes those timestamps in IPA's `generate-policies` output for each service that contributes actions to the generated policy, so results can be audited against the service-reference versions that informed them.

**Changes:**
- Parse `modified` from the service reference index (defaults to `0` when absent for backward compatibility)
- Add `ServiceReferenceModified` (`BTreeMap<service, epoch_seconds>`) to `GeneratePoliciesResult`
- Populate it from action prefixes in the final policies after generation/merge
- Best-effort: index fetch failures log a warning and omit the field rather than failing generation

**Example output shape:**
```json
{
  "Policies": [ ... ],
  "ServiceReferenceModified": {
    "ec2": 1785355296,
    "s3": 1774454984
  }
}
```

## Testing
- `cargo test -p iam-policy-autopilot-policy-generation --lib enrichment::service_reference` (22 passed, 2 ignored network)
- `cargo test -p iam-policy-autopilot-policy-generation --lib -- services_from_policies service_reference_modified modified_for_services`
- `cargo test -p iam-policy-autopilot-policy-generation --lib enrichment::` (144 passed)
- `cargo test -p iam-policy-autopilot-policy-generation --lib policy_generation::` (102 passed)
- `cargo test -p iam-policy-autopilot-mcp-server --lib` (22 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p iam-policy-autopilot-policy-generation --lib -- -D warnings`

## Checklist

- [x] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [ ] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.