### PR TITLE
chore: update pyproject.toml license declaration for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ version = "0.3.0"
 description = "An open source Model Context Protocol (MCP) server and command-line tool that helps your AI coding assistants quickly create baseline IAM policies that you can refine as your application evolves, so you can build faster. IAM Policy Autopilot analyzes your application code locally to generate identity-based policies for application roles, enabling faster IAM policy creation and reducing access troubleshooting time. IAM Policy Autopilot supports applications built in Python, Go, TypeScript, and Java."
 readme = "README.md"
 requires-python = ">=3.8"
-license = { file = "LICENSE" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 keywords = ["rust", "IAM Policy", "AWS"]
 
 [tool.maturin]


### PR DESCRIPTION
## Description

Updates the project license declaration which will allow the license to be properly included in package metadata. This is important for enterprise tools that check for proper licensing and prevent people from using libraries that are unlicensed or have restrictive licenses, e.g., AGPL-3.0

This is the current metadata for iam-policy-autopilot at https://pypi.org/project/iam-policy-autopilot/
<img width="375" height="586" alt="image" src="https://github.com/user-attachments/assets/77fd7546-bd7c-4fa5-813d-17ac04dff1ce" />

For comparison, this is the metadata for [GluonTS](https://pypi.org/project/gluonts/), note the clearly displayed license declaration:
<img width="330" height="584" alt="image" src="https://github.com/user-attachments/assets/87c42bf7-9d28-47be-927e-15a8ee128848" />


Reference:
> license
The new format for license is a valid [SPDX license expression](https://packaging.python.org/en/latest/glossary/#term-License-Expression) consisting of one or more [license identifiers](https://packaging.python.org/en/latest/glossary/#term-License-Identifier). The full license list is available at the [SPDX license list page](https://spdx.org/licenses/). The supported list version is 3.17 or any later compatible one.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#readme

## Checklist

- [X] I have updated [`CHANGELOG.md`](https://github.com/awslabs/iam-policy-autopilot/blob/main/CHANGELOG.md) under `[Unreleased]` (if this is a user-facing change)
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and use [clear messages](https://github.com/awslabs/iam-policy-autopilot/blob/main/CONTRIBUTING.md#commit-message-guidelines)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
