### PR TITLE
chore: exclude Terraform submodule from ruff check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ bindings = "bin"
 # not maintained Python code).
 exclude = [
     "iam-policy-autopilot-policy-generation/resources/config/sdks",
+    "iam-policy-autopilot-policy-generation/resources/config/terraform/terraform-provider-aws",
     "iam-policy-autopilot-policy-generation/tests/resources",
     "iam-policy-autopilot-cli/tests/resources",
     "iam-policy-autopilot-mcp-server/tests/test_data",


### PR DESCRIPTION
Closes #

## Description

Cherry-pick from release-0.2.4.rc.1: `chore: exclude Terraform submodule from ruff check`

## Checklist

- [X] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
