### PR TITLE
fix(deps): Bump quinn-proto to 0.11.15 for GHSA-4w2j-m93h-cj5j

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "iam-policy-autopilot-wasm"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "iam-policy-autopilot-policy-generation",
  "serde",
@@ -3192,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Addresses CVE-2026-25800, a remote memory exhaustion in quinn-proto's Assembler from unbounded out-of-order stream reassembly. Patch-level bump within 0.11.x; no manifest change required.

quinn enters the graph only via reqwest's optional HTTP/3 feature, which this workspace does not enable (reqwest uses default-features = false with rustls), so the vulnerable code path is not compiled. The bump clears the Dependabot alert on the lockfile regardless.

Closes https://github.com/awslabs/iam-policy-autopilot/security/dependabot/71

## Description

> The Assembler component that assembles unordered stream fragments into consecutive chunks of the stream incurs some overhead for non-contiguous fragments. Readers that read from a RecvStream in order (through an AsyncRead impl for example) will be sensitive to peers that send fragments while leaving out early parts of the stream, and in particular, fragments with many gaps (because these cannot be defragmented). In such a scenario, the receiving connection suffers from high buffer overhead, enabling memory exhaustion.

Dependabot flagged a vulnerable dependency, updating dependency even though the impacting code does not compile into our binary.

`quinn-proto` is only an optional dependency of `reqwest` behind its HTTP/3 feature, and the workspace builds `reqwest` with `default-features = false, features = ["rustls"]`, so the vulnerable code isn't compiled into any binary. The Dependabot alert fires on the `lockfile` version string, not on a reachable code path.

## Checklist

- [ ] ~~I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)~~
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
