### PR TITLE
feat: resolve ARNs from Terraform plan when possible

### DIFF
--- a/iam-policy-autopilot-cli/src/main.rs
+++ b/iam-policy-autopilot-cli/src/main.rs
@@ -425,7 +425,8 @@ Examples:\n  \
             long_help = "Directory containing Terraform .tf files. When provided, the tool parses \
 Terraform resources to discover AWS infrastructure and generates more precise IAM policies by \
 using concrete resource names in ARNs, when possible. .tf files discovered in the Terraform \
-directory are combined with any files specified via --tf-files."
+directory are combined with any files specified via --tf-files. Ignored when generating policies \
+from a Terraform plan."
         )]
         #[telemetry(presence)]
         tf_dir: Option<PathBuf>,
@@ -437,7 +438,8 @@ directory are combined with any files specified via --tf-files."
             long_help = "One or more individual Terraform .tf files to parse for AWS resource definitions. \
 When provided, the tool parses Terraform resources to discover AWS infrastructure and generates \
 more precise IAM policies by using concrete resource names in ARNs, when possible. These files \
-are combined with any directory specified via --tf-dir."
+are combined with any directory specified via --tf-dir. Ignored when generating policies from a Terraform \
+plan."
         )]
         #[telemetry(presence)]
         tf_files: Vec<PathBuf>,
@@ -451,7 +453,7 @@ provided, these files are used to resolve variable references in resource defini
 more precise IAM policies by using concrete resource names in ARNs. These files take precedence \
 over auto-discovered terraform.tfvars and *.auto.tfvars files from the Terraform directory. \
 Applied in order (later files override earlier ones). This is equivalent to Terraform's \
--var-file= CLI flag."
+-var-file= CLI flag. Ignored when generating policies from a Terraform plan."
         )]
         #[telemetry(presence)]
         tfvars: Vec<PathBuf>,
@@ -463,7 +465,7 @@ Applied in order (later files override earlier ones). This is equivalent to Terr
             long_help = "One or more terraform.tfstate files containing deployed resource state. \
 When provided, the tool uses actual deployed resource ARNs to generate more precise IAM policies. \
 State-derived ARNs take precedence over those derived from .tf files. Can be used with --tf-dir, \
---tf-files, or independently."
+--tf-files, or independently. Ignored when generating policies from a Terraform plan."
         )]
         #[telemetry(presence)]
         tfstate: Vec<PathBuf>,

--- a/iam-policy-autopilot-policy-generation/src/api/generate_policies.rs
+++ b/iam-policy-autopilot-policy-generation/src/api/generate_policies.rs
@@ -2,17 +2,19 @@ use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::time::Instant;
 
-use log::{debug, info, trace};
+use log::{debug, info, trace, warn};
 
 use crate::{
     api::{
         extract_sdk_calls::extract_sdk_calls,
+        input_kind::{classify_inputs, ClassifiedInputs, IacFormat},
         model::{GeneratePoliciesResult, GeneratePolicyConfig},
     },
     enrichment::{
         terraform::{resource_binder::TerraformResourceResolver, ResourceBindingExplanation},
         Explanation, Explanations,
     },
+    extraction::terraform::plan_to_calls::{self, PlannedResource},
     policy_generation::merge::PolicyMergerConfig,
     EnrichmentEngine, ExtractedMethods, PolicyGenerationEngine,
 };
@@ -164,6 +166,26 @@ fn filter_explanations(
     }
 }
 
+/// Extract the resources to bind ARNs against when the action-source inputs are
+/// Terraform plan(s).
+///
+/// Returns `Some(resources)` when the inputs are Terraform plan(s) (possibly an
+/// empty vec — the caller distinguishes "plan input" from "source input" by the
+/// `Option`, not the count), and `None` for application source. Classification
+/// or parse errors resolve to `None`/empty: [`extract_sdk_calls`] performs the
+/// authoritative parse and reports any real error with full context.
+fn extract_plan_resources(source_files: &[std::path::PathBuf]) -> Option<Vec<PlannedResource>> {
+    match classify_inputs(source_files) {
+        Ok(ClassifiedInputs::Iac(IacFormat::TerraformPlan, plan_paths)) => Some(
+            plan_to_calls::read_planned_resources(&plan_paths).unwrap_or_else(|e| {
+                debug!("Could not read Terraform plan resources for ARN binding: {e}");
+                Vec::new()
+            }),
+        ),
+        _ => None,
+    }
+}
+
 /// Generate policies for source files, with optional Terraform resource binding.
 ///
 /// When `config.terraform_dir` is set, the pipeline additionally:
@@ -182,37 +204,54 @@ pub async fn generate_policies(config: &GeneratePolicyConfig) -> Result<Generate
         EnrichmentEngine::new(config.disable_file_system_cache, config.resource_cutoff)?;
 
     // --- Optional Terraform resolution ---
-    let has_terraform_inputs = config.terraform_dir.is_some()
-        || !config.terraform_files.is_empty()
-        || !config.tfstate_paths.is_empty();
+    // ARN binding is sourced from whichever Terraform inputs are present:
+    //   * a Terraform **plan** → derive resources from the plan
+    //     itself. We take the plan is the authoritative binding
+    //     source. Explicit --tf-dir / --tf-files / --tfvars / --tfstate are
+    //     ignored.
+    //   * otherwise (application source input) → the existing HCL/state path,
+    //     driven by --tf-dir / --tf-files / --tfstate / --tfvars.
+    let has_hcl_inputs = config.terraform_dir.is_some() || !config.terraform_files.is_empty();
 
-    let terraform_resolver = if has_terraform_inputs {
-        if let Some(ref terraform_dir) = config.terraform_dir {
-            debug!("Terraform directory provided: {}", terraform_dir.display());
-        }
-        if !config.terraform_files.is_empty() {
-            debug!(
-                "{} individual Terraform files provided",
-                config.terraform_files.len()
+    let terraform_resolver = if let Some(planned) =
+        extract_plan_resources(&config.extract_sdk_calls_config.source_files)
+    {
+        // Plan input: bind ARNs from the plan itself.
+        if has_hcl_inputs || !config.tfvars_files.is_empty() || !config.tfstate_paths.is_empty() {
+            warn!(
+                "Ignoring --tf-dir/--tf-files/--tfvars/--tfstate for a Terraform plan input: \
+                 the plan already reflects resolved attributes and refreshed state, and is \
+                 used directly for ARN binding."
             );
         }
-        if !config.tfstate_paths.is_empty() {
-            debug!("{} tfstate files provided", config.tfstate_paths.len());
-        }
         let loader = enrichment_engine.service_reference_loader();
-        let resolver = TerraformResourceResolver::new(
-            config.terraform_dir.as_deref(),
-            &config.terraform_files,
-            &config.tfstate_paths,
-            &config.tfvars_files,
-            loader,
-        )
-        .await
-        .context("Failed to resolve Terraform resources")?;
-        debug!("Resolved {} resource groups from Terraform", resolver.len());
+        let resolver = TerraformResourceResolver::from_plan(&planned, loader)
+            .await
+            .context("Failed to resolve Terraform resources from plan")?;
+        debug!(
+            "Resolved {} resource groups from Terraform plan",
+            resolver.len()
+        );
         Some(resolver)
     } else {
-        None
+        // Application source input: bind from .tf/.tfstate when provided.
+        let has_terraform_inputs = has_hcl_inputs || !config.tfstate_paths.is_empty();
+        if has_terraform_inputs {
+            let loader = enrichment_engine.service_reference_loader();
+            let resolver = TerraformResourceResolver::new(
+                config.terraform_dir.as_deref(),
+                &config.terraform_files,
+                &config.tfstate_paths,
+                &config.tfvars_files,
+                loader,
+            )
+            .await
+            .context("Failed to resolve Terraform resources")?;
+            debug!("Resolved {} resource groups from Terraform", resolver.len());
+            Some(resolver)
+        } else {
+            None
+        }
     };
 
     // --- Determine SDK method calls ---
@@ -558,6 +597,7 @@ mod tests {
                 resource_type: "aws_test".to_string(),
                 resource_name: "test".to_string(),
                 location: crate::Location::new(std::path::PathBuf::from("main.tf"), (1, 1), (1, 1)),
+                change_side: None,
             })
             .collect()
     }

--- a/iam-policy-autopilot-policy-generation/src/enrichment/terraform/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/terraform/mod.rs
@@ -9,6 +9,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::extraction::terraform::ChangeSide;
 use crate::Location;
 
 pub mod resource_binder;
@@ -32,6 +33,10 @@ pub struct ResourceBindingExplanation {
     pub resource_name: String,
     /// Location of the resource definition
     pub location: Location,
+    /// Plan-diff side this ARN came from (a replace emits `Before` + `After`);
+    /// `None` for `.tf`-derived bindings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change_side: Option<ChangeSide>,
 }
 
 /// Whether the ARN came from Terraform configuration parsing or from a terraform.tfstate file.

--- a/iam-policy-autopilot-policy-generation/src/enrichment/terraform/resource_binder.rs
+++ b/iam-policy-autopilot-policy-generation/src/enrichment/terraform/resource_binder.rs
@@ -26,6 +26,7 @@ use crate::enrichment::ServiceReferenceLoader;
 use crate::enrichment::{Action, EnrichedSdkMethodCall, Resource};
 use crate::Location;
 
+use crate::extraction::terraform::plan_to_calls::PlannedResource;
 use crate::extraction::terraform::state_parser::TerraformStateResources;
 use crate::extraction::terraform::variable_resolver::VariableContext;
 use crate::extraction::terraform::{AttributeValue, TerraformResource, TerraformResources};
@@ -190,7 +191,7 @@ impl TerraformResourceResolver {
 
         // Step 4: Resolve all resources
         let resources = resolve_terraform_resources(
-            &tf_result,
+            tf_result.values(),
             &state_resources,
             &VariableContext::default(),
             loader,
@@ -205,6 +206,30 @@ impl TerraformResourceResolver {
         Ok(Self {
             resources,
             warnings: tf_result.take_warnings(),
+        })
+    }
+
+    /// Build a resolver from a Terraform **plan** instead of `.tf` files.
+    pub(crate) async fn from_plan(
+        planned: &[PlannedResource],
+        loader: &ServiceReferenceLoader,
+    ) -> Result<Self> {
+        let plan_resources: Vec<TerraformResource> = planned
+            .iter()
+            .flat_map(PlannedResource::to_terraform_resources)
+            .collect();
+
+        let resources = resolve_terraform_resources(
+            plan_resources.iter(),
+            &TerraformStateResources::default(),
+            &VariableContext::default(),
+            loader,
+        )
+        .await;
+
+        Ok(Self {
+            resources,
+            warnings: Vec::new(),
         })
     }
 
@@ -523,6 +548,7 @@ impl TerraformResourceResolver {
                         resource_type: resolved.resource.resource_type.clone(),
                         resource_name: resolved.resource.local_name.clone(),
                         location,
+                        change_side: resolved.resource.change_side,
                     });
                     continue;
                 }
@@ -537,6 +563,7 @@ impl TerraformResourceResolver {
                             resource_type: resolved.resource.resource_type.clone(),
                             resource_name: resolved.resource.local_name.clone(),
                             location: resource_location.clone(),
+                            change_side: resolved.resource.change_side,
                         });
                     }
                 }
@@ -551,15 +578,17 @@ impl TerraformResourceResolver {
 // Resource resolution (internal)
 // ---------------------------------------------------------------------------
 
-/// Build a `ResolvedResourceMap` from parsed HCL resources, enriched with
+/// Build a `ResolvedResourceMap` from parsed resources, enriched with
 /// state data, variable resolution, and SDF ARN patterns.
 ///
 /// Keyed by `(service_name, resource_type)` for direct lookup during
-/// policy generation.
+/// policy generation. Accepts a flat iterator (not the `(type, local_name)`
+/// map) so plan-derived replaces — whose two identities share a local name —
+/// both flow through; their `ChangeSide` keeps them distinct.
 ///
 /// Resources that don't map to a service in names_data.hcl are excluded.
-async fn resolve_terraform_resources(
-    terraform_resources: &TerraformResources,
+async fn resolve_terraform_resources<'a>(
+    terraform_resources: impl IntoIterator<Item = &'a TerraformResource>,
     state_resources: &TerraformStateResources,
     var_ctx: &VariableContext,
     loader: &ServiceReferenceLoader,
@@ -567,7 +596,7 @@ async fn resolve_terraform_resources(
     let resolver = super::service_resolver::TerraformServiceAndResourceResolver::global();
     let mut results = ResolvedResourceMap::new();
 
-    for resource in terraform_resources.values() {
+    for resource in terraform_resources {
         let mut resolved_res = ResolvedTerraformResource::from_parsed(resource.clone());
         let tf_key = (resource.resource_type.clone(), resource.local_name.clone());
 
@@ -577,7 +606,8 @@ async fn resolve_terraform_resources(
         resolved_res.service_name = Some(service.clone());
         resolved_res.resource_type = Some(resource_type.clone());
 
-        // Priority 1: Use state-derived ARN if available (exact deployed ARN)
+        // Priority 1: Use a state-derived ARN if one exists (the exact deployed
+        // ARN from a `--tfstate` file).
         let has_state_arn = if let Some(resources) = state_resources.get(&tf_key.0, &tf_key.1) {
             if let Some(resource) = resources.iter().find(|s| s.arn.is_some()) {
                 resolved_res.state_arn.clone_from(&resource.arn);
@@ -786,6 +816,7 @@ mod tests {
             local_name: name.to_string(),
             attributes: HashMap::from([(attr_key.to_string(), attr_val)]),
             location: Location::new(PathBuf::from("main.tf"), (10, 1), (10, 1)),
+            change_side: None,
         }
     }
 
@@ -830,6 +861,7 @@ mod tests {
                 local_name: local_name.to_string(),
                 attributes: HashMap::new(),
                 location: Location::new(PathBuf::from("main.tf"), (10, 1), (10, 1)),
+                change_side: None,
             },
             service_name: Some(service.to_string()),
             resource_type: Some(suffix.to_string()),
@@ -901,13 +933,9 @@ mod tests {
     ) {
         let state = make_state_resources(state_entries);
         let loader = ServiceReferenceLoader::empty_loader_for_tests().unwrap();
-        let resolved = resolve_terraform_resources(
-            &vec_to_terraform_resources(hcl),
-            &state,
-            &empty_var_ctx(),
-            &loader,
-        )
-        .await;
+        let tf = vec_to_terraform_resources(hcl);
+        let resolved =
+            resolve_terraform_resources(tf.values(), &state, &empty_var_ctx(), &loader).await;
 
         match expected_key {
             None => assert!(resolved.is_empty(), "expected empty resolved map"),

--- a/iam-policy-autopilot-policy-generation/src/extraction/terraform/hcl_parser.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/terraform/hcl_parser.rs
@@ -147,6 +147,8 @@ fn extract_resource_block(
         local_name: local_name.to_string(),
         attributes,
         location,
+        // Parsed from `.tf` config — no plan-diff context.
+        change_side: None,
     })
 }
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/terraform/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/terraform/mod.rs
@@ -8,11 +8,31 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::Location;
 
 pub mod hcl_parser;
 pub(crate) mod plan_to_calls;
 pub mod state_parser;
+
+/// Which side of a Terraform plan diff a resource identity was resolved from.
+///
+/// A create/update binds the planned (`After`) identity; a delete binds the
+/// currently-deployed (`Before`) identity; a **replace** binds both. Resources
+/// parsed from `.tf` config have no diff context and carry no side (`None`).
+///
+/// This drives two things during binding: state ARNs (from `--tfstate`) are only
+/// matched against the `Before`/`None` identities — never the `After` side of a
+/// replace, which is a brand-new resource absent from the current state — and it
+/// labels each binding in `--explain-resources` output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChangeSide {
+    /// The pre-change, currently-deployed identity (a delete, or the old side of a replace).
+    Before,
+    /// The planned post-change identity (a create/update, or the new side of a replace).
+    After,
+}
 
 /// Terraform AWS provider resource type prefix. Used to filter resources
 /// from multi-provider configurations — only types starting with this
@@ -61,6 +81,10 @@ pub(crate) struct TerraformResource {
     pub attributes: HashMap<String, AttributeValue>,
     /// Location of the resource block definition in the source `.tf` file
     pub location: Location,
+    /// Which side of a plan diff this identity came from, when sourced from a
+    /// Terraform plan. `None` for resources parsed from `.tf` config (no diff
+    /// context). Drives state-ARN matching and `--explain-resources` labeling.
+    pub change_side: Option<ChangeSide>,
 }
 
 /// A collection of parsed Terraform resource blocks with associated warnings.
@@ -181,6 +205,7 @@ mod tests {
                 AttributeValue::Literal("my-app-data".to_string()),
             )]),
             location: Location::new(PathBuf::from("main.tf"), (1, 1), (1, 1)),
+            change_side: None,
         };
         assert_eq!(resource.resource_type, "aws_s3_bucket");
         assert_eq!(resource.local_name, "data_bucket");
@@ -205,6 +230,7 @@ mod tests {
             local_name: "b".to_string(),
             attributes: HashMap::new(),
             location: Location::new(PathBuf::from("main.tf"), (1, 1), (1, 1)),
+            change_side: None,
         };
         result.insert(resource);
         assert_eq!(result.len(), 1);

--- a/iam-policy-autopilot-policy-generation/src/extraction/terraform/plan_to_calls/mapper.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/terraform/plan_to_calls/mapper.rs
@@ -125,6 +125,7 @@ mod tests {
     use super::*;
     use crate::extraction::terraform::plan_to_calls::crud_map::CrudSlot;
     use std::collections::BTreeSet;
+    use std::path::PathBuf;
 
     const PFX: &str = "github.com/hashicorp/terraform-provider-aws/internal/service/";
 
@@ -176,6 +177,8 @@ mod tests {
             resource_type: "aws_accessanalyzer_analyzer".to_string(),
             slots: slots.iter().copied().collect::<BTreeSet<_>>(),
             name_prefix: None,
+            identities: Vec::new(),
+            source_plan: PathBuf::new(),
         }
     }
 
@@ -248,6 +251,8 @@ mod tests {
             resource_type: "aws_unmodeled_thing".to_string(),
             slots: [CrudSlot::Read, CrudSlot::Create].into_iter().collect(),
             name_prefix: None,
+            identities: Vec::new(),
+            source_plan: PathBuf::new(),
         };
         let mapped = map_plan(&[unknown], &crud_map, &model);
         assert_eq!(mapped.calls, Vec::new());
@@ -267,6 +272,8 @@ mod tests {
             resource_type: "aws_accessanalyzer_analyzer".to_string(),
             slots: [CrudSlot::Read, CrudSlot::Create].into_iter().collect(),
             name_prefix: None,
+            identities: Vec::new(),
+            source_plan: PathBuf::new(),
         };
         let mapped = map_plan(&[r], &crud_map, &model);
         assert_eq!(mapped.calls, Vec::new());
@@ -321,6 +328,8 @@ mod tests {
             resource_type: "aws_bucket_like".to_string(),
             slots: slots.iter().copied().collect::<BTreeSet<_>>(),
             name_prefix: None,
+            identities: Vec::new(),
+            source_plan: PathBuf::new(),
         }
     }
 

--- a/iam-policy-autopilot-policy-generation/src/extraction/terraform/plan_to_calls/mod.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/terraform/plan_to_calls/mod.rs
@@ -56,13 +56,25 @@ pub(crate) fn plan_to_sdk_calls(
     let crud_map = crud_map::CrudMap::load()?;
     let model = model_index::ModelIndex::load()?;
 
+    let resources = read_planned_resources(plan_paths)?;
+
+    let mapped = mapper::map_plan(&resources, &crud_map, &model);
+    Ok((mapped, resources))
+}
+
+/// Read and union the managed resources from one or more `terraform show -json`
+/// plan files, without mapping them to SDK calls.
+///
+/// Used by the policy pipeline to derive resource ARNs directly from the plan
+/// (its `before`/`after` values are already resolved by Terraform), so scoping
+/// works with no `--tf-dir`/`--tf-files`. `plan_to_sdk_calls` uses the same
+/// reader for the action-derivation side.
+pub(crate) fn read_planned_resources(plan_paths: &[PathBuf]) -> Result<Vec<PlannedResource>> {
     let mut resources = Vec::new();
     for plan_path in plan_paths {
         resources.extend(plan_reader::read_plan(plan_path)?);
     }
-
-    let mapped = mapper::map_plan(&resources, &crud_map, &model);
-    Ok((mapped, resources))
+    Ok(resources)
 }
 
 /// The library name recorded in the embedded `terraform-model.json`.

--- a/iam-policy-autopilot-policy-generation/src/extraction/terraform/plan_to_calls/plan_reader.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/terraform/plan_to_calls/plan_reader.rs
@@ -10,14 +10,17 @@
 //! the user runs `terraform show -json plan.tfplan > plan.json` and passes the
 //! JSON.
 
-use std::collections::BTreeSet;
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::extraction::terraform::AWS_RESOURCE_PREFIX;
+use crate::extraction::terraform::{
+    AttributeValue, ChangeSide, TerraformResource, AWS_RESOURCE_PREFIX,
+};
+use crate::Location;
 
 use super::crud_map::CrudSlot;
 
@@ -45,11 +48,29 @@ struct RawResourceChange {
 struct RawChange {
     #[serde(default)]
     actions: Vec<String>,
+    /// Pre-change (currently deployed) attribute values. `null` for a create.
+    /// For a delete this is the only place the concrete identity lives (`after`
+    /// is `null`); for a replace it is the *old* identity being destroyed.
+    #[serde(default)]
+    before: Value,
     /// Planned post-apply attribute values. `null` keys (e.g. `name` when a
     /// `name_prefix` is used and the final name is known-after-apply) are
     /// preserved so the mapper can detect the `name_prefix` ARN-scoping case.
+    /// `null` for a delete.
     #[serde(default)]
     after: Value,
+}
+
+/// One concrete resource identity resolved from a plan change: which side of the
+/// diff it came from, plus the known (non-null, string) attribute values the
+/// resource binder turns into a scoped ARN.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlannedIdentity {
+    /// The change side this identity was read from (`after` for create/update,
+    /// `before` for delete, and both for a replace).
+    pub(crate) side: ChangeSide,
+    /// Known, resolved top-level string attributes (e.g. `{"name": "my-table"}`).
+    pub(crate) attributes: BTreeMap<String, String>,
 }
 
 /// A single managed-resource change extracted from the plan.
@@ -66,6 +87,15 @@ pub(crate) struct PlannedResource {
     /// prefix-glob ARN scoping (§5.1); not yet consumed — ARN binding currently
     /// comes from `.tf`/`.tfstate` via the existing resource binder.
     pub(crate) name_prefix: Option<String>,
+    /// Concrete resource identities resolved from the plan's `before`/`after`
+    /// attributes, which the resource binder turns into scoped ARNs.
+    ///
+    /// Usually one identity. A **replace** (`create`+`delete`) contributes two
+    /// — the new (`After`) and old (`Before`) identities — because the apply
+    /// creates one ARN and deletes the other; both belong in the policy.
+    pub(crate) identities: Vec<PlannedIdentity>,
+    /// The plan file this resource was read from.
+    pub(crate) source_plan: PathBuf,
 }
 
 /// Parse the CRUD slots a Terraform `actions` array implies.
@@ -98,6 +128,106 @@ fn slots_for_actions(actions: &[String]) -> BTreeSet<CrudSlot> {
         }
     }
     slots
+}
+
+impl PlannedResource {
+    /// Represent this planned resource's concrete identities as parsed
+    /// HCL-style resources, so the shared resource binder can derive ARNs from
+    /// their resolved attributes exactly as it does for `.tf`-sourced resources.
+    ///
+    /// Emits one [`TerraformResource`] per identity (see [`Self::identities`]),
+    /// each tagged with the [`ChangeSide`] it came from.
+    pub(crate) fn to_terraform_resources(&self) -> Vec<TerraformResource> {
+        let local_name = local_name_from_address(&self.address);
+        self.identities
+            .iter()
+            .map(|identity| {
+                let attributes = identity
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| (k.clone(), AttributeValue::Literal(v.clone())))
+                    .collect();
+                TerraformResource {
+                    resource_type: self.resource_type.clone(),
+                    local_name: local_name.clone(),
+                    attributes,
+                    location: Location::new(self.source_plan.clone(), (0, 0), (0, 0)),
+                    change_side: Some(identity.side),
+                }
+            })
+            .collect()
+    }
+}
+
+/// Derive a resource's local name from its plan address (the last dotted
+/// segment, with any `[index]`/`["key"]` suffix stripped). E.g.
+/// `aws_s3_bucket.data` → `data`
+fn local_name_from_address(address: &str) -> String {
+    let last = address.rsplit('.').next().unwrap_or(address);
+    match last.split_once('[') {
+        Some((name, _)) => name.to_string(),
+        None => last.to_string(),
+    }
+}
+
+/// Collect the resolved, non-null, top-level string attributes from a plan
+/// `before`/`after` object.
+fn known_string_attributes(value: &Value) -> BTreeMap<String, String> {
+    let mut attrs = BTreeMap::new();
+    if let Some(obj) = value.as_object() {
+        for (key, val) in obj {
+            if let Value::String(s) = val {
+                attrs.insert(key.clone(), s.clone());
+            }
+        }
+    }
+    attrs
+}
+
+/// Resolve a change's concrete identities from its `before`/`after` values.
+///
+/// - create → `After`
+/// - delete → `Before` (`after` is null)
+/// - update → `After` (identity is stable in place)
+/// - replace (`create`+`delete`) → both `After` (new) and `Before` (old) —
+///   the apply creates one ARN and deletes the other
+///
+/// Identities with no known attributes (all values known-after-apply) are
+/// dropped so those resources fall back to wildcard ARNs, as is a `Before` whose
+/// attributes duplicate the `After` (an in-place replace that didn't rename).
+fn resolve_identities(
+    slots: &BTreeSet<CrudSlot>,
+    before: &Value,
+    after: &Value,
+) -> Vec<PlannedIdentity> {
+    let after_known = known_string_attributes(after);
+    let before_known = known_string_attributes(before);
+    let is_replace = slots.contains(&CrudSlot::Create) && slots.contains(&CrudSlot::Delete);
+
+    let candidates = if is_replace {
+        vec![
+            (ChangeSide::After, after_known),
+            (ChangeSide::Before, before_known),
+        ]
+    } else if !after_known.is_empty() {
+        vec![(ChangeSide::After, after_known)]
+    } else {
+        vec![(ChangeSide::Before, before_known)]
+    };
+
+    let mut identities: Vec<PlannedIdentity> = Vec::new();
+    for (side, attributes) in candidates {
+        if attributes.is_empty() {
+            continue;
+        }
+        // Skip a Before whose attributes exactly match an already-kept identity
+        // (a replace that didn't change the naming attributes → one ARN).
+        if identities.iter().any(|id| id.attributes == attributes) {
+            continue;
+        }
+        identities.push(PlannedIdentity { side, attributes });
+    }
+    identities
 }
 
 /// Extract a `name_prefix` attribute from the planned `after` object, if the
@@ -140,10 +270,13 @@ pub(crate) fn file_looks_like_plan(path: &Path) -> bool {
     std::fs::read(path).is_ok_and(|bytes| looks_like_plan(&bytes))
 }
 
-/// Parse a plan document from raw `terraform show -json` bytes.
-fn from_slice(bytes: &[u8]) -> Result<Vec<PlannedResource>> {
+/// Read and parse a `terraform show -json` plan file from disk. Each resource
+/// records `path` as its `source_plan` for use as the binding's source location.
+pub(crate) fn read_plan(path: &Path) -> Result<Vec<PlannedResource>> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("Failed to read Terraform plan JSON at {}", path.display()))?;
     let doc: PlanDocument =
-        serde_json::from_slice(bytes).context("Failed to parse terraform plan JSON")?;
+        serde_json::from_slice(&bytes).context("Failed to parse terraform plan JSON")?;
 
     let resources = doc
         .resource_changes
@@ -151,22 +284,21 @@ fn from_slice(bytes: &[u8]) -> Result<Vec<PlannedResource>> {
         // Only managed AWS resources participate in IAM action derivation.
         .filter(|rc| rc.mode.as_deref() != Some("data"))
         .filter(|rc| rc.type_.starts_with(AWS_RESOURCE_PREFIX))
-        .map(|rc| PlannedResource {
-            address: rc.address,
-            resource_type: rc.type_,
-            slots: slots_for_actions(&rc.change.actions),
-            name_prefix: extract_name_prefix(&rc.change.after),
+        .map(|rc| {
+            let slots = slots_for_actions(&rc.change.actions);
+            let identities = resolve_identities(&slots, &rc.change.before, &rc.change.after);
+            PlannedResource {
+                address: rc.address,
+                resource_type: rc.type_,
+                slots,
+                name_prefix: extract_name_prefix(&rc.change.after),
+                identities,
+                source_plan: path.to_path_buf(),
+            }
         })
         .collect();
 
     Ok(resources)
-}
-
-/// Read and parse a `terraform show -json` plan file from disk.
-pub(crate) fn read_plan(path: &Path) -> Result<Vec<PlannedResource>> {
-    let bytes = std::fs::read(path)
-        .with_context(|| format!("Failed to read Terraform plan JSON at {}", path.display()))?;
-    from_slice(&bytes)
 }
 
 #[cfg(test)]
@@ -194,6 +326,16 @@ mod tests {
         assert_eq!(slots_for_actions(&actions), slots(expected));
     }
 
+    /// Write `json` to a temp file and return the handle (kept alive by the
+    /// caller). `read_plan` needs a real file; `.path()` is the recorded
+    /// `source_plan`.
+    fn write_plan(json: &str) -> tempfile::NamedTempFile {
+        use std::io::Write as _;
+        let mut file = tempfile::NamedTempFile::new().expect("create temp plan");
+        file.write_all(json.as_bytes()).expect("write temp plan");
+        file
+    }
+
     #[test]
     fn parses_managed_resource_change() {
         let json = r#"{
@@ -206,7 +348,8 @@ mod tests {
                 }
             ]
         }"#;
-        let resources = from_slice(json.as_bytes()).unwrap();
+        let plan = write_plan(json);
+        let resources = read_plan(plan.path()).unwrap();
         assert_eq!(
             resources,
             vec![PlannedResource {
@@ -214,6 +357,8 @@ mod tests {
                 resource_type: "aws_s3_bucket".to_string(),
                 slots: slots(&[CrudSlot::Read, CrudSlot::Create]),
                 name_prefix: None,
+                identities: vec![ident(ChangeSide::After, &[("name", "my-bucket")])],
+                source_plan: plan.path().to_path_buf(),
             }]
         );
     }
@@ -230,7 +375,8 @@ mod tests {
                   "change": { "actions": ["create"], "after": {} } }
             ]
         }"#;
-        let resources = from_slice(json.as_bytes()).unwrap();
+        let plan = write_plan(json);
+        let resources = read_plan(plan.path()).unwrap();
         let types: Vec<&str> = resources.iter().map(|r| r.resource_type.as_str()).collect();
         assert_eq!(types, vec!["aws_s3_bucket"]);
     }
@@ -251,8 +397,113 @@ mod tests {
 
     #[test]
     fn empty_plan_yields_no_resources() {
-        let resources = from_slice(br#"{ "resource_changes": [] }"#).unwrap();
+        let plan = write_plan(r#"{ "resource_changes": [] }"#);
+        let resources = read_plan(plan.path()).unwrap();
         assert_eq!(resources, vec![]);
+    }
+
+    /// Build a `BTreeMap` of attributes from `(key, value)` pairs.
+    fn btm(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    /// Build a `PlannedIdentity` for the given side from `(key, value)` pairs.
+    fn ident(side: ChangeSide, pairs: &[(&str, &str)]) -> PlannedIdentity {
+        PlannedIdentity {
+            side,
+            attributes: btm(pairs),
+        }
+    }
+
+    #[rstest]
+    // create: known values come from `after`.
+    #[case(&["create"], serde_json::json!(null), serde_json::json!({"name": "a"}), vec![ident(ChangeSide::After, &[("name", "a")])])]
+    // delete: `after` is null; the concrete identity is in `before`.
+    #[case(&["delete"], serde_json::json!({"name": "a"}), serde_json::json!(null), vec![ident(ChangeSide::Before, &[("name", "a")])])]
+    // update in place: identity is stable; `after` is used.
+    #[case(&["update"], serde_json::json!({"name": "a"}), serde_json::json!({"name": "a"}), vec![ident(ChangeSide::After, &[("name", "a")])])]
+    // replace with rename: BOTH the new (after) and old (before) identities, after first.
+    #[case(&["delete", "create"], serde_json::json!({"name": "old"}), serde_json::json!({"name": "new"}),
+        vec![ident(ChangeSide::After, &[("name", "new")]), ident(ChangeSide::Before, &[("name", "old")])])]
+    // replace, name unchanged: the two identities collapse to the After one.
+    #[case(&["create", "delete"], serde_json::json!({"name": "a"}), serde_json::json!({"name": "a"}), vec![ident(ChangeSide::After, &[("name", "a")])])]
+    // create with a known-after-apply name: no known attributes → no identity (wildcard fallback).
+    #[case(&["create"], serde_json::json!(null), serde_json::json!({}), Vec::new())]
+    fn resolve_identities_by_action_set(
+        #[case] actions: &[&str],
+        #[case] before: Value,
+        #[case] after: Value,
+        #[case] expected: Vec<PlannedIdentity>,
+    ) {
+        let actions: Vec<String> = actions.iter().map(|s| s.to_string()).collect();
+        let slots = slots_for_actions(&actions);
+        assert_eq!(resolve_identities(&slots, &before, &after), expected);
+    }
+
+    #[test]
+    fn known_string_attributes_keeps_only_scalar_strings() {
+        let value = serde_json::json!({
+            "name": "my-table",
+            "read_capacity": 5,            // number → skipped
+            "tags": { "env": "prod" },     // nested object → skipped
+            "attribute": [{ "name": "id" }] // array → skipped
+        });
+        assert_eq!(
+            known_string_attributes(&value),
+            btm(&[("name", "my-table")])
+        );
+    }
+
+    #[test]
+    fn to_terraform_resources_tags_each_identity_with_its_side() {
+        // A replace-with-rename resource: two identities → two TerraformResources
+        // that share the real local name but carry distinct change sides, so the
+        // binder keeps them apart (and only state-matches the Before one) while
+        // both contribute an ARN.
+        let planned = PlannedResource {
+            address: "aws_dynamodb_table.app".to_string(),
+            resource_type: "aws_dynamodb_table".to_string(),
+            slots: slots(&[CrudSlot::Read, CrudSlot::Create, CrudSlot::Delete]),
+            name_prefix: None,
+            identities: vec![
+                ident(ChangeSide::After, &[("name", "new")]),
+                ident(ChangeSide::Before, &[("name", "old")]),
+            ],
+            source_plan: PathBuf::from("plan.json"),
+        };
+        let resources = planned.to_terraform_resources();
+        assert_eq!(resources.len(), 2);
+        assert_eq!(resources[0].resource_type, "aws_dynamodb_table");
+        assert_eq!(resources[0].local_name, "app");
+        assert_eq!(resources[0].change_side, Some(ChangeSide::After));
+        // Location points at the source plan file.
+        assert_eq!(resources[0].location.file_path, PathBuf::from("plan.json"));
+        assert_eq!(
+            resources[0].attributes.get("name"),
+            Some(&AttributeValue::Literal("new".to_string()))
+        );
+        // Same real local name — the side, not a munged name, keeps it distinct.
+        assert_eq!(resources[1].local_name, "app");
+        assert_eq!(resources[1].change_side, Some(ChangeSide::Before));
+        assert_eq!(
+            resources[1].attributes.get("name"),
+            Some(&AttributeValue::Literal("old".to_string()))
+        );
+    }
+
+    #[rstest]
+    #[case("aws_s3_bucket.data", "data")]
+    #[case("module.m.aws_sqs_queue.jobs", "jobs")]
+    #[case("aws_dynamodb_table.app[0]", "app")]
+    #[case("aws_instance.web[\"a\"]", "web")]
+    fn local_name_from_address_strips_module_and_index(
+        #[case] address: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(local_name_from_address(address), expected);
     }
 
     #[rstest]

--- a/iam-policy-autopilot-policy-generation/src/extraction/terraform/variable_resolver.rs
+++ b/iam-policy-autopilot-policy-generation/src/extraction/terraform/variable_resolver.rs
@@ -420,6 +420,7 @@ mod tests {
             local_name: "b".to_string(),
             attributes: HashMap::from([(input_attr_key.to_string(), input_attr_value)]),
             location: crate::Location::new(std::path::PathBuf::from("main.tf"), (1, 1), (1, 1)),
+            change_side: None,
         };
         let mut result = TerraformResources::default();
         result.insert(resource);

--- a/iam-policy-autopilot-policy-generation/tests/terraform_plan_integration.rs
+++ b/iam-policy-autopilot-policy-generation/tests/terraform_plan_integration.rs
@@ -31,9 +31,9 @@ fn temp_json(contents: &str) -> NamedTempFile {
 }
 
 /// Build a plan-only config. Plans are passed as positional input files (no
-/// dedicated flag) and auto-detected by content; no ARN binding inputs are
-/// provided, so resources fall back to wildcards. Accepts one or more plans
-/// (multiple plans are unioned).
+/// dedicated flag) and auto-detected by content. No `.tf`/state binding inputs
+/// are provided — ARN scoping (when it happens) is derived from the plan itself.
+/// Accepts one or more plans (multiple plans are unioned).
 fn plan_only_config(plan_paths: Vec<std::path::PathBuf>) -> GeneratePolicyConfig {
     GeneratePolicyConfig {
         extract_sdk_calls_config: ExtractSdkCallsConfig {
@@ -80,6 +80,45 @@ fn collect_actions(value: &Value, out: &mut BTreeSet<String>) {
         Value::Array(items) => {
             for v in items {
                 collect_actions(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Collect every `Resource` ARN string across all generated policy statements.
+fn resources(result: &GeneratePoliciesResult) -> BTreeSet<String> {
+    let json = serde_json::to_value(&result.policies).expect("serialize policies");
+    let mut out = BTreeSet::new();
+    collect_field(&json, "Resource", &mut out);
+    out
+}
+
+/// Recursively collect string values found under `key` (a scalar or an array of
+/// scalars) anywhere in the JSON.
+fn collect_field(value: &Value, key: &str, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            match map.get(key) {
+                Some(Value::String(s)) => {
+                    out.insert(s.clone());
+                }
+                Some(Value::Array(items)) => {
+                    for item in items {
+                        if let Value::String(s) = item {
+                            out.insert(s.clone());
+                        }
+                    }
+                }
+                _ => {}
+            }
+            for v in map.values() {
+                collect_field(v, key, out);
+            }
+        }
+        Value::Array(items) => {
+            for v in items {
+                collect_field(v, key, out);
             }
         }
         _ => {}
@@ -177,5 +216,59 @@ async fn plan_emits_expected_actions(#[case] plans: Vec<String>, #[case] expecte
             .iter()
             .map(|s| s.to_string())
             .collect::<BTreeSet<_>>()
+    );
+}
+
+/// A rename-**replace** of a DynamoDB table: the resource is destroyed under its
+/// old name (`before`) and recreated under a new one (`after`), the classic case
+/// where `before` and `after` are different identities.
+fn dynamodb_replace_plan(old_name: &str, new_name: &str) -> String {
+    format!(
+        r#"{{
+            "format_version": "1.2",
+            "resource_changes": [
+                {{
+                    "address": "aws_dynamodb_table.app",
+                    "type": "aws_dynamodb_table",
+                    "mode": "managed",
+                    "change": {{
+                        "actions": ["delete", "create"],
+                        "before": {{ "name": "{old_name}" }},
+                        "after": {{ "name": "{new_name}" }}
+                    }}
+                }}
+            ]
+        }}"#
+    )
+}
+
+/// Plan-derived ARN scoping for a replace: the policy must be scoped to BOTH the
+/// old (`before`) and new (`after`) table ARNs — the apply deletes one and
+/// creates the other — with neither left as a wildcard. Binding is derived from
+/// the plan alone (no `--tf-dir`/`--tf-files`/`--tfstate`).
+#[tokio::test]
+async fn plan_replace_scopes_both_before_and_after_arns() {
+    let plan = dynamodb_replace_plan("ipa-tf-test-replace-old", "ipa-tf-test-replace-new");
+    let file = temp_json(&plan);
+    let config = plan_only_config(vec![file.path().to_path_buf()]);
+
+    let result = generate_policies(&config).await.expect("generate policies");
+    let res = resources(&result);
+
+    let old_arn = "arn:aws:dynamodb:us-east-1:123456789012:table/ipa-tf-test-replace-old";
+    let new_arn = "arn:aws:dynamodb:us-east-1:123456789012:table/ipa-tf-test-replace-new";
+
+    assert!(
+        res.contains(old_arn),
+        "old (before) table ARN must be scoped into the policy, got: {res:#?}"
+    );
+    assert!(
+        res.contains(new_arn),
+        "new (after) table ARN must be scoped into the policy, got: {res:#?}"
+    );
+    // Scoped, not wildcarded: the bare table wildcard must not appear.
+    assert!(
+        !res.contains("arn:aws:dynamodb:us-east-1:123456789012:table/*"),
+        "dynamodb table ARNs should be concrete, not a wildcard, got: {res:#?}"
     );
 }


### PR DESCRIPTION
Closes #

## Description

Resolve ARNs when generating policies from a Terrform plan whenever it is possible to do so.

## Checklist

- [X] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
