### PR TITLE
docs: Note Terraform plan support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # IAM Policy Autopilot
 
-An open source Model Context Protocol (MCP) server and command-line tool that helps your AI coding assistants quickly create baseline IAM policies that you can refine as your application evolves, so you can build faster. IAM Policy Autopilot analyzes your application code locally to generate identity-based policies for application roles, enabling faster IAM policy creation and reducing access troubleshooting time. IAM Policy Autopilot supports policy generation for applications built in Python, Go, TypeScript, JavaScript, and Java — see [Supported Languages and SDKs for policy generation](#supported-languages-and-sdks-for-policy-generation).
+An open source Model Context Protocol (MCP) server and command-line tool that helps your AI coding assistants quickly create baseline IAM policies that you can refine as your application evolves, so you can build faster. IAM Policy Autopilot analyzes your application code locally to generate identity-based policies for application roles, enabling faster IAM policy creation and reducing access troubleshooting time. IAM Policy Autopilot supports policy generation for applications built in Python, Go, TypeScript, JavaScript, and Java, and can also generate policies from a Terraform plan file in JSON format — see [Supported Languages and SDKs for policy generation](#supported-languages-and-sdks-for-policy-generation).
 
 We want to hear from you. Ask questions or share ideas in [Discussions](https://github.com/awslabs/iam-policy-autopilot/discussions), report bugs through [Issues](https://github.com/awslabs/iam-policy-autopilot/issues), or contribute directly with a [Pull Request](https://github.com/awslabs/iam-policy-autopilot/pulls). 
 
@@ -84,6 +84,8 @@ This significantly reduces unnecessary permissions and generates more targeted p
 | JavaScript | [AWS SDK for JavaScript v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/) |
 | TypeScript | [AWS SDK for JavaScript v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/) |
 | Python | [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html), [Botocore](https://botocore.amazonaws.com/v1/documentation/api/latest/index.html) |
+
+You can also generate policies from a [Terraform plan](https://developer.hashicorp.com/terraform/cli/commands/plan) file in JSON format, mapping the plan's resource changes to the actions the Terraform AWS provider performs — see [CLI Usage](#cli-usage). Native `.tf` configuration files are not yet supported as a direct input.
 
 ## Getting Started
 


### PR DESCRIPTION
Call out that generate-policies accepts a Terraform plan file (terraform show -json) in addition to application source, and link the What's New post announcing the 0.3.0 capability. Explicitly note that native .tf configuration files are not yet supported as a direct input, to avoid confusion.

Closes #

## Description

<!-- What does this PR do and why? -->

## Checklist

- [ ] ~~I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)~~
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
