### PR TITLE
fix: warning in submodule update action

### DIFF
--- a/.github/workflows/weekly_submodule_update.yml
+++ b/.github/workflows/weekly_submodule_update.yml
@@ -76,6 +76,7 @@ jobs:
       uses: actions/setup-go@v7
       with:
         go-version: '1.26'
+        cache-dependency-path: iam-policy-autopilot-policy-generation/resources/config/terraform/terraform-provider-aws/go.mod
 
     - name: Install gopls
       run: go install golang.org/x/tools/gopls@latest


### PR DESCRIPTION
Closes #

## Description

Try to fix the warning in https://github.com/awslabs/iam-policy-autopilot/actions/runs/32048739314

## Checklist

- [X] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
